### PR TITLE
feat: add Claude Opus 4.5 and extended thinking support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ Add the plugin to your `opencode.json` or `opencode.jsonc`:
           "name": "Claude Haiku 4.5",
           "limit": { "context": 200000, "output": 64000 },
           "modalities": { "input": ["text", "image"], "output": ["text"] }
+        },
+        "claude-opus-4-5": {
+          "name": "Claude Opus 4.5",
+          "limit": { "context": 200000, "output": 64000 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
+        },
+        "claude-opus-4-5-thinking": {
+          "name": "Claude Opus 4.5 Thinking",
+          "limit": { "context": 200000, "output": 64000 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+          "variants": {
+            "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
+            "medium": { "thinkingConfig": { "thinkingBudget": 16384 } },
+            "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
+          }
         }
       }
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -51,6 +51,8 @@ export const MODEL_MAPPING: Record<string, string> = {
   'claude-sonnet-4-5': 'CLAUDE_SONNET_4_5_20250929_V1_0',
   'claude-sonnet-4-5-thinking': 'CLAUDE_SONNET_4_5_20250929_V1_0',
   'claude-sonnet-4-5-20250929': 'CLAUDE_SONNET_4_5_20250929_V1_0',
+  'claude-opus-4-5': 'CLAUDE_OPUS_4_5_20251101_V1_0',
+  'claude-opus-4-5-thinking': 'CLAUDE_OPUS_4_5_20251101_V1_0',
   'claude-sonnet-4-20250514': 'CLAUDE_SONNET_4_20250514_V1_0',
   'claude-3-7-sonnet-20250219': 'CLAUDE_3_7_SONNET_20250219_V1_0'
 }


### PR DESCRIPTION
## Changes
- Added support for `claude-opus-4-5` using the Bedrock model ID `CLAUDE_OPUS_4_5_20251101_V1_0`.
- Added explicit `claude-opus-4-5-thinking` alias to ensure Thinking Mode is reliably detected when no variant is selected in OpenCode configuration.
- Updated `README.md` with configuration examples for the new model and thinking variants.

## Verification
- Verified local build.
- Verified that `thinkingConfig` is correctly sent when the model name ends with `-thinking`.