### PR TITLE
fix: add .js extensions to ESM imports via postbuild script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json && node scripts/fix-esm-imports.mjs",
     "format": "prettier --write 'src/**/*.ts'",
     "test": "bun test",
     "typecheck": "tsc --noEmit",

--- a/scripts/fix-esm-imports.mjs
+++ b/scripts/fix-esm-imports.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * Postbuild script: adds .js extensions to relative imports in dist/ files.
+ * Fixes ESM compatibility for strict runtimes (Bun 1.3.13+, Node.js).
+ */
+import { readFileSync, writeFileSync, readdirSync, statSync, existsSync } from 'node:fs'
+import { join, dirname, resolve } from 'node:path'
+
+const DIST_DIR = resolve(import.meta.dirname, '..', 'dist')
+
+function walk(dir) {
+  const results = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      results.push(...walk(full))
+    } else if (full.endsWith('.js') || full.endsWith('.d.ts')) {
+      results.push(full)
+    }
+  }
+  return results
+}
+
+// Match: from './foo' or from '../foo' (but NOT from './foo.js' or from 'zod')
+const IMPORT_RE = /(from\s+['"])(\.[^'"]*?)(?<!\.[cm]?js)(['"])/g
+
+function fixFile(filePath) {
+  const original = readFileSync(filePath, 'utf-8')
+  let changed = false
+
+  const fixed = original.replace(IMPORT_RE, (match, prefix, specifier, suffix) => {
+    if (specifier.endsWith('.js')) return match
+
+    const dir = dirname(filePath)
+
+    // Check if specifier points to a directory with index.js
+    const asDir = resolve(dir, specifier)
+    if (existsSync(join(asDir, 'index.js'))) {
+      changed = true
+      return `${prefix}${specifier}/index.js${suffix}`
+    }
+
+    // Check if specifier.js exists
+    if (existsSync(resolve(dir, specifier + '.js'))) {
+      changed = true
+      return `${prefix}${specifier}.js${suffix}`
+    }
+
+    return match
+  })
+
+  if (changed) {
+    writeFileSync(filePath, fixed, 'utf-8')
+  }
+  return changed
+}
+
+const files = walk(DIST_DIR)
+let fixedCount = 0
+for (const f of files) {
+  if (fixFile(f)) fixedCount++
+}
+console.log(`fix-esm-imports: patched ${fixedCount}/${files.length} files in dist/`)


### PR DESCRIPTION
## Problem

OpenCode v1.14.21 bumped its embedded Bun runtime from 1.3.11 to 1.3.13 ([sst/opencode#23791](https://github.com/sst/opencode/pull/23791)), which enforces strict ESM module resolution. The compiled `dist/` files use extensionless relative imports (e.g. `from './plugin/config/schema'`) that Bun 1.3.13+ refuses to resolve, causing the plugin to fail to load:

```
Cannot find module '.../dist/plugin/config/schema' imported from .../dist/constants.js
```

This breaks the kiro provider entirely on OpenCode >= 1.14.21.

## Root Cause

`tsconfig.json` uses `"module": "Preserve"` with `"moduleResolution": "bundler"`, which emits extensionless imports. This worked on Bun 1.3.11 (lenient resolution) but fails on Bun 1.3.13+ (strict ESM).

## Solution

Add a postbuild script (`scripts/fix-esm-imports.mjs`) that automatically appends `.js` extensions to all relative imports in `dist/` after `tsc` compilation. The `build` script in `package.json` is updated to run it:

```
"build": "tsc -p tsconfig.build.json && node scripts/fix-esm-imports.mjs"
```

This approach requires zero changes to source code or tsconfig.

## Verification

- Build succeeds: 37/106 files patched, 0 extensionless imports remaining
- Node.js strict ESM import test passes
- No source code changes required