### PR TITLE
feat: add Claude Opus 4.7 model mapping

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -66,6 +66,8 @@ export const MODEL_MAPPING: Record<string, string> = {
   'claude-opus-4-6-thinking': 'claude-opus-4.6',
   'claude-opus-4-6-1m': 'claude-opus-4.6-1m',
   'claude-opus-4-6-1m-thinking': 'claude-opus-4.6-1m',
+  'claude-opus-4-7': 'claude-opus-4.7',
+  'claude-opus-4-7-thinking': 'claude-opus-4.7',
   'claude-sonnet-4': 'claude-sonnet-4',
   'claude-3-7-sonnet': 'CLAUDE_3_7_SONNET_20250219_V1_0',
   'nova-swe': 'AGI_NOVA_SWE_V1_5',


### PR DESCRIPTION
Add Claude Opus 4.7 model mapping to `MODEL_MAPPING` in `constants.ts`.

## Changes

- `claude-opus-4-7` → `claude-opus-4.7`
- `claude-opus-4-7-thinking` → `claude-opus-4.7`

## Context

Kiro announced Claude Opus 4.7 availability on April 17, 2026:
https://kiro.dev/changelog/models/claude-opus-4-7-now-available/

- 1M token context window with 2.2x credit multiplier
- Inference in us-east-1 and eu-central-1
- Currently rolling out experimentally to a subset of Pro, Pro+, and Power tier subscribers signing in with AWS IAM Identity Center
- No `-1m` variants added since default models now natively support 1M context (ref: #77)

## Notes

- Server-side validation currently returns `INVALID_MODEL_ID` for accounts not yet in the rollout
- Once rolled out to your account, the model will work immediately with this mapping