### PR TITLE
feat: implement thinking configuration resolution and variant mapping

### DIFF
--- a/src/core/request/thinking.ts
+++ b/src/core/request/thinking.ts
@@ -1,0 +1,56 @@
+type RawBody = {
+  variant?: unknown
+  providerOptions?: {
+    variant?: unknown
+    modelVariant?: unknown
+    thinkingConfig?: {
+      thinkingBudget?: unknown
+    }
+  }
+}
+
+export type ThinkingVariant = 'low' | 'medium' | 'high' | 'max'
+
+export function resolveThinkingConfig(
+  model: string,
+  body: unknown,
+  defaults: { budget: number } = { budget: 20000 }
+): { enabled: boolean; budget: number; variant?: string } {
+  const b = (body || {}) as RawBody
+
+  const rawVariant =
+    (typeof b.variant === 'string' && b.variant) ||
+    (typeof b.providerOptions?.variant === 'string' && b.providerOptions.variant) ||
+    (typeof b.providerOptions?.modelVariant === 'string' && b.providerOptions.modelVariant) ||
+    undefined
+
+  const explicitBudget = b.providerOptions?.thinkingConfig?.thinkingBudget
+  const budgetFromBody =
+    typeof explicitBudget === 'number' && Number.isFinite(explicitBudget) && explicitBudget > 0
+      ? explicitBudget
+      : undefined
+
+  const budgetFromVariant = variantToBudget(rawVariant)
+  const enabled =
+    model.endsWith('-thinking') ||
+    budgetFromBody !== undefined ||
+    b.providerOptions?.thinkingConfig !== undefined ||
+    budgetFromVariant !== undefined
+
+  return {
+    enabled,
+    budget: budgetFromBody ?? budgetFromVariant ?? defaults.budget,
+    variant: rawVariant
+  }
+}
+
+function variantToBudget(rawVariant: string | undefined): number | undefined {
+  if (!rawVariant) return undefined
+
+  const v = rawVariant.toLowerCase()
+  if (v === 'low') return 8192
+  if (v === 'medium') return 16384
+  // "high" is the documented name, but "max" is kept as backward compat
+  if (v === 'high' || v === 'max') return 32768
+  return undefined
+}

--- a/test/thinking.test.js
+++ b/test/thinking.test.js
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { resolveThinkingConfig } from '../dist/core/request/thinking.js'
+
+test('resolveThinkingConfig: model suffix enables thinking with default budget', () => {
+  const r = resolveThinkingConfig('claude-sonnet-4-5-thinking', {})
+  assert.equal(r.enabled, true)
+  assert.equal(r.budget, 20000)
+})
+
+test('resolveThinkingConfig: explicit thinkingConfig takes precedence', () => {
+  const r = resolveThinkingConfig('claude-sonnet-4-5', {
+    providerOptions: { thinkingConfig: { thinkingBudget: 12345 } }
+  })
+  assert.equal(r.enabled, true)
+  assert.equal(r.budget, 12345)
+})
+
+test('resolveThinkingConfig: variant low/medium/high maps to budgets', () => {
+  assert.equal(resolveThinkingConfig('claude-sonnet-4-5', { variant: 'low' }).budget, 8192)
+  assert.equal(resolveThinkingConfig('claude-sonnet-4-5', { variant: 'medium' }).budget, 16384)
+  assert.equal(resolveThinkingConfig('claude-sonnet-4-5', { variant: 'high' }).budget, 32768)
+})
+
+test('resolveThinkingConfig: max is accepted as backward-compatible alias of high', () => {
+  const r = resolveThinkingConfig('claude-sonnet-4-5', { providerOptions: { variant: 'max' } })
+  assert.equal(r.enabled, true)
+  assert.equal(r.budget, 32768)
+})


### PR DESCRIPTION
## Summary
This PR implements the thinking configuration resolution logic, enabling the extraction of thinking budgets and variant mappings for model requests. It ensures that token budgets are correctly resolved based on model suffixes, explicit configurations, or variant presets.

## Key Features
- **Thinking Configuration Resolution**: Added `resolveThinkingConfig` to handle logic for enabling thinking and determining token budgets.
- **Variant Mapping**: Implemented mapping for `low`, `medium`, `high`, and `max` variants to their respective token budgets (8k, 16k, 32k).
- **Backward Compatibility**: Supports `max` as an alias for the `high` variant.
- **Explicit Overrides**: Supports explicit `thinkingBudget` overrides within `providerOptions.thinkingConfig`.

## Testing
- Added comprehensive unit tests in `test/thinking.test.js` covering:
  - Model suffix detection (`-thinking`).
  - Explicit budget overrides.
  - Variant-to-budget mapping.
  - Backward compatibility for the `max` variant.
