### PR TITLE
fix: ensure thinking blocks always stream before text blocks

### DIFF
--- a/src/plugin/streaming/stream-transformer.ts
+++ b/src/plugin/streaming/stream-transformer.ts
@@ -10,7 +10,7 @@ export async function* transformKiroStream(
   model: string,
   conversationId: string
 ): AsyncGenerator<any> {
-  const thinkingRequested = true
+  const thinkingRequested = model.endsWith('-thinking')
 
   const streamState: StreamState = {
     thinkingRequested,
@@ -37,6 +37,7 @@ export async function* transformKiroStream(
   let contextUsagePercentage: number | null = null
   const toolCalls: ToolCallState[] = []
   let currentToolCall: ToolCallState | null = null
+  let preThinkingText = ''
 
   try {
     while (true) {
@@ -71,7 +72,7 @@ export async function* transformKiroStream(
               if (startPos !== -1) {
                 const before = streamState.buffer.slice(0, startPos)
                 if (before) {
-                  deltaEvents.push(...createTextDeltaEvents(before, streamState))
+                  preThinkingText += before
                 }
 
                 streamState.buffer = streamState.buffer.slice(startPos + THINKING_START_TAG.length)
@@ -83,7 +84,7 @@ export async function* transformKiroStream(
               if (safeLen > 0) {
                 const safeText = streamState.buffer.slice(0, safeLen)
                 if (safeText) {
-                  deltaEvents.push(...createTextDeltaEvents(safeText, streamState))
+                  preThinkingText += safeText
                 }
                 streamState.buffer = streamState.buffer.slice(safeLen)
               }
@@ -108,6 +109,10 @@ export async function* transformKiroStream(
                 if (streamState.buffer.startsWith('\n\n')) {
                   streamState.buffer = streamState.buffer.slice(2)
                 }
+                if (preThinkingText) {
+                  deltaEvents.push(...createTextDeltaEvents(preThinkingText, streamState))
+                  preThinkingText = ''
+                }
                 continue
               }
 
@@ -123,6 +128,10 @@ export async function* transformKiroStream(
             }
 
             if (streamState.thinkingExtracted) {
+              if (preThinkingText) {
+                deltaEvents.push(...createTextDeltaEvents(preThinkingText, streamState))
+                preThinkingText = ''
+              }
               const rest = streamState.buffer
               streamState.buffer = ''
               if (rest) {
@@ -194,10 +203,21 @@ export async function* transformKiroStream(
         for (const ev of stopBlock(streamState.thinkingBlockIndex, streamState))
           yield convertToOpenAI(ev, conversationId, model)
       } else {
+        if (preThinkingText) {
+          for (const ev of createTextDeltaEvents(preThinkingText, streamState))
+            yield convertToOpenAI(ev, conversationId, model)
+          preThinkingText = ''
+        }
         for (const ev of createTextDeltaEvents(streamState.buffer, streamState))
           yield convertToOpenAI(ev, conversationId, model)
         streamState.buffer = ''
       }
+    }
+
+    if (preThinkingText) {
+      for (const ev of createTextDeltaEvents(preThinkingText, streamState))
+        yield convertToOpenAI(ev, conversationId, model)
+      preThinkingText = ''
     }
 
     for (const ev of stopBlock(streamState.textBlockIndex, streamState))


### PR DESCRIPTION
## Problem

When using thinking models (e.g. `claude-opus-4-6-thinking`), the thinking chain and response text appear in the wrong order in the UI — sometimes the response text shows above the thinking chain, or they are interleaved.

### Root Causes

1. **`thinkingRequested` hardcoded to `true`**: The stream transformer always tries to parse `<thinking>` tags, even for non-thinking models. This can cause false positives and unnecessary processing.

2. **Pre-thinking text creates text block before thinking block**: When any text arrives before the `<thinking>` tag in the stream (even whitespace or newlines), it gets emitted as `text_delta` immediately, creating a text block with a lower index than the thinking block. The UI then renders the response text above the thinking chain.

## Fix

### `stream-transformer.ts`

- **`thinkingRequested` is now model-dependent**: Changed from `const thinkingRequested = true` to `const thinkingRequested = model.endsWith('-thinking')`. Non-thinking models skip tag parsing entirely.

- **Pre-thinking text buffering**: Added a `preThinkingText` buffer that accumulates any text arriving before the `<thinking>` tag. Instead of emitting it immediately as `text_delta` (which would create the text block first), the text is held until the thinking block completes, then emitted afterward.

- **Guaranteed stream order**: The output order is now always: thinking deltas → text deltas, regardless of how the Kiro API chunks the response.

### Edge cases handled:
- If thinking is never found (model didn't output `<thinking>` tags), buffered text is emitted at end of stream
- If stream ends while still inside a thinking block, remaining content is properly flushed
- Non-thinking models bypass the entire tag parsing logic for better performance

## Verification
- TypeScript build passes with zero errors
- Only `stream-transformer.ts` is modified