### PR TITLE
feat: add kiro-cli login as fallback when OAuth re-auth fails

### DIFF
--- a/src/core/request/request-handler.ts
+++ b/src/core/request/request-handler.ts
@@ -1,4 +1,5 @@
 import { GenerateAssistantResponseCommand } from '@aws/codewhisperer-streaming-client'
+import { execFile } from 'node:child_process'
 import type { AccountRepository } from '../../infrastructure/database/account-repository'
 import type { AccountManager } from '../../plugin/accounts'
 import type { KiroConfig } from '../../plugin/config'
@@ -276,24 +277,64 @@ export class RequestHandler {
   }
 
   private async triggerReauth(showToast: ToastFunction): Promise<boolean> {
-    if (!this.client) return false
+    // Try OpenCode OAuth first if client is available
+    if (this.client) {
+      try {
+        showToast('Session expired. Re-authenticating...', 'warning')
+        await this.client.provider.oauth.authorize({
+          path: { id: 'kiro' },
+          body: { method: 0 }
+        })
+        await syncFromKiroCli()
+        this.repository.invalidateCache()
+        const accounts = await this.repository.findAll()
+        for (const acc of accounts) {
+          this.accountManager.addAccount(acc)
+        }
+        showToast('Re-authentication successful.', 'success')
+        return true
+      } catch (e) {
+        logger.warn(
+          'OAuth re-auth failed, trying kiro-cli login fallback',
+          e instanceof Error ? e : new Error(String(e))
+        )
+      }
+    }
+
+    // Fallback: try kiro-cli login
+    return this.triggerKiroCliLogin(showToast)
+  }
+
+  private async triggerKiroCliLogin(showToast: ToastFunction): Promise<boolean> {
     try {
-      showToast('Session expired. Re-authenticating...', 'warning')
-      await this.client.provider.oauth.authorize({
-        path: { id: 'kiro' },
-        body: { method: 0 }
+      showToast('Launching kiro-cli login...', 'warning')
+      logger.log('Triggering kiro-cli login for re-authentication')
+
+      await new Promise<void>((resolve, reject) => {
+        execFile('kiro-cli', ['login'], { timeout: 120000 }, (error) => {
+          if (error) reject(error)
+          else resolve()
+        })
       })
-      // Sync fresh tokens from CLI after re-auth
+
       await syncFromKiroCli()
       this.repository.invalidateCache()
       const accounts = await this.repository.findAll()
       for (const acc of accounts) {
         this.accountManager.addAccount(acc)
       }
-      showToast('Re-authentication successful.', 'success')
-      return true
+
+      const healthy = accounts.some((a) => a.isHealthy)
+      if (healthy) {
+        showToast('Re-authentication successful.', 'success')
+        return true
+      }
+
+      logger.warn('kiro-cli login completed but no healthy accounts found')
+      return false
     } catch (e) {
-      logger.error('Re-auth failed', e instanceof Error ? e : new Error(String(e)))
+      logger.error('kiro-cli login failed', e instanceof Error ? e : new Error(String(e)))
+      showToast('Re-authentication failed. Run kiro-cli login manually.', 'error')
       return false
     }
   }


### PR DESCRIPTION
## Problem

PR #70 added auto re-auth via `client.provider.oauth.authorize()`, which works for the OpenCode built-in OAuth device-code flow. However, users who authenticate through the Kiro CLI web login flow (`https://app.kiro.dev/signin`) cannot use this path — if `client` is unavailable or OAuth fails, re-auth silently returns `false` and throws.

## Changes

- When OAuth re-auth fails (or `client` is not available), fall back to running `kiro-cli login` as a subprocess
- This opens the user's browser for Kiro's native web-based authentication
- After login completes, sync fresh tokens from the kiro-cli SQLite database and reload accounts
- 120 second timeout for the login process
- Toast notifications for progress and result

## Flow

1. All accounts permanently unhealthy → `triggerReauth()`
2. Try OpenCode OAuth first (if `client` available)
3. If OAuth fails or `client` unavailable → fallback to `kiro-cli login`
4. Sync tokens → reload accounts → resume request loop

## Result

Users who authenticate via `kiro-cli login` (Google/GitHub OAuth, web-based flow) now get automatic recovery when tokens expire, without needing to manually restart OpenCode.

Builds on top of #70.