### PR TITLE
fix: handle invalid_grant as permanent auth error with improved resilience

### DIFF
--- a/src/core/auth/token-refresher.ts
+++ b/src/core/auth/token-refresher.ts
@@ -70,7 +70,8 @@ export class TokenRefresher {
         error.code === 'InvalidTokenException' ||
         error.code === 'HTTP_401' ||
         error.code === 'HTTP_403' ||
-        error.message.includes('Invalid refresh token provided'))
+        error.message.includes('Invalid refresh token provided') ||
+        error.message.includes('Invalid grant provided'))
     ) {
       this.accountManager.markUnhealthy(account, error.message)
       await this.repository.batchSave(this.accountManager.getAccounts())

--- a/src/plugin/accounts.ts
+++ b/src/plugin/accounts.ts
@@ -177,7 +177,7 @@ export class AccountManager {
       delete acc.unhealthyReason
       delete acc.recoveryTime
       kiroDb.upsertAccount(acc).catch(() => {})
-      writeToKiroCli(acc).catch(() => {})
+      writeToKiroCli(acc).catch((e) => logger.warn('Failed to write token back to Kiro CLI', e))
     }
   }
   markRateLimited(a: ManagedAccount, ms: number): void {

--- a/src/plugin/health.ts
+++ b/src/plugin/health.ts
@@ -2,6 +2,8 @@ export function isPermanentError(reason?: string): boolean {
   if (!reason) return false
   return (
     reason.includes('Invalid refresh token') ||
+    reason.includes('Invalid grant provided') ||
+    reason.includes('invalid_grant') ||
     reason.includes('ExpiredTokenException') ||
     reason.includes('InvalidTokenException') ||
     reason.includes('HTTP_401') ||

--- a/src/plugin/sync/kiro-cli.ts
+++ b/src/plugin/sync/kiro-cli.ts
@@ -130,7 +130,8 @@ export async function syncFromKiroCli() {
         if (
           existingById &&
           existingById.is_healthy === 1 &&
-          existingById.expires_at >= cliExpiresAt
+          existingById.expires_at >= cliExpiresAt &&
+          existingById.expires_at > Date.now()
         )
           continue
 


### PR DESCRIPTION
## Problem

When the Kiro server returns `invalid_grant` / `Invalid grant provided` during token refresh, the error was not recognized as a fatal auth failure. This caused the plugin to:
- Re-throw the error instead of marking the account unhealthy
- Retry the dead token up to 10 times before giving up
- Silently swallow `writeToKiroCli` failures, causing stale tokens to persist

## Changes

- Add `Invalid grant provided` and `invalid_grant` to `isPermanentError()` so accounts fail fast
- Catch `Invalid grant provided` in `token-refresher` error handler
- Fix CLI sync skip condition to also verify token is not already expired (`expires_at > Date.now()`)
- Log `writeToKiroCli` failures instead of silently swallowing them

## Root cause

`invalid_grant` is returned when a refresh token is revoked, expired server-side, or invalidated by a concurrent refresh (rotation race). The fix ensures these are treated as permanent failures requiring re-authentication rather than transient errors worth retrying.

Related to #43 #49