### PR TITLE
fix(sync): bootstrap IDC accounts from kiro-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # OpenCode Kiro Auth Plugin
+
 [![npm version](https://img.shields.io/npm/v/@zhafron/opencode-kiro-auth)](https://www.npmjs.com/package/@zhafron/opencode-kiro-auth)
 [![npm downloads](https://img.shields.io/npm/dm/@zhafron/opencode-kiro-auth)](https://www.npmjs.com/package/@zhafron/opencode-kiro-auth)
 [![license](https://img.shields.io/npm/l/@zhafron/opencode-kiro-auth)](https://www.npmjs.com/package/@zhafron/opencode-kiro-auth)
@@ -71,11 +72,24 @@ Add the plugin to your `opencode.json` or `opencode.jsonc`:
 1. **Authentication via Kiro CLI (Recommended)**:
    - Perform login directly in your terminal using `kiro-cli login`.
    - The plugin will automatically detect and import your session on startup.
+   - For AWS IAM Identity Center (SSO/IDC), the plugin imports both the token and device registration (OIDC client credentials) from the `kiro-cli` database.
 2. **Direct Authentication**:
    - Run `opencode auth login`.
    - Select `Other`, type `kiro`, and press enter.
    - Follow the instructions for **AWS Builder ID (IDC)**.
 3. Configuration will be automatically managed at `~/.config/opencode/kiro.db`.
+
+## Troubleshooting
+
+### Error: No accounts
+
+This happens when the plugin has no records in `~/.config/opencode/kiro.db`.
+
+1. Ensure `kiro-cli login` succeeds.
+2. Ensure `auto_sync_kiro_cli` is `true` in `~/.config/opencode/kiro.json`.
+3. Retry the request; the plugin will attempt a Kiro CLI sync when it detects zero accounts.
+
+Note for IDC/SSO (ODIC): the plugin may temporarily create an account with a placeholder email if it cannot fetch the real email during sync (e.g. offline). It will replace it with the real email once usage/email lookup succeeds.
 
 ## Configuration
 
@@ -118,10 +132,12 @@ The plugin supports extensive configuration options. Edit `~/.config/opencode/ki
 ## Storage
 
 **Linux/macOS:**
+
 - SQLite Database: `~/.config/opencode/kiro.db`
 - Plugin Config: `~/.config/opencode/kiro.json`
 
 **Windows:**
+
 - SQLite Database: `%APPDATA%\opencode\kiro.db`
 - Plugin Config: `%APPDATA%\opencode\kiro.json`
 

--- a/src/plugin/sync/kiro-cli.test.ts
+++ b/src/plugin/sync/kiro-cli.test.ts
@@ -1,0 +1,152 @@
+import { Database } from 'bun:sqlite'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+type SyncModule = typeof import('./kiro-cli')
+type SqliteModule = typeof import('../storage/sqlite')
+
+let baseDir = ''
+let cliDbPath = ''
+
+let syncFromKiroCli: SyncModule['syncFromKiroCli']
+let DB_PATH: SqliteModule['DB_PATH']
+let kiroDb: SqliteModule['kiroDb']
+
+function writeCliAuthKv(entries: Array<{ key: string; value: any }>) {
+  rmSync(cliDbPath, { force: true })
+  const db = new Database(cliDbPath)
+  db.run('PRAGMA busy_timeout = 5000')
+  db.run('CREATE TABLE auth_kv (key TEXT PRIMARY KEY, value TEXT)')
+  const ins = db.prepare('INSERT INTO auth_kv (key, value) VALUES (?, ?)')
+  for (const e of entries) ins.run(e.key, JSON.stringify(e.value))
+  db.close()
+}
+
+function clearPluginAccounts() {
+  const db = new Database(DB_PATH)
+  db.run('PRAGMA busy_timeout = 5000')
+  db.run('DELETE FROM accounts')
+  db.close()
+}
+
+describe('syncFromKiroCli (IDC bootstrap)', () => {
+  beforeAll(async () => {
+    baseDir = mkdtempSync(join(tmpdir(), 'opencode-kiro-auth-test-'))
+    cliDbPath = join(baseDir, 'kiro-cli.sqlite3')
+
+    process.env.XDG_CONFIG_HOME = baseDir
+    process.env.KIROCLI_DB_PATH = cliDbPath
+
+    const sqliteMod: SqliteModule = await import('../storage/sqlite')
+    DB_PATH = sqliteMod.DB_PATH
+    kiroDb = sqliteMod.kiroDb
+
+    const syncMod: SyncModule = await import('./kiro-cli')
+    syncFromKiroCli = syncMod.syncFromKiroCli
+  })
+
+  beforeEach(() => {
+    clearPluginAccounts()
+  })
+
+  afterAll(() => {
+    kiroDb.close()
+    rmSync(baseDir, { recursive: true, force: true })
+  })
+
+  test('upserts IDC account with nested device-registration creds even if usage fetch fails', async () => {
+    const origFetch = globalThis.fetch
+    globalThis.fetch = Object.assign(
+      async (..._args: Parameters<typeof fetch>) => new Response('fail', { status: 500 }),
+      origFetch
+    )
+
+    try {
+      writeCliAuthKv([
+        {
+          key: 'kirocli:odic:device-registration',
+          value: { registration: { clientId: 'cid-1', clientSecret: 'csec-1' } }
+        },
+        {
+          key: 'kirocli:odic:token',
+          value: {
+            access_token: 'AT',
+            refresh_token: 'RT',
+            expires_at: '2026-01-27T12:00:00Z',
+            region: 'us-east-1'
+          }
+        }
+      ])
+
+      await syncFromKiroCli()
+      const accs: any[] = kiroDb.getAccounts()
+      expect(accs.length).toBe(1)
+      expect(accs[0].auth_method).toBe('idc')
+      expect(accs[0].client_id).toBe('cid-1')
+      expect(accs[0].client_secret).toBe('csec-1')
+      expect(accs[0].refresh_token).toBe('RT')
+      expect(accs[0].access_token).toBe('AT')
+      expect(typeof accs[0].expires_at).toBe('number')
+      expect(accs[0].expires_at).toBeGreaterThan(0)
+      expect(typeof accs[0].email).toBe('string')
+      expect(accs[0].email).toContain('idc-placeholder+')
+    } finally {
+      globalThis.fetch = origFetch
+    }
+  })
+
+  test('when usage fetch succeeds later, inserts real-email account and disables placeholder', async () => {
+    const origFetch = globalThis.fetch
+
+    try {
+      // First pass: fail usage fetch -> placeholder account
+      globalThis.fetch = Object.assign(
+        async (..._args: Parameters<typeof fetch>) => new Response('fail', { status: 500 }),
+        origFetch
+      )
+      writeCliAuthKv([
+        {
+          key: 'kirocli:odic:device-registration',
+          value: { client_id: 'cid-2', client_secret: 'csec-2' }
+        },
+        {
+          key: 'kirocli:odic:token',
+          value: {
+            access_token: 'AT2',
+            refresh_token: 'RT2',
+            expires_at: '2026-01-27T12:00:00Z',
+            region: 'us-east-1'
+          }
+        }
+      ])
+      await syncFromKiroCli()
+
+      // Second pass: succeed -> real email, placeholder should be disabled
+      globalThis.fetch = Object.assign(
+        async (..._args: Parameters<typeof fetch>) =>
+          new Response(
+            JSON.stringify({ userInfo: { email: 'real@example.com' }, usageBreakdownList: [] }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } }
+          ),
+        origFetch
+      )
+      await syncFromKiroCli()
+
+      const accs: any[] = kiroDb.getAccounts()
+      expect(accs.some((a) => a.email === 'real@example.com')).toBe(true)
+      expect(
+        accs.some(
+          (a) =>
+            typeof a.email === 'string' &&
+            a.email.includes('idc-placeholder+') &&
+            a.is_healthy === 0 &&
+            (a.fail_count || 0) >= 10
+        )
+      ).toBe(true)
+    } finally {
+      globalThis.fetch = origFetch
+    }
+  })
+})

--- a/src/plugin/sync/kiro-cli.ts
+++ b/src/plugin/sync/kiro-cli.ts
@@ -1,4 +1,5 @@
 import { Database } from 'bun:sqlite'
+import { createHash } from 'node:crypto'
 import { existsSync } from 'node:fs'
 import { homedir, platform } from 'node:os'
 import { join } from 'node:path'
@@ -8,6 +9,8 @@ import { kiroDb } from '../storage/sqlite'
 import { fetchUsageLimits } from '../usage'
 
 function getCliDbPath(): string {
+  const override = process.env.KIROCLI_DB_PATH
+  if (override) return override
   const p = platform()
   if (p === 'win32')
     return join(
@@ -20,6 +23,67 @@ function getCliDbPath(): string {
   return join(homedir(), '.local', 'share', 'kiro-cli', 'data.sqlite3')
 }
 
+function safeJsonParse(value: unknown): any | null {
+  if (typeof value !== 'string') return null
+  try {
+    return JSON.parse(value)
+  } catch {
+    return null
+  }
+}
+
+function normalizeExpiresAt(input: unknown): number {
+  if (typeof input === 'number') {
+    // Heuristic: < 10^10 is likely seconds.
+    return input < 10_000_000_000 ? input * 1000 : input
+  }
+  if (typeof input === 'string' && input.trim()) {
+    const t = new Date(input).getTime()
+    if (!Number.isNaN(t) && t > 0) return t
+    const n = Number(input)
+    if (Number.isFinite(n) && n > 0) return normalizeExpiresAt(n)
+  }
+  return 0
+}
+
+function findClientCredsRecursive(input: unknown): { clientId?: string; clientSecret?: string } {
+  const root = input as any
+  if (!root || typeof root !== 'object') return {}
+
+  const stack: any[] = [root]
+  const visited = new Set<any>()
+  while (stack.length) {
+    const cur = stack.pop()
+    if (!cur || typeof cur !== 'object') continue
+    if (visited.has(cur)) continue
+    visited.add(cur)
+
+    const clientId = cur.client_id || cur.clientId
+    const clientSecret = cur.client_secret || cur.clientSecret
+    if (typeof clientId === 'string' && typeof clientSecret === 'string') {
+      if (clientId && clientSecret) return { clientId, clientSecret }
+    }
+
+    if (Array.isArray(cur)) {
+      for (const v of cur) stack.push(v)
+      continue
+    }
+    for (const v of Object.values(cur)) stack.push(v)
+  }
+  return {}
+}
+
+function makePlaceholderEmail(
+  authMethod: string,
+  region: string,
+  clientId?: string,
+  profileArn?: string
+): string {
+  const seed = `${authMethod}:${region}:${clientId || ''}:${profileArn || ''}`
+  const h = createHash('sha256').update(seed).digest('hex').slice(0, 16)
+  return `${authMethod}-placeholder+${h}@awsapps.local`
+}
+
 export async function syncFromKiroCli() {
   const dbPath = getCliDbPath()
   if (!existsSync(dbPath)) return
@@ -27,63 +91,150 @@ export async function syncFromKiroCli() {
     const cliDb = new Database(dbPath, { readonly: true })
     cliDb.run('PRAGMA busy_timeout = 5000')
     const rows = cliDb.prepare('SELECT key, value FROM auth_kv').all() as any[]
+
+    const deviceRegRow = rows.find(
+      (r) => typeof r?.key === 'string' && r.key.includes('device-registration')
+    )
+    const deviceReg = safeJsonParse(deviceRegRow?.value)
+    const regCreds = deviceReg ? findClientCredsRecursive(deviceReg) : {}
+
     for (const row of rows) {
       if (row.key.includes(':token')) {
-        let data: any
-        try {
-          data = JSON.parse(row.value)
-        } catch {
+        const data = safeJsonParse(row.value)
+        if (!data) continue
+
+        const isIdc = row.key.includes('odic')
+        const authMethod = isIdc ? 'idc' : 'desktop'
+        const region = data.region || 'us-east-1'
+        const profileArn = data.profile_arn || data.profileArn
+
+        const accessToken = data.access_token || data.accessToken || ''
+        const refreshToken = data.refresh_token || data.refreshToken
+        if (!refreshToken) continue
+
+        const clientId = data.client_id || data.clientId || (isIdc ? regCreds.clientId : undefined)
+        const clientSecret =
+          data.client_secret || data.clientSecret || (isIdc ? regCreds.clientSecret : undefined)
+
+        if (authMethod === 'idc' && (!clientId || !clientSecret)) {
+          logger.warn('Kiro CLI sync: missing IDC device credentials; skipping token import')
           continue
         }
-        if (!data.access_token) continue
-        const authMethod = row.key.includes('odic') ? 'idc' : 'desktop'
-        const region = data.region || 'us-east-1'
-        const clientId =
-          data.client_id ||
-          (authMethod === 'idc'
-            ? JSON.parse(rows.find((r) => r.key.includes('device-registration'))?.value || '{}')
-                .client_id
-            : undefined)
-        const clientSecret =
-          data.client_secret ||
-          (authMethod === 'idc'
-            ? JSON.parse(rows.find((r) => r.key.includes('device-registration'))?.value || '{}')
-                .client_secret
-            : undefined)
+
+        const cliExpiresAt =
+          normalizeExpiresAt(data.expires_at ?? data.expiresAt) || Date.now() + 3600000
+
+        let usedCount = 0
+        let limitCount = 0
+        let email: string | undefined
+        let usageOk = false
+
         try {
-          const u = await fetchUsageLimits({
+          const authForUsage: any = {
             refresh: '',
-            access: data.access_token,
-            expires: 0,
+            access: accessToken,
+            expires: cliExpiresAt,
             authMethod,
             region,
-            clientId,
-            clientSecret
-          })
-          const email = u.email
-          if (!email) continue
-          const id = createDeterministicAccountId(email, authMethod, clientId, data.profile_arn)
-          const existing = kiroDb.getAccounts().find((a) => a.id === id)
-          const cliExpiresAt = data.expires_at ? new Date(data.expires_at).getTime() : 0
-          if (existing && existing.is_healthy === 1 && existing.expires_at >= cliExpiresAt) continue
-          kiroDb.upsertAccount({
-            id,
-            email,
-            authMethod,
-            region,
+            profileArn,
             clientId,
             clientSecret,
-            profileArn: data.profile_arn,
-            refreshToken: data.refresh_token,
-            accessToken: data.access_token,
-            expiresAt: cliExpiresAt || Date.now() + 3600000,
-            isHealthy: 1,
-            failCount: 0,
-            usedCount: u.usedCount,
-            limitCount: u.limitCount,
-            lastSync: Date.now()
+            email: ''
+          }
+          const u = await fetchUsageLimits(authForUsage)
+          usedCount = u.usedCount || 0
+          limitCount = u.limitCount || 0
+          if (typeof u.email === 'string' && u.email) {
+            email = u.email
+            usageOk = true
+          }
+        } catch (e) {
+          logger.warn('Kiro CLI sync: failed to fetch usage/email; falling back', {
+            authMethod,
+            region
           })
-        } catch {}
+          logger.debug('Kiro CLI sync: usage fetch error', e)
+        }
+
+        const all = kiroDb.getAccounts()
+        if (!email) {
+          let existing: any | undefined
+          if (profileArn) {
+            existing = all.find((a) => a.auth_method === authMethod && a.profile_arn === profileArn)
+          }
+          if (!existing && authMethod === 'idc' && clientId) {
+            existing = all.find((a) => a.auth_method === 'idc' && a.client_id === clientId)
+          }
+          if (existing && typeof existing.email === 'string' && existing.email) {
+            email = existing.email
+          } else {
+            email = makePlaceholderEmail(authMethod, region, clientId, profileArn)
+          }
+        }
+
+        const resolvedEmail =
+          email || makePlaceholderEmail(authMethod, region, clientId, profileArn)
+
+        const id = createDeterministicAccountId(resolvedEmail, authMethod, clientId, profileArn)
+        const existingById = all.find((a) => a.id === id)
+        if (
+          existingById &&
+          existingById.is_healthy === 1 &&
+          existingById.expires_at >= cliExpiresAt
+        )
+          continue
+
+        if (usageOk) {
+          const placeholderEmail = makePlaceholderEmail(authMethod, region, clientId, profileArn)
+          const placeholderId = createDeterministicAccountId(
+            placeholderEmail,
+            authMethod,
+            clientId,
+            profileArn
+          )
+          if (placeholderId !== id) {
+            const placeholderRow = all.find((a) => a.id === placeholderId)
+            if (placeholderRow) {
+              kiroDb.upsertAccount({
+                id: placeholderId,
+                email: placeholderRow.email,
+                authMethod,
+                region: placeholderRow.region || region,
+                clientId,
+                clientSecret,
+                profileArn,
+                refreshToken: placeholderRow.refresh_token || refreshToken,
+                accessToken: placeholderRow.access_token || accessToken,
+                expiresAt: placeholderRow.expires_at || cliExpiresAt,
+                isHealthy: 0,
+                failCount: 10,
+                unhealthyReason: 'Replaced by real email',
+                recoveryTime: Date.now() + 31536000000,
+                usedCount: placeholderRow.used_count || 0,
+                limitCount: placeholderRow.limit_count || 0,
+                lastSync: Date.now()
+              })
+            }
+          }
+        }
+
+        kiroDb.upsertAccount({
+          id,
+          email: resolvedEmail,
+          authMethod,
+          region,
+          clientId,
+          clientSecret,
+          profileArn,
+          refreshToken,
+          accessToken,
+          expiresAt: cliExpiresAt,
+          isHealthy: 1,
+          failCount: 0,
+          usedCount,
+          limitCount,
+          lastSync: Date.now()
+        })
       }
     }
     cliDb.close()


### PR DESCRIPTION
## Problem
After clearing `~/.config/opencode/kiro.db` and re-authing via `kiro-cli login` (IAM Identity Center / SSO), the plugin can fail to import any accounts and OpenCode errors with `Error: No accounts`.

For IDC/ODIC, storing only `access_token`/`refresh_token`/`expires_at` is not enough: refresh requires OIDC client credentials (`client_id`/`client_secret`) from the `device-registration` record.

## Fix
- Make kiro-cli sync robust for IDC (odic) sessions:
  - read both `kirocli:odic:token` and `kirocli:odic:device-registration`
  - recursively extract client credentials (snake_case + camelCase, nested)
  - normalize `expires_at` to ms epoch
  - upsert an account even when usage/email lookup fails (deterministic placeholder email)
  - when the real email is later available, insert the real-email account and disable the placeholder to avoid account rotation duplicates
- In the request path, if account count is 0, attempt a one-time `syncFromKiroCli()` + reload before throwing `No accounts`.
- Add Bun tests covering fallback bootstrap and placeholder -> real email replacement.

## How to test
1. macOS/Linux:
   - `rm ~/.config/opencode/kiro.db`
   - `kiro-cli login` (SSO/IDC)
   - `opencode run -m kiro/claude-sonnet-4-5 "OK"` (should not throw `No accounts`)
2. Sanity check:
   - `sqlite3 ~/.config/opencode/kiro.db "select auth_method, client_id is not null, client_secret is not null, email from accounts;"`
3. Offline behavior (optional):
   - disable network, run a request (placeholder-email account should be created)
   - re-enable network, run again (real email appears, placeholder becomes unhealthy)

## Notes
- Added `KIROCLI_DB_PATH` env override to make it easier to test/debug against a specific kiro-cli sqlite path.