### PR TITLE
fix(region): validate region by format

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,9 +1,9 @@
 import type { KiroRegion } from './plugin/types'
 
-const VALID_REGIONS: readonly KiroRegion[] = ['us-east-1', 'us-west-2']
+const REGION_REGEX = /^[a-z]{2}-[a-z-]+-\d+$/
 
 export function isValidRegion(region: string): region is KiroRegion {
-  return VALID_REGIONS.includes(region as KiroRegion)
+  return REGION_REGEX.test(region)
 }
 
 export function normalizeRegion(region: string | undefined): KiroRegion {

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -1,5 +1,5 @@
 export type KiroAuthMethod = 'idc' | 'desktop'
-export type KiroRegion = 'us-east-1' | 'us-west-2'
+export type KiroRegion = string
 
 export interface KiroAuthDetails {
   refresh: string


### PR DESCRIPTION
## Context
Region strings are used for endpoint construction and auth flows. A fixed allowlist breaks valid non-US regions.

## Problem
The code only treated a couple of regions as valid. Users in eu-* / ap-* regions hit confusing failures even with correct region values.

## Scope
- Region validation and typing only.
- No request payload changes.
- No auth flow behavior changes.

## Changes
- `src/constants.ts`: validate regions via regex format.
- `src/plugin/types.ts`: allow valid AWS region strings.

## How To Verify
- bun install
- bun run typecheck
- bun run build

## Risk / Rollback
- Low risk. Revert commit to rollback.