### PR TITLE
add: npm explicit mention to installation append json

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Add the plugin to your `opencode.json` or `opencode.jsonc`:
   "plugin": ["@zhafron/opencode-kiro-auth"],
   "provider": {
     "kiro": {
+      "npm": "@zhafron/opencode-kiro-auth",
       "models": {
         "claude-sonnet-4-5": {
           "name": "Claude Sonnet 4.5",


### PR DESCRIPTION
## Bug
After copy pasting what's given in the readme, I got this error

```
{
  "name": "UnknownError",
  "data": {
    "message": "TypeError: Object.values requires that input parameter not be null or undefined\n    at values (unknown)\n    at /home/karthidreamr/.cache/opencode/node_modules/@zhafron/opencode-kiro-auth/dist/constants.js:2:30\n    at moduleEvaluation (native:1:11)\n    at moduleEvaluation (native:1:11)\n    at moduleEvaluation (native:1:11)\n    at requestImportModule (native:2)\n    at processTicksAndRejections (native:7:39)"
  }
}
```

## My Findings:

The error is coming from the @zhafron/opencode-kiro-auth plugin trying to access a null/undefined value. This is likely  because the kiro provider configuration is incomplete - it's missing required fields like npm that other providers have.

## Solution:

 Add missing npm field to kiro provider configuration

```
20, 20:     "kiro": {
+   21:       "npm": "@zhafron/opencode-kiro-auth",
21, 22:       "models": {
```