### PR TITLE
fix(health): treat suspended as permanent

### DIFF
--- a/src/plugin/health.ts
+++ b/src/plugin/health.ts
@@ -1,6 +1,7 @@
 export function isPermanentError(reason?: string): boolean {
   if (!reason) return false
   return (
+    reason.includes('Account Suspended') ||
     reason.includes('Invalid refresh token') ||
     reason.includes('ExpiredTokenException') ||
     reason.includes('InvalidTokenException') ||


### PR DESCRIPTION
## Context
This repo integrates OpenCode with AWS Kiro/CodeWhisperer accounts and rotates across them. In mixed-account setups (IDC + Desktop), some accounts can become *suspended* by AWS.

A suspended account is not transiently rate-limited; it's effectively unusable until the suspension is cleared. Treating it as recoverable causes repeated failures and noisy rotation.

## Problem
The plugin already has the concept of "permanent" vs "recoverable" unhealthy reasons via `isPermanentError(reason)`. However, the suspension marker currently written by the request error handler ("Account Suspended") is not classified as permanent.

That mismatch allows other code paths (usage update / successful requests / time-based recovery) to inadvertently rehabilitate the suspended account and reintroduce it into rotation.

## Scope (deliberately narrow)
- Only updates permanence classification.
- No changes to rotation strategy, sync rules, request payloads, or auth flows.

## Change
- `src/plugin/health.ts`
  - `isPermanentError()` now treats "Account Suspended" as a permanent unhealthy reason.

## Expected Behavior After This Change
- A suspended account stays unhealthy.
- Generic recovery logic will not clear `unhealthyReason` / reset `failCount` for suspended accounts.
- Rotation will keep skipping suspended accounts when alternatives exist.

## How To Verify
- `bun install`
- `bun run typecheck`
- `bun run build`

Manual validation (recommended):
1. Ensure you have at least 2 accounts (one suspended, one usable).
2. Run a few requests and confirm the suspended account never becomes healthy again.

## Risk / Rollback
- Risk: low. If AWS changes the suspension reason string, the marker may stop being treated as permanent.
- Rollback: revert this commit.