### PR TITLE
fix(sync): preserve permanent unhealthy during kiro-cli sync

### DIFF
--- a/src/plugin/sync/kiro-cli.ts
+++ b/src/plugin/sync/kiro-cli.ts
@@ -1,6 +1,7 @@
 import { Database } from 'bun:sqlite'
 import { existsSync } from 'node:fs'
 import { createDeterministicAccountId } from '../accounts'
+import { isPermanentError } from '../health'
 import * as logger from '../logger'
 import { kiroDb } from '../storage/sqlite'
 import { fetchUsageLimits } from '../usage'
@@ -112,6 +113,9 @@ export async function syncFromKiroCli() {
         )
           continue
 
+        const preservePermanentUnhealthy =
+          !!existingById && isPermanentError(existingById.unhealthy_reason)
+
         if (usageOk) {
           const placeholderEmail = makePlaceholderEmail(authMethod, region, clientId, profileArn)
           const placeholderId = createDeterministicAccountId(
@@ -159,8 +163,10 @@ export async function syncFromKiroCli() {
           accessToken,
           expiresAt: cliExpiresAt,
           rateLimitResetTime: 0,
-          isHealthy: true,
-          failCount: 0,
+          isHealthy: preservePermanentUnhealthy ? existingById.is_healthy === 1 : true,
+          failCount: preservePermanentUnhealthy ? existingById.fail_count || 10 : 0,
+          unhealthyReason: preservePermanentUnhealthy ? existingById.unhealthy_reason : undefined,
+          recoveryTime: preservePermanentUnhealthy ? existingById.recovery_time : undefined,
           usedCount,
           limitCount,
           lastSync: Date.now()


### PR DESCRIPTION
## Context
`syncFromKiroCli()` imports token/account metadata from the local kiro-cli sqlite DB into the plugin’s sqlite DB. This helps bootstrap accounts and keep tokens in sync.

## Problem
The sync path currently writes imported accounts with:
- `isHealthy: true`
- `failCount: 0`

That is dangerous when an existing account is already marked permanently unhealthy (e.g., suspended) because a sync can "heal" it and reintroduce it into rotation.

## Scope (deliberately narrow)
- Only changes kiro-cli sync behavior.
- No changes to how permanence is classified.
- No changes to selection strategy.

## Change
- `src/plugin/sync/kiro-cli.ts`
  - If the imported account already exists and its `unhealthy_reason` is permanent, preserve:
    - `is_healthy`
    - `fail_count`
    - `unhealthy_reason`
    - `recovery_time`
  - Still updates token metadata fields needed for future recovery (access/refresh/expires).

## Expected Behavior After This Change
- A permanently unhealthy account cannot be healed by a sync operation.
- Token metadata stays current without overriding health classification.

## How To Verify
- `bun install`
- `bun run typecheck`
- `bun run build`

Manual validation (recommended):
1. Mark an account permanently unhealthy in the plugin DB.
2. Trigger kiro-cli sync.
3. Confirm health fields remain unchanged.

## Risk / Rollback
- Risk: low. Preserves state only when it is already classified as permanent.
- Rollback: revert commit.