### PR TITLE
fix(rotation): skip permanently unhealthy accounts

### DIFF
--- a/src/plugin/accounts.ts
+++ b/src/plugin/accounts.ts
@@ -81,10 +81,10 @@ export class AccountManager {
   getCurrentOrNext(): ManagedAccount | null {
     const now = Date.now()
     const available = this.accounts.filter((a) => {
+      if (isPermanentError(a.unhealthyReason)) {
+        return false
+      }
       if (!a.isHealthy) {
-        if (isPermanentError(a.unhealthyReason)) {
-          return false
-        }
         if (a.failCount < 10 && a.recoveryTime && now >= a.recoveryTime) {
           a.isHealthy = true
           delete a.unhealthyReason
@@ -170,10 +170,12 @@ export class AccountManager {
       acc.refreshToken = p.refreshToken
       if (p.profileArn) acc.profileArn = p.profileArn
       if (p.clientId) acc.clientId = p.clientId
-      acc.failCount = 0
-      acc.isHealthy = true
-      delete acc.unhealthyReason
-      delete acc.recoveryTime
+      if (!isPermanentError(acc.unhealthyReason)) {
+        acc.failCount = 0
+        acc.isHealthy = true
+        delete acc.unhealthyReason
+        delete acc.recoveryTime
+      }
       kiroDb.upsertAccount(acc).catch(() => {})
       writeToKiroCli(acc).catch(() => {})
     }


### PR DESCRIPTION
## Context
Account rotation and health state are persisted in sqlite (`is_healthy`, `unhealthy_reason`, `fail_count`, `recovery_time`). In the real world, these fields can drift or become inconsistent due to partial writes, stale state, or import/sync behaviors.

## Problem
A permanently unhealthy account (e.g., suspended) must never be selected if there is any usable alternative. Today there are two risky cases:

1) Selection may trust `isHealthy` even if `unhealthyReason` indicates a permanent failure.
2) `updateFromAuth()` clears health flags unconditionally, which can accidentally rehabilitate an account that was intentionally marked permanently unhealthy.

## Scope (deliberately narrow)
- Only hardens selection and auth-update behavior against permanent-unhealthy states.
- Does not change how accounts become unhealthy.
- Does not change sync behavior.

## Changes
- `src/plugin/accounts.ts`
  - Selection: treat `isPermanentError(unhealthyReason)` as a hard exclusion from the selectable pool (even if `isHealthy` is true).
  - Auth update: do not clear `unhealthyReason` / `recoveryTime` / `failCount` if the account is permanently unhealthy.

## Expected Behavior After This Change
- Permanently unhealthy accounts never enter the selectable pool when there are other usable accounts.
- Auth refresh won't silently clear permanent unhealthy status.

## How To Verify
- `bun install`
- `bun run typecheck`
- `bun run build`

Manual validation (recommended):
- Create a scenario with 2 accounts where one is permanently unhealthy (e.g. suspended) and one is healthy; confirm selection always uses the healthy account.

## Risk / Rollback
- Risk: low. The change is scoped to permanent-unhealthy states only.
- Rollback: revert commit.