### PR TITLE
feat: auto re-auth when all accounts are permanently unhealthy

### DIFF
--- a/src/core/request/request-handler.ts
+++ b/src/core/request/request-handler.ts
@@ -28,7 +28,8 @@ export class RequestHandler {
   constructor(
     private accountManager: AccountManager,
     private config: KiroConfig,
-    private repository: AccountRepository
+    private repository: AccountRepository,
+    private client?: any
   ) {
     this.accountSelector = new AccountSelector(accountManager, config, syncFromKiroCli, repository)
     this.tokenRefresher = new TokenRefresher(config, accountManager, syncFromKiroCli, repository)
@@ -70,7 +71,11 @@ export class RequestHandler {
       }
 
       if (this.allAccountsPermanentlyUnhealthy()) {
-        throw new Error('All accounts are permanently unhealthy (quota exceeded or suspended)')
+        const reauthed = await this.triggerReauth(showToast)
+        if (!reauthed) {
+          throw new Error('All accounts are permanently unhealthy. Please re-authenticate.')
+        }
+        continue
       }
 
       let acc = await this.accountSelector.selectHealthyAccount(showToast)
@@ -256,6 +261,29 @@ export class RequestHandler {
         rData,
         logger.getTimestamp()
       )
+    }
+  }
+
+  private async triggerReauth(showToast: ToastFunction): Promise<boolean> {
+    if (!this.client) return false
+    try {
+      showToast('Session expired. Re-authenticating...', 'warning')
+      await this.client.provider.oauth.authorize({
+        path: { id: 'kiro' },
+        body: { method: 0 }
+      })
+      // Sync fresh tokens from CLI after re-auth
+      await syncFromKiroCli()
+      this.repository.invalidateCache()
+      const accounts = await this.repository.findAll()
+      for (const acc of accounts) {
+        this.accountManager.addAccount(acc)
+      }
+      showToast('Re-authentication successful.', 'success')
+      return true
+    } catch (e) {
+      logger.error('Re-auth failed', e instanceof Error ? e : new Error(String(e)))
+      return false
     }
   }
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -26,14 +26,14 @@ export const createKiroPlugin =
     const accountManager = await AccountManager.loadFromDisk(config.account_selection_strategy)
     authHandler.setAccountManager(accountManager)
 
-    const requestHandler = new RequestHandler(accountManager, config, repository)
+    const requestHandler = new RequestHandler(accountManager, config, repository, client)
 
     return {
       auth: {
         provider: id,
         loader: async (getAuth: any) => {
           await getAuth()
-          await authHandler.initialize()
+          await authHandler.initialize(showToast as any)
 
           return {
             apiKey: '',


### PR DESCRIPTION
## Problem

When all accounts become permanently unhealthy (e.g. after `invalid_grant`, account suspension, or token expiry), the plugin throws:
```
Error: All accounts are permanently unhealthy (quota exceeded or suspended)
```
This requires the user to manually restart OpenCode and re-authenticate.

## Changes

- When `allAccountsPermanentlyUnhealthy()` is detected, instead of throwing, call `client.provider.oauth.authorize()` to automatically trigger the browser-based OAuth re-auth flow
- After re-auth completes, sync fresh tokens from Kiro CLI and reload accounts
- Resume the request loop with the new valid tokens
- Show toast notifications for re-auth progress and success

## Result

Users no longer need to manually restart or re-authenticate — the plugin recovers automatically when tokens go permanently invalid.

Closes #43