### PR TITLE
fix: complete OAuth callback flow and add single-flight reauth guard

### DIFF
--- a/src/core/request/request-handler.ts
+++ b/src/core/request/request-handler.ts
@@ -18,6 +18,7 @@ import { RetryStrategy } from './retry-strategy'
 type ToastFunction = (message: string, variant: 'info' | 'warning' | 'success' | 'error') => void
 
 const KIRO_API_PATTERN = /^(https?:\/\/)?q\.[a-z0-9-]+\.amazonaws\.com/
+const REAUTH_FAILURE_COOLDOWN_MS = 60000
 
 export class RequestHandler {
   private accountSelector: AccountSelector
@@ -26,6 +27,8 @@ export class RequestHandler {
   private responseHandler: ResponseHandler
   private usageTracker: UsageTracker
   private retryStrategy: RetryStrategy
+  private reauthInFlight: Promise<boolean> | null = null
+  private lastFailedReauthAt = 0
 
   constructor(
     private accountManager: AccountManager,
@@ -277,25 +280,66 @@ export class RequestHandler {
 
   private async triggerReauth(showToast: ToastFunction): Promise<boolean> {
     if (!this.client) return false
+
+    const cooldownRemaining = REAUTH_FAILURE_COOLDOWN_MS - (Date.now() - this.lastFailedReauthAt)
+    if (cooldownRemaining > 0) {
+      showToast(
+        'Recent re-authentication failed. Please complete authentication manually.',
+        'error'
+      )
+      return false
+    }
+
+    if (this.reauthInFlight) {
+      return this.reauthInFlight
+    }
+
+    this.reauthInFlight = this.performReauth(showToast)
+    const success = await this.reauthInFlight.finally(() => {
+      this.reauthInFlight = null
+    })
+    if (!success) this.lastFailedReauthAt = Date.now()
+    return success
+  }
+
+  private async performReauth(showToast: ToastFunction): Promise<boolean> {
     try {
       showToast('Session expired. Re-authenticating...', 'warning')
       await this.client.provider.oauth.authorize({
         path: { id: 'kiro' },
         body: { method: 0 }
       })
-      // Sync fresh tokens from CLI after re-auth
-      await syncFromKiroCli()
+
+      await this.client.provider.oauth.callback({
+        path: { id: 'kiro' },
+        body: { method: 0 }
+      })
+
       this.repository.invalidateCache()
       const accounts = await this.repository.findAll()
       for (const acc of accounts) {
         this.accountManager.addAccount(acc)
       }
+
+      if (!this.hasUsableAccount(accounts)) {
+        logger.warn('Re-auth completed but no usable Kiro account was found')
+        showToast('Re-authentication completed but no usable Kiro account was found.', 'error')
+        return false
+      }
+
       showToast('Re-authentication successful.', 'success')
       return true
     } catch (e) {
       logger.error('Re-auth failed', e instanceof Error ? e : new Error(String(e)))
       return false
     }
+  }
+
+  private hasUsableAccount(accounts: ManagedAccount[]): boolean {
+    const now = Date.now()
+    return accounts.some(
+      (acc) => acc.isHealthy && acc.expiresAt > now && !isPermanentError(acc.unhealthyReason)
+    )
   }
 
   private allAccountsPermanentlyUnhealthy(): boolean {


### PR DESCRIPTION
## Problem

PR #70 introduced auto re-authentication when all accounts become permanently unhealthy, but it only called `client.provider.oauth.authorize()` without the subsequent `callback()`. This caused:

1. **Browser opens but tokens are never saved** — `authorize()` starts the device-code flow and opens the browser, but without `callback()` the plugin never polls for the completed auth and never saves the new account.
2. **Browser storm** — Without concurrency control, every concurrent Kiro request that hits the permanently-unhealthy state triggers a separate `authorize()` call, opening dozens of browser tabs simultaneously.
3. **Stale token re-import** — After `authorize()`, `syncFromKiroCli()` was called, which re-imports tokens from the Kiro CLI SQLite DB. These are often the same expired/invalid tokens that caused the permanent failure in the first place.

## Changes

Single file change: `src/core/request/request-handler.ts`

- **Add `callback()` after `authorize()`** — Completes the OAuth device-code polling flow so tokens are actually saved to the plugin repository
- **Single-flight guard (`reauthInFlight`)** — All concurrent requests await the same reauth promise instead of each opening a new browser
- **60s failure cooldown** — After a failed reauth attempt, subsequent requests get an immediate error instead of re-opening the browser
- **`hasUsableAccount()` verification** — After reauth completes, verify that at least one healthy, unexpired account exists before declaring success
- **Remove `syncFromKiroCli()` from OAuth path** — Plugin OAuth saves accounts directly to the repository; CLI sync would re-import stale tokens

## Testing

Verified locally: when all accounts become permanently unhealthy, a single browser tab opens for authentication. After completing auth, the callback polls for the token, saves the account, and requests resume automatically. No browser storms.

Fixes #70's incomplete OAuth flow. Related: #43