### PR TITLE
fix(idc): gracefully handle FEATURE_NOT_SUPPORTED in usage limits

### DIFF
--- a/src/core/account/usage-tracker.ts
+++ b/src/core/account/usage-tracker.ts
@@ -38,6 +38,11 @@ export class UsageTracker {
         return this.syncWithRetry(account, auth, attempt + 1)
       }
 
+      if (e.message?.includes('FEATURE_NOT_SUPPORTED')) {
+        // Some IDC profiles don't support getUsageLimits; don't penalize the account.
+        return
+      }
+
       if (
         e.message?.includes('403') ||
         e.message?.includes('invalid') ||

--- a/src/core/auth/idc-auth-method.ts
+++ b/src/core/auth/idc-auth-method.ts
@@ -5,6 +5,7 @@ import type { AccountRepository } from '../../infrastructure/database/account-re
 import { authorizeKiroIDC, pollKiroIDCToken } from '../../kiro/oauth-idc.js'
 import { createDeterministicAccountId } from '../../plugin/accounts.js'
 import * as logger from '../../plugin/logger.js'
+import { makePlaceholderEmail } from '../../plugin/sync/kiro-cli-parser.js'
 import { readActiveProfileArnFromKiroCli } from '../../plugin/sync/kiro-cli-profile.js'
 import type { KiroRegion, ManagedAccount } from '../../plugin/types.js'
 import { fetchUsageLimits } from '../../plugin/usage.js'
@@ -102,7 +103,7 @@ export class IdcAuthMethod {
 
           const profileArn = configuredProfileArn || readActiveProfileArnFromKiroCli()
           const serviceRegion = extractRegionFromArn(profileArn) || configuredServiceRegion
-          let usage: any
+          let usage: any = { usedCount: 0, limitCount: 0, email: undefined }
           try {
             usage = await fetchUsageLimits({
               refresh: '',
@@ -122,14 +123,23 @@ export class IdcAuthMethod {
                 }`
               )
             }
-            throw e
+            const errMsg = e instanceof Error ? e.message : String(e)
+            if (errMsg.includes('FEATURE_NOT_SUPPORTED')) {
+              logger.warn('fetchUsageLimits returned FEATURE_NOT_SUPPORTED; skipping usage check', {
+                serviceRegion,
+                profileArn
+              })
+            } else {
+              throw e
+            }
           }
-          if (!usage.email) return { type: 'failed' }
 
-          const id = createDeterministicAccountId(usage.email, 'idc', token.clientId, profileArn)
+          const email =
+            usage.email || makePlaceholderEmail('idc', serviceRegion, token.clientId, profileArn)
+          const id = createDeterministicAccountId(email, 'idc', token.clientId, profileArn)
           const acc: ManagedAccount = {
             id,
-            email: usage.email,
+            email,
             authMethod: 'idc',
             region: serviceRegion,
             oidcRegion,


### PR DESCRIPTION
## Problem

Some IDC profiles do not support `getUsageLimits`, which returns a `FEATURE_NOT_SUPPORTED` error. This caused:
1. Account registration to fail during IDC auth flow
2. Usage tracker to penalize healthy accounts unnecessarily

## Changes

### `src/core/auth/idc-auth-method.ts`
- Initialize `usage` with safe defaults so auth can proceed even if `fetchUsageLimits` fails
- Catch `FEATURE_NOT_SUPPORTED` error and log a warning instead of throwing
- Use `makePlaceholderEmail` as fallback when real email is unavailable

### `src/core/account/usage-tracker.ts`
- Early return on `FEATURE_NOT_SUPPORTED` to avoid penalizing the account

## Testing
- Build passes
- No breaking changes to existing functionality