### PR TITLE
feat: add AWS SSO (IAM Identity Center) authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,16 @@ OpenCode plugin for AWS Kiro (CodeWhisperer) providing access to Claude Sonnet a
 
 ## Features
 
-- AWS Builder ID (IDC) authentication with seamless device code flow.
-- Intelligent multi-account rotation prioritized by lowest usage.
-- Automated token refresh and rate limit handling with exponential backoff.
-- Native thinking mode support via virtual model mappings.
-- Decoupled storage for credentials and real-time usage metadata.
-- Configurable request timeout and iteration limits to prevent hangs.
-- Automatic port selection for auth server to avoid conflicts.
-- Usage tracking with automatic retry on sync failures.
+- **Multiple Authentication Methods**: AWS Builder ID (personal) and AWS SSO (enterprise)
+- AWS Builder ID (IDC) authentication with seamless device code flow
+- AWS SSO (IAM Identity Center) for enterprise users with organization identity providers
+- Intelligent multi-account rotation prioritized by lowest usage
+- Automated token refresh and rate limit handling with exponential backoff
+- Native thinking mode support via virtual model mappings
+- Decoupled storage for credentials and real-time usage metadata
+- Configurable request timeout and iteration limits to prevent hangs
+- Automatic port selection for auth server to avoid conflicts
+- Usage tracking with automatic retry on sync failures
 
 ## Installation
 
@@ -54,10 +56,56 @@ Add the plugin to your `opencode.json` or `opencode.jsonc`:
 
 ## Setup
 
+### AWS Builder ID (Personal)
+
 1. Run `opencode auth login`.
 2. Select `Other`, type `kiro`, and press enter.
-3. Follow the terminal instructions to complete the AWS Builder ID authentication.
-4. Configuration template will be automatically created at `~/.config/opencode/kiro.json` on first load.
+3. Select `AWS Builder ID (IDC)`.
+4. Follow the terminal instructions to complete the AWS Builder ID authentication.
+5. Configuration template will be automatically created at `~/.config/opencode/kiro.json` on first load.
+
+### AWS SSO (Enterprise/Organization)
+
+For organizations using AWS IAM Identity Center with corporate identity providers (Okta, Azure AD, etc.).
+
+#### Prerequisites
+
+1. Your organization must have IAM Identity Center enabled
+2. You need your organization's SSO start URL (e.g., `https://my-org.awsapps.com/start`)
+3. Your admin must grant you appropriate permissions (e.g., PowerUserAccess)
+
+#### Finding Your SSO Start URL
+
+You can find your SSO start URL in one of these ways:
+- Contact your AWS administrator
+- Check your AWS access portal URL
+- Find it in IAM Identity Center console under Settings → AWS access portal URL
+
+#### Configuration (Optional)
+
+You can pre-configure your SSO start URL in `~/.config/opencode/kiro.json`:
+
+```json
+{
+  "sso_start_url": "https://my-org.awsapps.com/start",
+  "sso_region": "us-east-1"
+}
+```
+
+#### Login
+
+1. Run `opencode auth login`.
+2. Select `Other`, type `kiro`, and press enter.
+3. Select `AWS SSO (IAM Identity Center)`.
+4. Enter your SSO start URL when prompted (if not pre-configured).
+5. Complete authentication in your browser using your organization's identity provider.
+
+### Multi-Account Support
+
+Both authentication methods support multiple accounts:
+- Mix and match Builder ID and SSO accounts
+- Automatic rotation based on usage and rate limits
+- Each account tracked independently
 
 ## Configuration
 
@@ -76,7 +124,9 @@ The plugin supports extensive configuration options. Edit `~/.config/opencode/ki
   "auth_server_port_start": 19847,
   "auth_server_port_range": 10,
   "usage_tracking_enabled": true,
-  "enable_log_api_request": false
+  "enable_log_api_request": false,
+  "sso_start_url": "https://my-org.awsapps.com/start",
+  "sso_region": "us-east-1"
 }
 ```
 
@@ -94,6 +144,8 @@ The plugin supports extensive configuration options. Edit `~/.config/opencode/ki
 - `auth_server_port_range`: Number of ports to try (1-100)
 - `usage_tracking_enabled`: Enable usage tracking and toast notifications
 - `enable_log_api_request`: Enable detailed API request logging
+- `sso_start_url`: (Optional) Pre-configure your organization's SSO start URL
+- `sso_region`: (Optional) AWS region for SSO authentication
 
 ### Environment Variables
 
@@ -111,6 +163,8 @@ All configuration options can be overridden via environment variables:
 - `KIRO_AUTH_SERVER_PORT_RANGE`
 - `KIRO_USAGE_TRACKING_ENABLED`
 - `KIRO_ENABLE_LOG_API_REQUEST`
+- `KIRO_SSO_START_URL`
+- `KIRO_SSO_REGION`
 
 ## Storage
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zhafron/opencode-kiro-auth",
-  "version": "1.2.8",
+  "version": "1.3.0",
   "description": "OpenCode plugin for AWS Kiro (CodeWhisperer) providing access to Claude models",
   "type": "module",
   "main": "dist/index.js",

--- a/src/kiro/auth.ts
+++ b/src/kiro/auth.ts
@@ -5,8 +5,21 @@ export function decodeRefreshToken(refresh: string): RefreshParts {
   if (parts.length < 2) return { refreshToken: parts[0]!, authMethod: 'idc' }
   const refreshToken = parts[0]!
   const authMethod = parts[parts.length - 1]!
-  if (authMethod === 'idc')
+  
+  if (authMethod === 'idc') {
     return { refreshToken, clientId: parts[1], clientSecret: parts[2], authMethod: 'idc' }
+  }
+  
+  if (authMethod === 'sso') {
+    return {
+      refreshToken,
+      clientId: parts[1],
+      clientSecret: parts[2],
+      ssoStartUrl: parts[3],
+      authMethod: 'sso'
+    }
+  }
+  
   return { refreshToken, authMethod: 'idc' }
 }
 
@@ -16,10 +29,26 @@ export function accessTokenExpired(auth: KiroAuthDetails, bufferMs = 120000): bo
 }
 
 export function validateAuthDetails(auth: KiroAuthDetails): boolean {
-  return !!auth.refresh && auth.authMethod === 'idc' && !!auth.clientId && !!auth.clientSecret
+  if (!auth.refresh || !auth.clientId || !auth.clientSecret) return false
+  
+  if (auth.authMethod === 'idc') {
+    return true
+  }
+  
+  if (auth.authMethod === 'sso') {
+    return !!auth.ssoStartUrl
+  }
+  
+  return false
 }
 
 export function encodeRefreshToken(parts: RefreshParts): string {
   if (!parts.clientId || !parts.clientSecret) throw new Error('Missing credentials')
+  
+  if (parts.authMethod === 'sso') {
+    if (!parts.ssoStartUrl) throw new Error('Missing SSO start URL')
+    return `${parts.refreshToken}|${parts.clientId}|${parts.clientSecret}|${parts.ssoStartUrl}|sso`
+  }
+  
   return `${parts.refreshToken}|${parts.clientId}|${parts.clientSecret}|idc`
 }

--- a/src/kiro/oauth-sso.ts
+++ b/src/kiro/oauth-sso.ts
@@ -1,0 +1,234 @@
+import type { KiroRegion } from '../plugin/types'
+import { KIRO_AUTH_SERVICE, KIRO_CONSTANTS, buildUrl, normalizeRegion } from '../constants'
+
+export interface KiroSSOAuthorization {
+  verificationUrl: string
+  verificationUriComplete: string
+  userCode: string
+  deviceCode: string
+  clientId: string
+  clientSecret: string
+  interval: number
+  expiresIn: number
+  region: KiroRegion
+  ssoStartUrl: string
+}
+
+export interface KiroSSOTokenResult {
+  refreshToken: string
+  accessToken: string
+  expiresAt: number
+  email: string
+  clientId: string
+  clientSecret: string
+  region: KiroRegion
+  authMethod: 'sso'
+  ssoStartUrl: string
+}
+
+export async function authorizeKiroSSO(
+  ssoStartUrl: string,
+  region?: KiroRegion
+): Promise<KiroSSOAuthorization> {
+  const effectiveRegion = normalizeRegion(region)
+  const ssoOIDCEndpoint = buildUrl(KIRO_AUTH_SERVICE.SSO_OIDC_ENDPOINT, effectiveRegion)
+
+  try {
+    const registerResponse = await fetch(`${ssoOIDCEndpoint}/client/register`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'User-Agent': KIRO_CONSTANTS.USER_AGENT
+      },
+      body: JSON.stringify({
+        clientName: 'Kiro IDE',
+        clientType: 'public',
+        scopes: KIRO_AUTH_SERVICE.SCOPES,
+        grantTypes: ['urn:ietf:params:oauth:grant-type:device_code', 'refresh_token']
+      })
+    })
+
+    if (!registerResponse.ok) {
+      const errorText = await registerResponse.text().catch(() => '')
+      const error = new Error(`Client registration failed: ${registerResponse.status} ${errorText}`)
+      throw error
+    }
+
+    const registerData = await registerResponse.json()
+    const { clientId, clientSecret } = registerData
+
+    if (!clientId || !clientSecret) {
+      const error = new Error('Client registration response missing clientId or clientSecret')
+      throw error
+    }
+
+    const deviceAuthResponse = await fetch(`${ssoOIDCEndpoint}/device_authorization`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'User-Agent': KIRO_CONSTANTS.USER_AGENT
+      },
+      body: JSON.stringify({
+        clientId,
+        clientSecret,
+        startUrl: ssoStartUrl
+      })
+    })
+
+    if (!deviceAuthResponse.ok) {
+      const errorText = await deviceAuthResponse.text().catch(() => '')
+      const error = new Error(
+        `Device authorization failed: ${deviceAuthResponse.status} ${errorText}`
+      )
+      throw error
+    }
+
+    const deviceAuthData = await deviceAuthResponse.json()
+
+    const {
+      verificationUri,
+      verificationUriComplete,
+      userCode,
+      deviceCode,
+      interval = 5,
+      expiresIn = 600
+    } = deviceAuthData
+
+    if (!deviceCode || !userCode || !verificationUri || !verificationUriComplete) {
+      const error = new Error('Device authorization response missing required fields')
+      throw error
+    }
+
+    return {
+      verificationUrl: verificationUri,
+      verificationUriComplete,
+      userCode,
+      deviceCode,
+      clientId,
+      clientSecret,
+      interval,
+      expiresIn,
+      region: effectiveRegion,
+      ssoStartUrl
+    }
+  } catch (error) {
+    throw error
+  }
+}
+
+export async function pollKiroSSOToken(
+  clientId: string,
+  clientSecret: string,
+  deviceCode: string,
+  interval: number,
+  expiresIn: number,
+  region: KiroRegion,
+  ssoStartUrl: string
+): Promise<KiroSSOTokenResult> {
+  if (!clientId || !clientSecret || !deviceCode) {
+    const error = new Error('Missing required parameters for token polling')
+    throw error
+  }
+
+  const effectiveRegion = normalizeRegion(region)
+  const ssoOIDCEndpoint = buildUrl(KIRO_AUTH_SERVICE.SSO_OIDC_ENDPOINT, effectiveRegion)
+
+  const maxAttempts = Math.floor(expiresIn / interval)
+  let currentInterval = interval * 1000
+  let attempts = 0
+
+  while (attempts < maxAttempts) {
+    attempts++
+
+    await new Promise((resolve) => setTimeout(resolve, currentInterval))
+
+    try {
+      const tokenResponse = await fetch(`${ssoOIDCEndpoint}/token`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': KIRO_CONSTANTS.USER_AGENT
+        },
+        body: JSON.stringify({
+          clientId,
+          clientSecret,
+          deviceCode,
+          grantType: 'urn:ietf:params:oauth:grant-type:device_code'
+        })
+      })
+
+      const tokenData = await tokenResponse.json()
+
+      if (tokenData.error) {
+        const errorType = tokenData.error
+
+        if (errorType === 'authorization_pending') {
+          continue
+        }
+
+        if (errorType === 'slow_down') {
+          currentInterval += 5000
+          continue
+        }
+
+        if (errorType === 'expired_token') {
+          const error = new Error(
+            'Device code has expired. Please restart the authorization process.'
+          )
+          throw error
+        }
+
+        if (errorType === 'access_denied') {
+          const error = new Error('Authorization was denied by the user.')
+          throw error
+        }
+
+        const error = new Error(
+          `Token polling failed: ${errorType} - ${tokenData.error_description || ''}`
+        )
+        throw error
+      }
+
+      if (tokenData.accessToken && tokenData.refreshToken) {
+        const expiresInSeconds = tokenData.expiresIn || 3600
+        const expiresAt = Date.now() + expiresInSeconds * 1000
+
+        return {
+          refreshToken: tokenData.refreshToken,
+          accessToken: tokenData.accessToken,
+          expiresAt,
+          email: 'sso-user@aws.amazon.com',
+          clientId,
+          clientSecret,
+          region: effectiveRegion,
+          authMethod: 'sso',
+          ssoStartUrl
+        }
+      }
+
+      if (!tokenResponse.ok) {
+        const error = new Error(`Token request failed with status: ${tokenResponse.status}`)
+        throw error
+      }
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        (error.message.includes('expired') ||
+          error.message.includes('denied') ||
+          error.message.includes('failed'))
+      ) {
+        throw error
+      }
+
+      if (attempts >= maxAttempts) {
+        const finalError = new Error(
+          `Token polling failed after ${attempts} attempts: ${error instanceof Error ? error.message : 'Unknown error'}`
+        )
+        throw finalError
+      }
+    }
+  }
+
+  const timeoutError = new Error('Token polling timed out. Authorization may have expired.')
+  throw timeoutError
+}

--- a/src/plugin/accounts.ts
+++ b/src/plugin/accounts.ts
@@ -156,11 +156,14 @@ export class AccountManager {
       acc.accessToken = auth.access
       acc.expiresAt = auth.expires
       acc.lastUsed = Date.now()
-      if (auth.email && auth.email !== 'builder-id@aws.amazon.com') acc.realEmail = auth.email
+      if (auth.email && auth.email !== 'builder-id@aws.amazon.com' && auth.email !== 'sso-user@aws.amazon.com') {
+        acc.realEmail = auth.email
+      }
       const p = decodeRefreshToken(auth.refresh)
       acc.refreshToken = p.refreshToken
       if (p.profileArn) acc.profileArn = p.profileArn
       if (p.clientId) acc.clientId = p.clientId
+      if (p.ssoStartUrl) acc.ssoStartUrl = p.ssoStartUrl
     }
   }
 
@@ -192,7 +195,8 @@ export class AccountManager {
       profileArn: a.profileArn,
       clientId: a.clientId,
       clientSecret: a.clientSecret,
-      authMethod: a.authMethod
+      authMethod: a.authMethod,
+      ssoStartUrl: a.ssoStartUrl
     }
     return {
       refresh: encodeRefreshToken(p),
@@ -203,7 +207,8 @@ export class AccountManager {
       profileArn: a.profileArn,
       clientId: a.clientId,
       clientSecret: a.clientSecret,
-      email: a.email
+      email: a.email,
+      ssoStartUrl: a.ssoStartUrl
     }
   }
 }

--- a/src/plugin/cli.ts
+++ b/src/plugin/cli.ts
@@ -46,3 +46,62 @@ export async function promptLoginMode(existingAccounts: ExistingAccountInfo[]): 
     rl.close()
   }
 }
+
+export async function promptForSSOUrl(): Promise<string> {
+  const rl = createInterface({ input, output })
+  try {
+    while (true) {
+      const answer = await rl.question('SSO Start URL: ')
+      const trimmed = answer.trim()
+
+      if (!trimmed) {
+        console.log('URL cannot be empty. Please try again.')
+        continue
+      }
+
+      try {
+        new URL(trimmed)
+        if (!trimmed.includes('awsapps.com')) {
+          console.log('Warning: URL does not appear to be an AWS SSO URL')
+          const confirm = await rl.question('Continue anyway? (y/n): ')
+          if (confirm.trim().toLowerCase() !== 'y' && confirm.trim().toLowerCase() !== 'yes') {
+            continue
+          }
+        }
+        return trimmed
+      } catch {
+        console.log('Invalid URL format. Please try again.')
+      }
+    }
+  } finally {
+    rl.close()
+  }
+}
+
+export type AuthMethodChoice = 'idc' | 'sso'
+
+export async function promptAuthMethod(): Promise<AuthMethodChoice> {
+  const rl = createInterface({ input, output })
+  try {
+    console.log('\nSelect authentication method:')
+    console.log('1. AWS Builder ID (Personal/Trial)')
+    console.log('2. AWS SSO (Enterprise/Organization)\n')
+
+    while (true) {
+      const answer = await rl.question('Choice (1 or 2): ')
+      const choice = answer.trim()
+
+      if (choice === '1') {
+        return 'idc'
+      }
+      if (choice === '2') {
+        return 'sso'
+      }
+
+      console.log('Invalid choice. Please enter 1 or 2.')
+    }
+  } finally {
+    rl.close()
+  }
+}
+

--- a/src/plugin/config/schema.ts
+++ b/src/plugin/config/schema.ts
@@ -31,7 +31,11 @@ export const KiroConfigSchema = z.object({
 
   usage_tracking_enabled: z.boolean().default(true),
 
-  enable_log_api_request: z.boolean().default(false)
+  enable_log_api_request: z.boolean().default(false),
+
+  sso_start_url: z.string().url().optional(),
+
+  sso_region: RegionSchema.optional()
 })
 
 export type KiroConfig = z.infer<typeof KiroConfigSchema>

--- a/src/plugin/token.ts
+++ b/src/plugin/token.ts
@@ -10,6 +10,10 @@ export async function refreshAccessToken(auth: KiroAuthDetails): Promise<KiroAut
     throw new KiroTokenRefreshError('Missing creds', 'MISSING_CREDENTIALS')
   }
 
+  if (auth.authMethod === 'sso' && !p.ssoStartUrl) {
+    throw new KiroTokenRefreshError('Missing SSO start URL', 'MISSING_SSO_URL')
+  }
+
   const requestBody = {
     refreshToken: p.refreshToken,
     clientId: p.clientId,
@@ -55,18 +59,20 @@ export async function refreshAccessToken(auth: KiroAuthDetails): Promise<KiroAut
       refreshToken: d.refresh_token || d.refreshToken || p.refreshToken,
       clientId: p.clientId,
       clientSecret: p.clientSecret,
-      authMethod: 'idc'
+      authMethod: auth.authMethod,
+      ssoStartUrl: p.ssoStartUrl
     }
 
     return {
       refresh: encodeRefreshToken(upP),
       access: acc,
       expires: Date.now() + (d.expires_in || 3600) * 1000,
-      authMethod: 'idc',
+      authMethod: auth.authMethod,
       region: auth.region,
       clientId: auth.clientId,
       clientSecret: auth.clientSecret,
-      email: auth.email
+      email: auth.email,
+      ssoStartUrl: auth.ssoStartUrl
     }
   } catch (error) {
     if (error instanceof KiroTokenRefreshError) {

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -1,4 +1,4 @@
-export type KiroAuthMethod = 'idc'
+export type KiroAuthMethod = 'idc' | 'sso'
 export type KiroRegion = 'us-east-1' | 'us-west-2'
 
 export interface KiroAuthDetails {
@@ -11,6 +11,7 @@ export interface KiroAuthDetails {
   clientSecret?: string
   email?: string
   profileArn?: string
+  ssoStartUrl?: string
 }
 
 export interface RefreshParts {
@@ -19,6 +20,7 @@ export interface RefreshParts {
   clientSecret?: string
   profileArn?: string
   authMethod?: KiroAuthMethod
+  ssoStartUrl?: string
 }
 
 export interface ManagedAccount {
@@ -30,6 +32,7 @@ export interface ManagedAccount {
   clientId?: string
   clientSecret?: string
   profileArn?: string
+  ssoStartUrl?: string
   refreshToken: string
   accessToken: string
   expiresAt: number
@@ -51,6 +54,7 @@ export interface AccountMetadata {
   clientId?: string
   clientSecret?: string
   profileArn?: string
+  ssoStartUrl?: string
   refreshToken: string
   accessToken: string
   expiresAt: number


### PR DESCRIPTION
## Summary

- **AWS SSO (IAM Identity Center) Authentication**: Enterprise users can now authenticate using their organization's SSO portal
  - Support for organization-specific SSO start URLs
  - Compatible with corporate identity providers (Okta, Azure AD, etc.)
  - Seamless integration with existing multi-account management
- New configuration options: `sso_start_url` and `sso_region`
- CLI prompts for SSO URL input during authentication
- Mixed authentication support: Use both Builder ID and SSO accounts simultaneously

## Technical Changes

- Added `src/kiro/oauth-sso.ts` for SSO-specific OAuth flow
- Enhanced auth method type system to support both 'idc' and 'sso'
- Updated token encoding/decoding to preserve SSO start URL
- Improved account manager to handle SSO-specific fields
- Enhanced token refresh logic to handle SSO tokens