### PR TITLE
fix: prevent image serialization 400 errors with Uint8Array and API limits

### DIFF
--- a/src/infrastructure/transformers/history-builder.ts
+++ b/src/infrastructure/transformers/history-builder.ts
@@ -36,7 +36,11 @@ export function buildHistory(
 
         const unifiedImages = extractAllImages(m.content)
         if (unifiedImages.length > 0) {
-          uim.images = convertImagesToKiroFormat(unifiedImages)
+          const { images, omitted } = convertImagesToKiroFormat(unifiedImages)
+          uim.images = images
+          if (omitted > 0) {
+            uim.content += `\n\n[${omitted} image(s) omitted due to API limits]`
+          }
         }
       } else {
         uim.content = getContentText(m)

--- a/src/plugin/image-handler.ts
+++ b/src/plugin/image-handler.ts
@@ -3,11 +3,22 @@ interface UnifiedImage {
   data: string
 }
 
+const MAX_KIRO_IMAGES = 4
+const MAX_KIRO_IMAGE_BYTES = 3_750_000
+
 interface KiroImage {
   format: string
   source: {
-    bytes: string
+    bytes: Uint8Array
   }
+}
+
+/** Decode base64 to a plain Uint8Array (NOT Buffer) to avoid Buffer.toJSON() trap. */
+function base64ToUint8Array(b64: string): Uint8Array {
+  const bin = atob(b64)
+  const arr = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i)
+  return arr
 }
 
 function extractImagesFromAnthropicFormat(content: any[]): UnifiedImage[] {
@@ -59,17 +70,29 @@ export function extractAllImages(content: any): UnifiedImage[] {
   return [...extractImagesFromAnthropicFormat(content), ...extractImagesFromOpenAI(content)]
 }
 
-export function convertImagesToKiroFormat(images: UnifiedImage[]): KiroImage[] {
-  return images.map((img) => {
-    const format = img.mediaType.split('/')[1] || 'png'
+interface ImageConversionResult {
+  images: KiroImage[]
+  omitted: number
+}
 
-    return {
-      format,
-      source: {
-        bytes: img.data
-      }
-    }
-  })
+export function convertImagesToKiroFormat(images: UnifiedImage[]): ImageConversionResult {
+  const selected: UnifiedImage[] = []
+  let totalBase64Chars = 0
+
+  for (const img of images) {
+    if (selected.length >= MAX_KIRO_IMAGES) break
+    if (totalBase64Chars + img.data.length > MAX_KIRO_IMAGE_BYTES) break
+    selected.push(img)
+    totalBase64Chars += img.data.length
+  }
+
+  return {
+    images: selected.map((img) => {
+      const format = img.mediaType.split('/')[1] || 'png'
+      return { format, source: { bytes: base64ToUint8Array(img.data) } }
+    }),
+    omitted: images.length - selected.length
+  }
 }
 
 export function extractTextFromParts(parts: any[]): string {

--- a/src/plugin/logger.ts
+++ b/src/plugin/logger.ts
@@ -1,6 +1,12 @@
+import { Buffer } from 'node:buffer'
 import { appendFileSync, mkdirSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
+
+const binaryToBase64Replacer = (_key: string, value: unknown): unknown => {
+  if (value instanceof Uint8Array) return Buffer.from(value).toString('base64')
+  return value
+}
 
 const getLogDir = () => {
   const platform = process.platform
@@ -48,7 +54,7 @@ const writeApiLog = (
     const prefix = isError ? 'error_' : ''
     const filename = `${prefix}${timestamp}_${type}.json`
     const path = join(dir, filename)
-    const content = JSON.stringify(data, null, 2)
+    const content = JSON.stringify(data, binaryToBase64Replacer, 2)
     writeFileSync(path, content)
   } catch (e) {}
 }

--- a/src/plugin/request.ts
+++ b/src/plugin/request.ts
@@ -136,7 +136,11 @@ export function transformToCodeWhisperer(
 
       const unifiedImages = extractAllImages(curMsg.content)
       if (unifiedImages.length > 0) {
-        curImgs.push(...convertImagesToKiroFormat(unifiedImages))
+        const { images, omitted } = convertImagesToKiroFormat(unifiedImages)
+        curImgs.push(...images)
+        if (omitted > 0) {
+          curContent += `\n\n[${omitted} image(s) omitted due to API limits]`
+        }
       }
     } else curContent = getContentText(curMsg)
     if (!curContent) curContent = curTrs.length ? 'Tool results provided.' : 'Continue'

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -54,7 +54,7 @@ export interface CodeWhispererMessage {
     content: string
     modelId: string
     origin: string
-    images?: Array<{ format: string; source: { bytes: string } }>
+    images?: Array<{ format: string; source: { bytes: Uint8Array } }>
     userInputMessageContext?: {
       toolResults?: Array<{
         toolUseId: string


### PR DESCRIPTION
## Problem

Kiro API returns `400 ValidationException: Improperly formed request` when images are included in requests. Two root causes:

1. **Buffer.toJSON() serialization trap**: `Buffer.from(base64, 'base64')` produces a `Buffer` instance whose `.toJSON()` outputs `{"type":"Buffer","data":[137,80,...]}`. When the AWS SDK serializes this, the wire format becomes an object instead of a base64 string, causing the API to reject it. A single ~1MB image inflates to ~600MB+ of JSON.

2. **No image count/size limits**: Confluence pages can return 33+ images at once. Even with correct serialization, sending too many images triggers Kiro API validation errors.

## Solution

### Commit 1: `image-handler.ts` + `types.ts`
- Replace `Buffer.from(base64, 'base64')` with plain `Uint8Array` via `atob` + `charCodeAt` — avoids the `Buffer.toJSON()` trap entirely
- Cap images at **4 per request** and **3.75MB total** base64 to stay within Kiro API limits
- Return `{ images, omitted }` from `convertImagesToKiroFormat` so callers can notify about dropped images
- Update `types.ts` bytes field from `string` to `Uint8Array`

### Commit 2: `request.ts` + `history-builder.ts` + `logger.ts`
- Consume `ImageConversionResult` in both request builders
- Append `[N image(s) omitted due to API limits]` text when images are capped
- Add `binaryToBase64Replacer` to logger to prevent `Uint8Array` object explosion in log files

## Verification

- `bun run typecheck` ✅
- `bun run build` ✅
- `bun test` ✅ (11 pass)
- Tested with Confluence page (content_id=241043246, 33 images) — 4 images sent successfully, 200 OK