### PR TITLE
fix(opencode): register config hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "type": "plugin",
     "hooks": [
       "auth",
+      "config",
       "event"
     ]
   },


### PR DESCRIPTION
## Context
The plugin implements a `config` hook to wire provider defaults (e.g., OpenAI-compatible baseURL/fetch). OpenCode only calls a plugin hook if it is declared in `package.json` under `opencode.hooks`.

## Problem
`package.json` currently declares only:
- `auth`
- `event`

So OpenCode does not invoke the plugin's `config` hook even if it exists in code. In practice this causes missing provider options and can surface as invalid URL construction (e.g. `undefined/chat/completions`) when the OpenAI-compatible provider tries to build endpoints without a base URL.

## Scope (deliberately narrow)
- Only changes plugin hook registration.
- No changes to request logic, rotation logic, sync logic, or auth flows.

## Change
- `package.json`
  - Add `"config"` to `opencode.hooks`.

## Expected Behavior After This Change
- OpenCode discovers and invokes the plugin `config` hook.
- Provider options that depend on `config` are applied reliably (especially relevant for file-based plugin installs).

## How To Verify
- `bun install`
- `bun run typecheck`
- `bun run build`

Optional manual check:
- Run OpenCode with the plugin installed via `file:` and confirm provider requests no longer fail due to missing base URL.

## Risk / Rollback
- Risk: minimal. Additive hook registration only.
- Rollback: remove `config` from the hooks list.