### PR TITLE
Harden Kiro rate-limit and auth retry handling

### DIFF
--- a/src/__tests__/account-health.test.ts
+++ b/src/__tests__/account-health.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'bun:test'
+import { AccountManager } from '../plugin/accounts.js'
+import { isPermanentError } from '../plugin/health.js'
+import { mergeAccounts } from '../plugin/storage/locked-operations.js'
+import type { ManagedAccount } from '../plugin/types.js'
+
+function account(overrides: Partial<ManagedAccount> = {}): ManagedAccount {
+  return {
+    id: overrides.id || 'acct-1',
+    email: overrides.email || 'user@example.com',
+    authMethod: 'idc',
+    region: 'us-east-1',
+    refreshToken: 'refresh',
+    accessToken: 'access',
+    expiresAt: Date.now() + 60000,
+    rateLimitResetTime: 0,
+    isHealthy: true,
+    failCount: 0,
+    ...overrides
+  }
+}
+
+describe('Kiro account health gating', () => {
+  test('classifies bad credentials and invalid bearer tokens as permanent auth failures', () => {
+    expect(isPermanentError('Refresh failed: Bad credentials')).toBe(true)
+    expect(isPermanentError('The bearer token included in the request is invalid.')).toBe(true)
+    expect(isPermanentError('HTTP_401')).toBe(true)
+    expect(isPermanentError('HTTP_403')).toBe(true)
+  })
+
+  test('does not revive or select accounts carrying permanent auth failure reasons', () => {
+    const manager = new AccountManager(
+      [
+        account({
+          id: 'bad',
+          unhealthyReason: 'Refresh failed: Bad credentials',
+          failCount: 242
+        }),
+        account({
+          id: 'good',
+          email: 'good@example.com',
+          usedCount: 10
+        })
+      ],
+      'lowest-usage'
+    )
+
+    expect(manager.getCurrentOrNext()?.id).toBe('good')
+  })
+
+  test('keeps temporary unhealthy accounts recoverable after recovery time', () => {
+    const manager = new AccountManager(
+      [
+        account({
+          id: 'temporary',
+          isHealthy: false,
+          unhealthyReason: 'Server Error (500)',
+          failCount: 1,
+          recoveryTime: Date.now() - 1
+        })
+      ],
+      'sticky'
+    )
+
+    expect(manager.getCurrentOrNext()?.id).toBe('temporary')
+  })
+
+  test('preserves permanent auth quarantine when Kiro CLI sync re-imports an account', () => {
+    const existing = account({
+      id: 'bad',
+      isHealthy: false,
+      unhealthyReason: 'The bearer token included in the request is invalid.',
+      failCount: 11,
+      usedCount: 1783
+    })
+    const incoming = account({
+      id: 'bad',
+      isHealthy: true,
+      unhealthyReason: undefined,
+      failCount: 0,
+      usedCount: 1784
+    })
+
+    const [merged] = mergeAccounts([existing], [incoming])
+
+    expect(merged).toBeDefined()
+    if (!merged) throw new Error('Expected merged account')
+    expect(merged.isHealthy).toBe(false)
+    expect(merged.unhealthyReason).toBe('The bearer token included in the request is invalid.')
+    expect(merged.failCount).toBe(10)
+    expect(merged.usedCount).toBe(1784)
+  })
+})

--- a/src/__tests__/request-handler.test.ts
+++ b/src/__tests__/request-handler.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'bun:test'
+import { RequestHandler } from '../core/request/request-handler.js'
+import { AccountManager } from '../plugin/accounts.js'
+import { DEFAULT_CONFIG } from '../plugin/config/schema.js'
+import type { ManagedAccount } from '../plugin/types.js'
+
+function account(overrides: Partial<ManagedAccount> = {}): ManagedAccount {
+  return {
+    id: overrides.id || 'acct-1',
+    email: overrides.email || 'user@example.com',
+    authMethod: 'idc',
+    region: 'us-east-1',
+    refreshToken: 'refresh',
+    accessToken: 'access',
+    expiresAt: Date.now() + 60000,
+    rateLimitResetTime: 0,
+    isHealthy: true,
+    failCount: 0,
+    ...overrides
+  }
+}
+
+const repository = {
+  save: async () => undefined,
+  batchSave: async () => undefined,
+  invalidateCache: () => undefined,
+  findAll: async () => []
+}
+
+const toast = () => undefined
+
+describe('RequestHandler account loop guards', () => {
+  test('fails fast when all accounts need reauthentication', async () => {
+    const manager = new AccountManager([
+      account({
+        unhealthyReason: 'Refresh failed: Bad credentials',
+        failCount: 242
+      })
+    ])
+    const handler = new RequestHandler(manager, DEFAULT_CONFIG, repository as any)
+
+    await expect(
+      handler.handle(
+        'https://q.us-east-1.amazonaws.com/models/claude-haiku-4-5/invoke',
+        { body: JSON.stringify({ messages: [] }) },
+        toast
+      )
+    ).rejects.toThrow('All Kiro accounts need re-authentication.')
+  })
+
+  test('fails fast when all accounts are rate-limited', async () => {
+    const manager = new AccountManager([
+      account({
+        rateLimitResetTime: Date.now() + 60000
+      })
+    ])
+    const handler = new RequestHandler(manager, DEFAULT_CONFIG, repository as any)
+
+    await expect(
+      handler.handle(
+        'https://q.us-east-1.amazonaws.com/models/claude-haiku-4-5/invoke',
+        { body: JSON.stringify({ messages: [] }) },
+        toast
+      )
+    ).rejects.toThrow('All Kiro accounts are rate-limited.')
+  })
+})

--- a/src/__tests__/retry-strategy.test.ts
+++ b/src/__tests__/retry-strategy.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test'
+import { RetryStrategy } from '../core/request/retry-strategy.js'
+
+describe('RetryStrategy', () => {
+  test('stops after max_request_iterations', () => {
+    const strategy = new RetryStrategy({
+      max_request_iterations: 2,
+      request_timeout_ms: 60000
+    })
+    const context = strategy.createContext()
+
+    expect(strategy.shouldContinue(context)).toEqual({ canContinue: true })
+    expect(strategy.shouldContinue(context)).toEqual({ canContinue: true })
+    expect(strategy.shouldContinue(context)).toEqual({
+      canContinue: false,
+      error: 'Exceeded max iterations (2)'
+    })
+  })
+
+  test('stops on request_timeout_ms', () => {
+    const strategy = new RetryStrategy({
+      max_request_iterations: 20,
+      request_timeout_ms: 1
+    })
+    const context = strategy.createContext()
+    context.startTime = Date.now() - 1000
+
+    expect(strategy.shouldContinue(context)).toEqual({
+      canContinue: false,
+      error: 'Request timeout'
+    })
+  })
+})

--- a/src/core/account/account-selector.ts
+++ b/src/core/account/account-selector.ts
@@ -36,18 +36,15 @@ export class AccountSelector {
       throw new Error('No accounts')
     }
 
-    let acc = this.accountManager.getCurrentOrNext()
+    const acc = this.accountManager.getCurrentOrNext()
 
     if (!acc) {
-      this.circuitBreakerTrips++
       const wait = this.accountManager.getMinWaitTime()
-      if (wait > 0 && wait < 30000) {
-        if (this.accountManager.shouldShowToast()) {
-          showToast(`All accounts rate-limited. Waiting ${Math.ceil(wait / 1000)}s...`, 'warning')
-        }
-        await this.sleep(wait)
-        return null
+      if (wait > 0) {
+        this.resetCircuitBreaker()
+        throw new Error(`All accounts rate-limited. Retry after ${Math.ceil(wait / 1000)}s`)
       }
+      this.circuitBreakerTrips++
       throw new Error('All accounts are unhealthy or rate-limited: reauth required')
     }
 
@@ -95,9 +92,5 @@ export class AccountSelector {
       this.circuitBreakerTrips = 0
       this.lastCircuitBreakerReset = Date.now()
     }
-  }
-
-  private sleep(ms: number): Promise<void> {
-    return new Promise((r) => setTimeout(r, ms))
   }
 }

--- a/src/core/auth/token-refresher.ts
+++ b/src/core/auth/token-refresher.ts
@@ -70,6 +70,16 @@ export class TokenRefresher {
       return { account: stillAcc, shouldContinue: true }
     }
 
+    if (error instanceof KiroTokenRefreshError && error.code === 'HTTP_429') {
+      this.accountManager.markRateLimited(account, 60000)
+      await this.repository.batchSave(this.accountManager.getAccounts())
+      if (this.accountManager.getUsableAccountCount() === 0) {
+        throw new Error('All Kiro accounts are rate-limited. Retry after 60s.')
+      }
+      showToast('Token refresh rate-limited. Switching account.', 'warning')
+      return { account, shouldContinue: true }
+    }
+
     if (
       error instanceof KiroTokenRefreshError &&
       (error.code === 'ExpiredTokenException' ||

--- a/src/core/request/error-handler.ts
+++ b/src/core/request/error-handler.ts
@@ -84,13 +84,15 @@ export class ErrorHandler {
       const w = parseInt(response.headers.get('retry-after') || '60') * 1000
       this.accountManager.markRateLimited(account, w)
       await this.repository.batchSave(this.accountManager.getAccounts())
-      const count = this.accountManager.getAccountCount()
-      if (count > 1) {
+      const usableCount = this.accountManager.getUsableAccountCount()
+      if (usableCount > 0) {
+        showToast(
+          `429: ${account.email || 'account'} rate-limited. Switching account...`,
+          'warning'
+        )
         return { shouldRetry: true, switchAccount: true }
       }
-      showToast(`429: Rate limited. Waiting ${Math.ceil(w / 1000)}s...`, 'warning')
-      await this.sleep(w)
-      return { shouldRetry: true }
+      throw new Error(`All Kiro accounts are rate-limited. Retry after ${Math.ceil(w / 1000)}s.`)
     }
 
     if (response.status === 402 || response.status === 403) {

--- a/src/core/request/request-handler.ts
+++ b/src/core/request/request-handler.ts
@@ -69,6 +69,11 @@ export class RequestHandler {
     const retryContext = this.retryStrategy.createContext()
 
     while (true) {
+      const accountBlocker = this.getAccountBlocker()
+      if (accountBlocker) {
+        throw new Error(accountBlocker)
+      }
+
       const check = this.retryStrategy.shouldContinue(retryContext)
       if (!check.canContinue) {
         throw new Error(check.error)
@@ -93,6 +98,15 @@ export class RequestHandler {
       })
       if (!acc) {
         consecutiveNullAccounts++
+        if (consecutiveNullAccounts >= Math.min(3, this.config.max_request_iterations)) {
+          const wait = this.accountManager.getMinWaitTime()
+          if (wait > 0) {
+            throw new Error(
+              `All Kiro accounts are rate-limited. Retry after ${Math.ceil(wait / 1000)}s.`
+            )
+          }
+          throw new Error('No usable Kiro account available. Please re-authenticate.')
+        }
         const backoffDelay = Math.min(1000 * Math.pow(2, consecutiveNullAccounts - 1), 10000)
         await this.sleep(backoffDelay)
         continue
@@ -348,6 +362,32 @@ export class RequestHandler {
     return accounts.some(
       (acc) => acc.isHealthy && acc.expiresAt > now && !isPermanentError(acc.unhealthyReason)
     )
+  }
+
+  private getAccountBlocker(): string | null {
+    const accounts = this.accountManager.getAccounts()
+    if (accounts.length === 0) return null
+
+    const allPermanent = accounts.every((acc) => isPermanentError(acc.unhealthyReason))
+    if (allPermanent) {
+      return 'All Kiro accounts need re-authentication.'
+    }
+
+    const now = Date.now()
+    const usable = accounts.some(
+      (acc) =>
+        acc.isHealthy &&
+        !isPermanentError(acc.unhealthyReason) &&
+        !(acc.rateLimitResetTime && now < acc.rateLimitResetTime)
+    )
+    if (usable) return null
+
+    const wait = this.accountManager.getMinWaitTime()
+    if (wait > 0) {
+      return `All Kiro accounts are rate-limited. Retry after ${Math.ceil(wait / 1000)}s.`
+    }
+
+    return null
   }
 
   private allAccountsPermanentlyUnhealthy(): boolean {

--- a/src/plugin/accounts.ts
+++ b/src/plugin/accounts.ts
@@ -77,16 +77,26 @@ export class AccountManager {
   }
   getMinWaitTime(): number {
     const now = Date.now()
-    const waits = this.accounts.map((a) => (a.rateLimitResetTime || 0) - now).filter((t) => t > 0)
+    const waits = this.accounts
+      .filter((a) => !isPermanentError(a.unhealthyReason))
+      .map((a) => (a.rateLimitResetTime || 0) - now)
+      .filter((t) => t > 0)
     return waits.length > 0 ? Math.min(...waits) : 0
+  }
+  getUsableAccountCount(): number {
+    const now = Date.now()
+    return this.accounts.filter(
+      (a) =>
+        a.isHealthy &&
+        !isPermanentError(a.unhealthyReason) &&
+        !(a.rateLimitResetTime && now < a.rateLimitResetTime)
+    ).length
   }
   getCurrentOrNext(): ManagedAccount | null {
     const now = Date.now()
     const available = this.accounts.filter((a) => {
+      if (isPermanentError(a.unhealthyReason)) return false
       if (!a.isHealthy) {
-        if (isPermanentError(a.unhealthyReason)) {
-          return false
-        }
         if (a.failCount < 10 && a.recoveryTime && now >= a.recoveryTime) {
           a.isHealthy = true
           delete a.unhealthyReason
@@ -112,7 +122,13 @@ export class AccountManager {
     }
     if (!selected) {
       const fallback = this.accounts
-        .filter((a) => !a.isHealthy && a.failCount < 10 && !isPermanentError(a.unhealthyReason))
+        .filter(
+          (a) =>
+            !a.isHealthy &&
+            a.failCount < 10 &&
+            a.unhealthyReason &&
+            !isPermanentError(a.unhealthyReason)
+        )
         .sort(
           (a, b) => (a.usedCount || 0) - (b.usedCount || 0) || (a.lastUsed || 0) - (b.lastUsed || 0)
         )[0]

--- a/src/plugin/health.ts
+++ b/src/plugin/health.ts
@@ -1,14 +1,17 @@
 export function isPermanentError(reason?: string): boolean {
   if (!reason) return false
+  const normalized = reason.toLowerCase()
   return (
-    reason.includes('Invalid refresh token') ||
-    reason.includes('Invalid grant provided') ||
-    reason.includes('invalid_grant') ||
-    reason.includes('ExpiredTokenException') ||
-    reason.includes('InvalidTokenException') ||
-    reason.includes('ExpiredClientException') ||
-    reason.includes('Client is expired') ||
-    reason.includes('HTTP_401') ||
-    reason.includes('HTTP_403')
+    normalized.includes('invalid refresh token') ||
+    normalized.includes('invalid grant provided') ||
+    normalized.includes('invalid_grant') ||
+    normalized.includes('expiredtokenexception') ||
+    normalized.includes('invalidtokenexception') ||
+    normalized.includes('expiredclientexception') ||
+    normalized.includes('client is expired') ||
+    normalized.includes('bad credentials') ||
+    normalized.includes('bearer token included in the request is invalid') ||
+    normalized.includes('http_401') ||
+    normalized.includes('http_403')
   )
 }

--- a/src/plugin/storage/locked-operations.ts
+++ b/src/plugin/storage/locked-operations.ts
@@ -65,6 +65,11 @@ export function mergeAccounts(
     if (existingAcc) {
       const hasPermanentError =
         isPermanentError(existingAcc.unhealthyReason) || isPermanentError(acc.unhealthyReason)
+      const permanentReason = isPermanentError(existingAcc.unhealthyReason)
+        ? existingAcc.unhealthyReason
+        : isPermanentError(acc.unhealthyReason)
+          ? acc.unhealthyReason
+          : undefined
 
       accountMap.set(acc.id, {
         ...existingAcc,
@@ -77,7 +82,13 @@ export function mergeAccounts(
           acc.rateLimitResetTime || 0
         ),
         isHealthy: hasPermanentError ? false : existingAcc.isHealthy || acc.isHealthy,
-        failCount: Math.max(existingAcc.failCount || 0, acc.failCount || 0),
+        unhealthyReason: permanentReason || acc.unhealthyReason || existingAcc.unhealthyReason,
+        recoveryTime: hasPermanentError
+          ? undefined
+          : Math.max(existingAcc.recoveryTime || 0, acc.recoveryTime || 0) || undefined,
+        failCount: hasPermanentError
+          ? 10
+          : Math.max(existingAcc.failCount || 0, acc.failCount || 0),
         lastSync: Math.max(existingAcc.lastSync || 0, acc.lastSync || 0)
       })
     } else {


### PR DESCRIPTION
Summary:
- Harden Kiro account health handling for permanent auth failures.
- Quarantine 429-limited accounts and switch to another usable account.
- Fail fast when all Kiro accounts are rate-limited instead of looping to max iterations.
- Preserve permanent auth quarantine across Kiro CLI sync.

Risk notes:
- Scope is limited to Kiro auth request retry, token refresh, account selection, health merge logic, and focused tests.
- This PR intentionally excludes account-manager CLI and TUI work.

Verification:
- npm run typecheck
- bun test
- npm run build
- Real global OpenCode smoke before split: OK-RATEFIX-A and OK-RATEFIX-B exited 0.