### PR TITLE
feat: add new Kiro model mappings and fix existing IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ Add the plugin to your `opencode.json` or `opencode.jsonc`:
             "medium": { "thinkingConfig": { "thinkingBudget": 16384 } },
             "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
           }
+        },
+        "claude-sonnet-4-5-1m": {
+          "name": "Claude Sonnet 4.5 1M",
+          "limit": { "context": 1000000, "output": 64000 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
+        },
+        "qwen3-coder-480b": {
+          "name": "Qwen3 Coder 480B",
+          "limit": { "context": 200000, "output": 64000 },
+          "modalities": { "input": ["text"], "output": ["text"] }
         }
       }
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -38,14 +38,21 @@ export const KIRO_CONSTANTS = {
 }
 
 export const MODEL_MAPPING: Record<string, string> = {
-  'claude-haiku-4-5': 'claude-haiku-4.5',
+  'claude-haiku-4-5': 'CLAUDE_HAIKU_4_5_20251001_V1_0',
+  'claude-haiku-4-5-thinking': 'CLAUDE_HAIKU_4_5_20251001_V1_0',
   'claude-sonnet-4-5': 'CLAUDE_SONNET_4_5_20250929_V1_0',
   'claude-sonnet-4-5-thinking': 'CLAUDE_SONNET_4_5_20250929_V1_0',
-  'claude-sonnet-4-5-20250929': 'CLAUDE_SONNET_4_5_20250929_V1_0',
+  'claude-sonnet-4-5-1m': 'CLAUDE_SONNET_4_5_20250929_LONG_V1_0',
+  'claude-sonnet-4-5-1m-thinking': 'CLAUDE_SONNET_4_5_20250929_LONG_V1_0',
   'claude-opus-4-5': 'CLAUDE_OPUS_4_5_20251101_V1_0',
   'claude-opus-4-5-thinking': 'CLAUDE_OPUS_4_5_20251101_V1_0',
-  'claude-sonnet-4-20250514': 'CLAUDE_SONNET_4_20250514_V1_0',
-  'claude-3-7-sonnet-20250219': 'CLAUDE_3_7_SONNET_20250219_V1_0'
+  'claude-sonnet-4': 'CLAUDE_SONNET_4_20250514_V1_0',
+  'claude-3-7-sonnet': 'CLAUDE_3_7_SONNET_20250219_V1_0',
+  'nova-swe': 'AGI_NOVA_SWE_V1_5',
+  'gpt-oss-120b': 'OPENAI_GPT_OSS_120B_1_0',
+  'qwen3-coder-480b': 'QWEN3_CODER_480B_A35B_1_0',
+  'minimax-m2': 'MINIMAX_MINIMAX_M2',
+  'kimi-k2-thinking': 'MOONSHOT_KIMI_K2_THINKING'
 }
 
 export const SUPPORTED_MODELS = Object.keys(MODEL_MAPPING)


### PR DESCRIPTION
## Summary

This PR adds support for new Kiro models and fixes existing model ID mappings.

### Changes

#### Fixed
- `claude-haiku-4-5` model ID corrected to use proper backend format (`CLAUDE_HAIKU_4_5_20251001_V1_0`)

#### Added Models
- `claude-haiku-4-5-thinking` - Haiku with thinking support
- `claude-sonnet-4-5-1m` - Sonnet 4.5 with 1M context window
- `claude-sonnet-4-5-1m-thinking` - Sonnet 4.5 1M with thinking support
- `nova-swe` - Amazon Nova SWE
- `gpt-oss-120b` - OpenAI GPT OSS 120B
- `qwen3-coder-480b` - Qwen3 Coder 480B
- `minimax-m2` - MiniMax M2 (1M context)
- `kimi-k2-thinking` - Moonshot Kimi K2 Thinking

#### Renamed (cleaner aliases)
- `claude-sonnet-4-20250514` → `claude-sonnet-4`
- `claude-3-7-sonnet-20250219` → `claude-3-7-sonnet`

### Testing
All 15 models have been verified working via `opencode run` CLI tests.

### Notes
- Removed non-working models: `titan-text-premier`, `nova-pro`, `nova-swe-alpha`, `olympus-premier`, `gpt-oss-20b`, `qwen3-coder-30b` (these return 400 errors)