### PR TITLE
feat: auto re-auth via kiro-cli login when all accounts are permanently unhealthy

### DIFF
--- a/src/core/request/request-handler.ts
+++ b/src/core/request/request-handler.ts
@@ -1,3 +1,4 @@
+import { execFile } from 'node:child_process'
 import type { AccountRepository } from '../../infrastructure/database/account-repository'
 import type { AccountManager } from '../../plugin/accounts'
 import type { KiroConfig } from '../../plugin/config'
@@ -70,7 +71,13 @@ export class RequestHandler {
       }
 
       if (this.allAccountsPermanentlyUnhealthy()) {
-        throw new Error('All accounts are permanently unhealthy (quota exceeded or suspended)')
+        const reauthed = await this.triggerKiroCliLogin(showToast)
+        if (!reauthed) {
+          throw new Error(
+            'All accounts are permanently unhealthy. Please re-authenticate with kiro-cli login.'
+          )
+        }
+        continue
       }
 
       let acc = await this.accountSelector.selectHealthyAccount(showToast)
@@ -256,6 +263,40 @@ export class RequestHandler {
         rData,
         logger.getTimestamp()
       )
+    }
+  }
+
+  private async triggerKiroCliLogin(showToast: ToastFunction): Promise<boolean> {
+    try {
+      showToast('Session expired. Launching kiro-cli login...', 'warning')
+      logger.log('Triggering kiro-cli login for re-authentication')
+
+      await new Promise<void>((resolve, reject) => {
+        execFile('kiro-cli', ['login'], { timeout: 120000 }, (error) => {
+          if (error) reject(error)
+          else resolve()
+        })
+      })
+
+      await syncFromKiroCli()
+      this.repository.invalidateCache()
+      const accounts = await this.repository.findAll()
+      for (const acc of accounts) {
+        this.accountManager.addAccount(acc)
+      }
+
+      const healthy = accounts.some((a) => a.isHealthy)
+      if (healthy) {
+        showToast('Re-authentication successful.', 'success')
+        return true
+      }
+
+      logger.warn('kiro-cli login completed but no healthy accounts found')
+      return false
+    } catch (e) {
+      logger.error('kiro-cli login failed', e instanceof Error ? e : new Error(String(e)))
+      showToast('Re-authentication failed. Run kiro-cli login manually.', 'error')
+      return false
     }
   }
 


### PR DESCRIPTION
## Problem

When all accounts become permanently unhealthy (e.g. after `invalid_grant`, account suspension, or token expiry), the plugin throws:
```
Error: All accounts are permanently unhealthy (quota exceeded or suspended)
```
This requires the user to manually restart OpenCode and re-authenticate.

## Approach

Alternative to #70 — instead of using OpenCode's built-in OAuth device-code flow (`client.provider.oauth.authorize()`), this uses `kiro-cli login` to trigger the native browser-based re-authentication via `https://app.kiro.dev/signin`.

This approach works for users who authenticate through the Kiro CLI web login flow rather than the IDC device-code flow.

## Changes

- When `allAccountsPermanentlyUnhealthy()` is detected, instead of throwing, run `kiro-cli login` as a subprocess to trigger browser-based re-auth
- After login completes, sync fresh tokens from the kiro-cli SQLite database and reload accounts
- Resume the request loop with new valid tokens
- Show toast notifications for re-auth progress and result
- 120 second timeout for the login process
- No changes to `plugin.ts` or `auth-handler.ts` — only `request-handler.ts` is modified

## Result

Users no longer need to manually restart or re-authenticate — the plugin recovers automatically by launching `kiro-cli login` when tokens go permanently invalid.

Related: #43, #70