### PR TITLE
feat: improve usage tracking, reporting and remove debug logs

### DIFF
--- a/src/core/account/account-selector.ts
+++ b/src/core/account/account-selector.ts
@@ -53,6 +53,12 @@ export class AccountSelector {
 
     this.resetCircuitBreaker()
 
+    const used = acc.usedCount ?? 0
+    const limit = acc.limitCount ?? 0
+    if (limit > 0 && used / limit >= 0.9 && this.accountManager.shouldShowUsageToast()) {
+      showToast(this.formatUsageMessage(used, limit, acc.email || ''), 'warning')
+    }
+
     return acc
   }
 

--- a/src/core/account/usage-tracker.ts
+++ b/src/core/account/usage-tracker.ts
@@ -1,26 +1,40 @@
 import type { AccountRepository } from '../../infrastructure/database/account-repository'
 import type { AccountManager } from '../../plugin/accounts'
+import * as logger from '../../plugin/logger'
 import type { KiroAuthDetails, ManagedAccount } from '../../plugin/types'
 import { fetchUsageLimits, updateAccountQuota } from '../../plugin/usage'
 
 interface UsageTrackerConfig {
   usage_tracking_enabled: boolean
   usage_sync_max_retries: number
+  usage_sync_cooldown_ms?: number
 }
 
 export class UsageTracker {
+  private lastSyncTime = new Map<string, number>()
+  private readonly cooldownMs: number
+
   constructor(
     private config: UsageTrackerConfig,
     private accountManager: AccountManager,
     private repository: AccountRepository
-  ) {}
+  ) {
+    this.cooldownMs = config.usage_sync_cooldown_ms ?? 60000
+  }
 
   async syncUsage(account: ManagedAccount, auth: KiroAuthDetails): Promise<void> {
-    if (!this.config.usage_tracking_enabled) {
-      return
-    }
+    if (!this.config.usage_tracking_enabled) return
 
-    this.syncWithRetry(account, auth, 0).catch(() => {})
+    const last = this.lastSyncTime.get(account.id) ?? 0
+    if (Date.now() - last < this.cooldownMs) return
+
+    this.lastSyncTime.set(account.id, Date.now())
+    this.syncWithRetry(account, auth, 0).catch((e) => {
+      logger.warn('Usage sync failed after all retries', {
+        accountId: account.id,
+        error: e instanceof Error ? e.message : String(e)
+      })
+    })
   }
 
   private async syncWithRetry(
@@ -46,6 +60,8 @@ export class UsageTracker {
         this.accountManager.markUnhealthy(account, e.message)
         this.repository.save(account).catch(() => {})
       }
+
+      throw e
     }
   }
 

--- a/src/core/auth/auth-handler.ts
+++ b/src/core/auth/auth-handler.ts
@@ -4,6 +4,8 @@ import { RegionSchema } from '../../plugin/config/schema.js'
 import * as logger from '../../plugin/logger.js'
 import { IdcAuthMethod } from './idc-auth-method.js'
 
+type ToastFunction = (message: string, variant: 'info' | 'warning' | 'success' | 'error') => void
+
 export class AuthHandler {
   private accountManager?: any
 
@@ -12,7 +14,7 @@ export class AuthHandler {
     private repository: AccountRepository
   ) {}
 
-  async initialize(): Promise<void> {
+  async initialize(showToast?: ToastFunction): Promise<void> {
     const { syncFromKiroCli } = await import('../../plugin/sync/kiro-cli.js')
 
     logger.log('Auth init', { autoSyncKiroCli: !!this.config.auto_sync_kiro_cli })
@@ -25,6 +27,32 @@ export class AuthHandler {
         for (const a of accounts) this.accountManager.addAccount(a)
       }
       logger.log('Kiro CLI sync: done', { importedAccounts: accounts.length })
+    }
+
+    this.logUsageSummary(showToast)
+  }
+
+  private logUsageSummary(showToast?: ToastFunction): void {
+    if (!this.accountManager) return
+    const accounts = this.accountManager.getAccounts()
+    if (!accounts.length) return
+
+    for (const acc of accounts) {
+      const used = acc.usedCount ?? 0
+      const limit = acc.limitCount ?? 0
+      if (limit > 0) {
+        const pct = Math.round((used / limit) * 100)
+        const msg = `Kiro usage (${acc.email}): ${used}/${limit} (${pct}%)`
+        logger.log(msg)
+        if (showToast) {
+          const variant = pct >= 90 ? 'warning' : 'info'
+          setTimeout(() => showToast(msg, variant), 3000)
+        }
+      } else if (used > 0) {
+        const msg = `Kiro usage (${acc.email}): ${used} requests used`
+        logger.log(msg)
+        if (showToast) setTimeout(() => showToast(msg, 'info'), 3000)
+      }
     }
   }
 

--- a/src/core/auth/idc-auth-method.ts
+++ b/src/core/auth/idc-auth-method.ts
@@ -115,6 +115,9 @@ export class IdcAuthMethod {
               profileArn
             })
           } catch (e) {
+            logger.warn('fetchUsageLimits failed during auth', {
+              error: e instanceof Error ? e.message : String(e)
+            })
             if (startUrl && !profileArn) {
               throw new Error(
                 `Missing profile ARN for IAM Identity Center. Set "idc_profile_arn" in ~/.config/opencode/kiro.json, or run "kiro-cli profile" once so it can be auto-detected. Original error: ${
@@ -122,9 +125,35 @@ export class IdcAuthMethod {
                 }`
               )
             }
-            throw e
+            usage = {
+              usedCount: 0,
+              limitCount: 0,
+              email: undefined
+            }
           }
-          if (!usage.email) return { type: 'failed' }
+
+          if (!usage.email) {
+            try {
+              const tokenParts = token.accessToken.split('.')
+              if (tokenParts.length === 3 && tokenParts[1]) {
+                const payload = JSON.parse(Buffer.from(tokenParts[1], 'base64').toString())
+                usage.email =
+                  payload.email || payload.sub || `user-${token.clientId.substring(0, 8)}@idc.local`
+              } else {
+                usage.email = `user-${token.clientId.substring(0, 8)}@idc.local`
+              }
+            } catch {
+              usage.email = `user-${token.clientId.substring(0, 8)}@idc.local`
+            }
+          }
+
+          if (!usage.email) {
+            usage.email = `user-${token.clientId.substring(0, 8)}@idc.local`
+          }
+
+          if (!usage.email) {
+            return { type: 'failed' }
+          }
 
           const id = createDeterministicAccountId(usage.email, 'idc', token.clientId, profileArn)
           const acc: ManagedAccount = {

--- a/src/plugin/usage.ts
+++ b/src/plugin/usage.ts
@@ -1,57 +1,81 @@
 import { KiroAuthDetails, ManagedAccount } from './types'
 
 export async function fetchUsageLimits(auth: KiroAuthDetails): Promise<any> {
-  const url = new URL(`https://q.${auth.region}.amazonaws.com/getUsageLimits`)
-  url.searchParams.set('isEmailRequired', 'true')
-  url.searchParams.set('origin', 'AI_EDITOR')
-  url.searchParams.set('resourceType', 'AGENTIC_REQUEST')
-  if (auth.profileArn) url.searchParams.set('profileArn', auth.profileArn)
-  try {
-    const res = await fetch(url.toString(), {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${auth.access}`,
-        'Content-Type': 'application/json',
-        'x-amzn-kiro-agent-mode': 'vibe',
-        'amz-sdk-request': 'attempt=1; max=1'
-      }
-    })
-    if (!res.ok) {
-      const body = await res.text().catch(() => '')
-      const requestId =
-        res.headers.get('x-amzn-requestid') ||
-        res.headers.get('x-amzn-request-id') ||
-        res.headers.get('x-amz-request-id') ||
-        ''
-      const errType =
-        res.headers.get('x-amzn-errortype') || res.headers.get('x-amzn-error-type') || ''
-      const msg =
-        body && body.length > 0
-          ? `${body.slice(0, 2000)}${body.length > 2000 ? '…' : ''}`
-          : `HTTP ${res.status}`
-      throw new Error(
-        `Status: ${res.status}${errType ? ` (${errType})` : ''}${
-          requestId ? ` [${requestId}]` : ''
-        }: ${msg}`
-      )
-    }
-    const data: any = await res.json()
-    let usedCount = 0,
-      limitCount = 0
-    if (Array.isArray(data.usageBreakdownList)) {
-      for (const s of data.usageBreakdownList) {
-        if (s.freeTrialInfo) {
-          usedCount += s.freeTrialInfo.currentUsage || 0
-          limitCount += s.freeTrialInfo.usageLimit || 0
+  // Try different parameter combinations
+  const attempts: Array<{ resourceType?: string; origin?: string }> = [
+    { resourceType: 'AGENTIC_REQUEST', origin: 'AI_EDITOR' },
+    { origin: 'AI_EDITOR' },
+    { resourceType: 'CONVERSATION', origin: 'AI_EDITOR' },
+    {}
+  ]
+
+  let lastError: Error | null = null
+
+  for (const [index, params] of attempts.entries()) {
+    const url = new URL(`https://q.${auth.region}.amazonaws.com/getUsageLimits`)
+    url.searchParams.set('isEmailRequired', 'true')
+    if (params.origin) url.searchParams.set('origin', params.origin)
+    if (params.resourceType) url.searchParams.set('resourceType', params.resourceType)
+    if (auth.profileArn) url.searchParams.set('profileArn', auth.profileArn)
+
+    try {
+      const res = await fetch(url.toString(), {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${auth.access}`,
+          'Content-Type': 'application/json',
+          'x-amzn-kiro-agent-mode': 'vibe',
+          'amz-sdk-request': 'attempt=1; max=1'
         }
-        usedCount += s.currentUsage || 0
-        limitCount += s.usageLimit || 0
+      })
+
+      if (!res.ok) {
+        const body = await res.text().catch(() => '')
+        const requestId =
+          res.headers.get('x-amzn-requestid') ||
+          res.headers.get('x-amzn-request-id') ||
+          res.headers.get('x-amz-request-id') ||
+          ''
+        const errType =
+          res.headers.get('x-amzn-errortype') || res.headers.get('x-amzn-error-type') || ''
+
+        if (body.includes('FEATURE_NOT_SUPPORTED') && index < attempts.length - 1) {
+          continue
+        }
+
+        const msg =
+          body && body.length > 0
+            ? `${body.slice(0, 2000)}${body.length > 2000 ? '…' : ''}`
+            : `HTTP ${res.status}`
+        lastError = new Error(
+          `Status: ${res.status}${errType ? ` (${errType})` : ''}${
+            requestId ? ` [${requestId}]` : ''
+          }: ${msg}`
+        )
+        continue
       }
+
+      const data: any = await res.json()
+      let usedCount = 0,
+        limitCount = 0
+      if (Array.isArray(data.usageBreakdownList)) {
+        for (const s of data.usageBreakdownList) {
+          if (s.freeTrialInfo) {
+            usedCount += s.freeTrialInfo.currentUsage || 0
+            limitCount += s.freeTrialInfo.usageLimit || 0
+          }
+          usedCount += s.currentUsage || 0
+          limitCount += s.usageLimit || 0
+        }
+      }
+      return { usedCount, limitCount, email: data.userInfo?.email }
+    } catch (e) {
+      lastError = e instanceof Error ? e : new Error(String(e))
+      if (index < attempts.length - 1) continue
     }
-    return { usedCount, limitCount, email: data.userInfo?.email }
-  } catch (e) {
-    throw e
   }
+
+  throw lastError || new Error('All getUsageLimits attempts failed')
 }
 
 export function updateAccountQuota(


### PR DESCRIPTION
## Changes

### Usage sync throttle
- Add 60s per-account cooldown to `UsageTracker` to avoid hammering `getUsageLimits` on every request
- Previously every successful request triggered a usage sync call — with high request volume this could itself trigger rate limits

### Usage sync error logging
- Log usage sync failures after all retries instead of silently swallowing them
- Makes it visible in `~/.config/opencode/kiro-logs/plugin.log` when usage sync is consistently failing

### Startup usage summary
- Show a toast on startup with current usage per account: `Kiro usage (user@example.com): 37/1000 (3.7%)`
- Show as `warning` variant when at 90%+ of quota, `info` otherwise
- Also written to the log file on every startup

### Quota warning toast
- Show a warning toast when a selected account reaches 90% of its quota
- Uses existing `shouldShowUsageToast()` debounce to avoid spam