### PR TITLE
fix(health): treat suspended as permanent

### DIFF
--- a/src/plugin/health.ts
+++ b/src/plugin/health.ts
@@ -1,6 +1,7 @@
 export function isPermanentError(reason?: string): boolean {
   if (!reason) return false
   return (
+    reason.includes('Account Suspended') ||
     reason.includes('Invalid refresh token') ||
     reason.includes('ExpiredTokenException') ||
     reason.includes('InvalidTokenException') ||


### PR DESCRIPTION
## Problem
In mixed-account setups (e.g. IDC + Desktop), a suspended account should be treated as permanently unhealthy and skipped by rotation.

Currently, the suspension marker ("Account Suspended") is not classified as permanent by `isPermanentError`, which can allow generic recovery/success paths to rehabilitate it.

## Fix
Treat "Account Suspended" as a permanent unhealthy reason in `src/plugin/health.ts`.

## Verification
- bun install
- bun run typecheck
- bun run build

Manual scenario:
- Mixed accounts with one suspended: the suspended account should never be revived/selected while a healthy account exists.