### PR TITLE
fix: restore compatibility with OpenCode ≥1.15 and update models

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ Add the plugin to your `opencode.json` or `opencode.jsonc`:
         },
         "claude-sonnet-4-6": {
           "name": "Claude Sonnet 4.6",
-          "limit": { "context": 200000, "output": 64000 },
+          "limit": { "context": 1000000, "output": 64000 },
           "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
         },
         "claude-sonnet-4-6-thinking": {
           "name": "Claude Sonnet 4.6 Thinking",
-          "limit": { "context": 200000, "output": 64000 },
+          "limit": { "context": 1000000, "output": 64000 },
           "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
           "variants": {
             "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
@@ -86,12 +86,12 @@ Add the plugin to your `opencode.json` or `opencode.jsonc`:
         },
         "claude-opus-4-6": {
           "name": "Claude Opus 4.6",
-          "limit": { "context": 200000, "output": 64000 },
+          "limit": { "context": 1000000, "output": 64000 },
           "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
         },
         "claude-opus-4-6-thinking": {
           "name": "Claude Opus 4.6 Thinking",
-          "limit": { "context": 200000, "output": 64000 },
+          "limit": { "context": 1000000, "output": 64000 },
           "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
           "variants": {
             "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
@@ -150,12 +150,27 @@ Add the plugin to your `opencode.json` or `opencode.jsonc`:
           }
         },
         "auto": { "name": "Auto (1.0x)" },
-        "claude-sonnet-4": { "name": "Claude Sonnet 4.0 (1.3x)", "limit": { "context": 200000, "output": 64000 } },
-        "deepseek-3.2": { "name": "DeepSeek 3.2 (0.25x)", "limit": { "context": 128000, "output": 64000 } },
+        "claude-sonnet-4": {
+          "name": "Claude Sonnet 4.0 (1.3x)",
+          "limit": { "context": 200000, "output": 64000 }
+        },
+        "deepseek-3.2": {
+          "name": "DeepSeek 3.2 (0.25x)",
+          "limit": { "context": 128000, "output": 64000 }
+        },
         "glm-5": { "name": "GLM-5 (0.5x)", "limit": { "context": 200000, "output": 64000 } },
-        "minimax-m2.5": { "name": "MiniMax 2.5 (0.25x)", "limit": { "context": 200000, "output": 64000 } },
-        "minimax-m2.1": { "name": "MiniMax 2.1 (0.15x)", "limit": { "context": 200000, "output": 64000 } },
-        "qwen3-coder-next": { "name": "Qwen3 Coder Next (0.05x)", "limit": { "context": 256000, "output": 64000 } }
+        "minimax-m2.5": {
+          "name": "MiniMax 2.5 (0.25x)",
+          "limit": { "context": 200000, "output": 64000 }
+        },
+        "minimax-m2.1": {
+          "name": "MiniMax 2.1 (0.15x)",
+          "limit": { "context": 200000, "output": 64000 }
+        },
+        "qwen3-coder-next": {
+          "name": "Qwen3 Coder Next (0.05x)",
+          "limit": { "context": 256000, "output": 64000 }
+        }
       }
     }
   }
@@ -166,7 +181,9 @@ Add the plugin to your `opencode.json` or `opencode.jsonc`:
 
 1. **Authentication via Kiro CLI (Recommended)**:
    - Perform login directly in your terminal using `kiro-cli login`.
-   - The plugin will automatically detect and import your session on startup.
+   - The plugin automatically bootstraps a minimal `kiro` placeholder in
+     OpenCode's `auth.json` when it detects the Kiro CLI database, then imports
+     and synchronizes your active session on startup.
    - For AWS IAM Identity Center (SSO/IDC), the plugin imports both the token and device
      registration (OIDC client credentials) from the `kiro-cli` database.
 2. **Direct Authentication**:
@@ -242,32 +259,23 @@ Note for IDC/SSO (ODIC): the plugin may temporarily create an account with a pla
 email if it cannot fetch the real email during sync (e.g. offline).
 It will replace it with the real email once usage/email lookup succeeds.
 
-### Kiro CLI (Google/GitHub OAuth) users: plugin sync never runs
+### Kiro CLI (Google/GitHub OAuth) users: plugin sync does not start
 
 If you authenticated via `kiro-cli login` using Google or GitHub OAuth (not AWS Builder
-ID or IAM Identity Center), the plugin's sync may never trigger.
-This happens because OpenCode requires a kiro entry in `auth.json` before making API
-requests, but the plugin loader only runs when a request is made.
+ID or IAM Identity Center), OpenCode still needs a stored `kiro` auth entry before it
+will call the plugin loader.
 
-**Workaround:** Add a minimal placeholder entry to `~/.local/share/opencode/auth.json`:
+The plugin now creates that minimal placeholder automatically when it detects the local
+Kiro CLI database. Restart OpenCode after `kiro-cli login`; the loader should then run
+and sync your actual tokens into `kiro.db`. The placeholder values are not used for API
+calls.
 
-```json
-{
-  "kiro": {
-    "type": "api",
-    "key": "placeholder"
-  }
-}
-```
-
-After adding this, OpenCode will treat the provider as connected, trigger the plugin
-loader, and the kiro-cli sync will populate `kiro.db` with your actual tokens.
-The placeholder values are not used for API calls.
+If bootstrap is skipped because `auth.json` is malformed, fix the JSON first. The plugin
+will not overwrite malformed auth files because they may contain other provider
+credentials.
 
 **Important:** Ensure `auto_sync_kiro_cli` is `true` in `~/.config/opencode/kiro.json`
-and that `kiro-cli login` succeeds before applying this workaround.
-
-
+and that `kiro-cli login` succeeds.
 
 The plugin supports extensive configuration options.
 Edit `~/.config/opencode/kiro.json`:

--- a/README.md
+++ b/README.md
@@ -114,6 +114,21 @@ Add the plugin to your `opencode.json` or `opencode.jsonc`:
             "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
           }
         },
+        "claude-opus-4-7": {
+          "name": "Claude Opus 4.7",
+          "limit": { "context": 1000000, "output": 64000 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
+        },
+        "claude-opus-4-7-thinking": {
+          "name": "Claude Opus 4.7 Thinking",
+          "limit": { "context": 1000000, "output": 64000 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+          "variants": {
+            "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
+            "medium": { "thinkingConfig": { "thinkingBudget": 16384 } },
+            "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
+          }
+        },
         "claude-sonnet-4-5-1m": {
           "name": "Claude Sonnet 4.5 (1M Context)",
           "limit": { "context": 1000000, "output": 64000 },
@@ -137,6 +152,7 @@ Add the plugin to your `opencode.json` or `opencode.jsonc`:
         "auto": { "name": "Auto (1.0x)" },
         "claude-sonnet-4": { "name": "Claude Sonnet 4.0 (1.3x)", "limit": { "context": 200000, "output": 64000 } },
         "deepseek-3.2": { "name": "DeepSeek 3.2 (0.25x)", "limit": { "context": 128000, "output": 64000 } },
+        "glm-5": { "name": "GLM-5 (0.5x)", "limit": { "context": 200000, "output": 64000 } },
         "minimax-m2.5": { "name": "MiniMax 2.5 (0.25x)", "limit": { "context": 200000, "output": 64000 } },
         "minimax-m2.1": { "name": "MiniMax 2.1 (0.15x)", "limit": { "context": 200000, "output": 64000 } },
         "qwen3-coder-next": { "name": "Qwen3 Coder Next (0.05x)", "limit": { "context": 256000, "output": 64000 } }
@@ -177,30 +193,19 @@ Add the plugin to your `opencode.json` or `opencode.jsonc`:
 
 ## Local plugin development
 
-OpenCode installs plugins into a cache directory (typically
-`~/.cache/opencode/node_modules`).
+The simplest way to test local changes is to point OpenCode directly at your local repo
+path in `opencode.json` or `opencode.jsonc`:
 
-The simplest way to test local changes (without publishing to npm) is to build this repo
-and hot-swap the cached plugin `dist/` folder:
-
-1. Build this repo: `bun run build` (or `npm run build`)
-2. Hot-swap `dist/` (creates a timestamped backup):
-
-```bash
-PLUGIN_DIR="$HOME/.cache/opencode/node_modules/@zhafron/opencode-kiro-auth"
-TS=$(date +%Y%m%d-%H%M%S)
-cp -a "$PLUGIN_DIR/dist" "$PLUGIN_DIR/dist.bak.$TS"
-rm -rf "$PLUGIN_DIR/dist"
-cp -a "/absolute/path/to/opencode-kiro-auth/dist" "$PLUGIN_DIR/dist"
-echo "Backup at: $PLUGIN_DIR/dist.bak.$TS"
+```json
+{
+  "plugin": ["/path/to/opencode-kiro-auth"]
+}
 ```
 
-Revert:
+Then build and restart OpenCode to pick up changes:
 
 ```bash
-PLUGIN_DIR="$HOME/.cache/opencode/node_modules/@zhafron/opencode-kiro-auth"
-rm -rf "$PLUGIN_DIR/dist"
-mv "$PLUGIN_DIR/dist.bak.YYYYMMDD-HHMMSS" "$PLUGIN_DIR/dist"
+npm run build
 ```
 
 ## Troubleshooting
@@ -262,23 +267,7 @@ The placeholder values are not used for API calls.
 **Important:** Ensure `auto_sync_kiro_cli` is `true` in `~/.config/opencode/kiro.json`
 and that `kiro-cli login` succeeds before applying this workaround.
 
-### Error: ERR_INVALID_URL
 
-`TypeError [ERR_INVALID_URL]: "undefined/chat/completions" cannot be parsed as a URL`
-
-If this happens, check your auth.json in .local/share/opencode.
-example:
-
-```json
-{
-  "kiro": {
-    "type": "api",
-    "key": "whatever"
-  }
-}
-```
-
-## Configuration
 
 The plugin supports extensive configuration options.
 Edit `~/.config/opencode/kiro.json`:

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,8 @@
     "": {
       "name": "@zhafron/opencode-kiro-auth",
       "dependencies": {
-        "@opencode-ai/plugin": "^1.2.6",
+        "@aws/codewhisperer-streaming-client": "^1.0.34",
+        "@opencode-ai/plugin": "^1.15.11",
         "proper-lockfile": "^4.1.2",
         "zod": "^3.24.0",
       },
@@ -22,9 +23,131 @@
     },
   },
   "packages": {
-    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.2.6", "https://registry.npmmirror.com/@opencode-ai/plugin/-/plugin-1.2.6.tgz", { "dependencies": { "@opencode-ai/sdk": "1.2.6", "zod": "4.1.8" } }, "sha512-CJEp3k17yWsjyfivm3zQof8L42pdze3a7iTqMOyesHgJplSuLiBYAMndbBYMDuJkyAh0dHYjw8v10vVw7Kfl4Q=="],
+    "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],
 
-    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.2.6", "https://registry.npmmirror.com/@opencode-ai/sdk/-/sdk-1.2.6.tgz", {}, "sha512-dWMF8Aku4h7fh8sw5tQ2FtbqRLbIFT8FcsukpxTird49ax7oUXP+gzqxM/VdxHjfksQvzLBjLZyMdDStc5g7xA=="],
+    "@aws-crypto/sha256-browser": ["@aws-crypto/sha256-browser@5.2.0", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw=="],
+
+    "@aws-crypto/sha256-js": ["@aws-crypto/sha256-js@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA=="],
+
+    "@aws-crypto/supports-web-crypto": ["@aws-crypto/supports-web-crypto@5.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg=="],
+
+    "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.974.14", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@aws-sdk/xml-builder": "^3.972.26", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.3", "@smithy/signature-v4": "^5.4.2", "@smithy/types": "^4.14.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw=="],
+
+    "@aws-sdk/middleware-host-header": ["@aws-sdk/middleware-host-header@3.972.15", "", { "dependencies": { "@aws-sdk/core": "^3.974.14", "tslib": "^2.6.2" } }, "sha512-BMvPJcSE+e5Up4eRvIVDOp6Aiwh3ce0z9FJ8LsRBGE9d64j67HLdyqlDaUtzCjmhxDvxw+qIiAElu3+AOzhAnA=="],
+
+    "@aws-sdk/middleware-logger": ["@aws-sdk/middleware-logger@3.972.14", "", { "dependencies": { "@aws-sdk/core": "^3.974.14", "tslib": "^2.6.2" } }, "sha512-f/9Rln5bNIoHwPVxSXmW5+8SnteHFwwuoR5Ce+SEis36fKw7pu84G2SpaWRpGqj7zbIAECFVJ+pDiGfQq5r4FQ=="],
+
+    "@aws-sdk/middleware-recursion-detection": ["@aws-sdk/middleware-recursion-detection@3.972.16", "", { "dependencies": { "@aws-sdk/core": "^3.974.14", "tslib": "^2.6.2" } }, "sha512-AGAe/c6Da/FEjtkR3LViqvaJdxaHQqcVpmf6UMBRQ3e8G2c6EWqjRidMw/FiQzWXUrmfjgXoVcc8QXc4kcuWLQ=="],
+
+    "@aws-sdk/middleware-user-agent": ["@aws-sdk/middleware-user-agent@3.972.44", "", { "dependencies": { "@aws-sdk/core": "^3.974.14", "tslib": "^2.6.2" } }, "sha512-K9kryZwhKBsAdk1R6TCMSUDGF2XjMcC89Qm/6o8szdRSodN5MIlo3KzAV4vKyKTkOu/UwoB+Yrj78M+omPZzkA=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.12", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.14", "@aws-sdk/signature-v4-multi-region": "^3.996.29", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/fetch-http-handler": "^5.4.3", "@smithy/node-http-handler": "^4.7.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q=="],
+
+    "@aws-sdk/region-config-resolver": ["@aws-sdk/region-config-resolver@3.972.18", "", { "dependencies": { "@aws-sdk/core": "^3.974.14", "tslib": "^2.6.2" } }, "sha512-FQLLmG0RHPleDCQAkl10LNH5L+FDOcUKwnRHRhfH0NHhleo46j9u1q0UHlVbKYOBfB0LjQMQgioxrWvLqEZ5Bg=="],
+
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.29", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@smithy/signature-v4": "^5.4.2", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Few9FoQqOt/0KSvZYP+qdW0dfOhfQ9N+gl2UUDvCPW6mkPKHli9LMbKxWj+wZ5zKPaOoqxuR3Hhy3OTpndkfSw=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1055.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.14", "@aws-sdk/nested-clients": "^3.997.12", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-NSCniZ0HmeOWrX1k9aXZtKEST+JlNqOMNe87Vll1y25WlHOErNGgk8oFoMGnbiuWsG8ZS8zLby8fqVmrH8/ufQ=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
+
+    "@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.996.13", "", { "dependencies": { "@aws-sdk/core": "^3.974.14", "@smithy/core": "^3.24.3", "tslib": "^2.6.2" } }, "sha512-uuAuMkEzZHfiOkIRj2xexSSgfvBnhbI+6pd+o/RET7EZXDG1wrC4PINCs0PTkswYhD6kOb+av4NG89CWLC5/4Q=="],
+
+    "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.5", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ=="],
+
+    "@aws-sdk/util-user-agent-browser": ["@aws-sdk/util-user-agent-browser@3.972.15", "", { "dependencies": { "@aws-sdk/core": "^3.974.14", "tslib": "^2.6.2" } }, "sha512-8/+GtB/BjIul7uGFXNztIeiQBZbb1eEl/+M8Q+l1qg9uKSGEZf4VtI+9VidrQ3BBE1J1GDkn5W/n+tuHhXSbOg=="],
+
+    "@aws-sdk/util-user-agent-node": ["@aws-sdk/util-user-agent-node@3.973.30", "", { "dependencies": { "@aws-sdk/core": "^3.974.14", "tslib": "^2.6.2" } }, "sha512-W5Pr3Kl9tyH7Pcht2sx90YeO2ennDIwzbBVfQ+bt6MQUNMtf+hPMic8O/IsSWRNn1qTgfuCjTYmB/UD4A75xBA=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.26", "", { "dependencies": { "@smithy/types": "^4.14.2", "fast-xml-parser": "5.7.3", "tslib": "^2.6.2" } }, "sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g=="],
+
+    "@aws/codewhisperer-streaming-client": ["@aws/codewhisperer-streaming-client@1.0.45", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.7", "@aws-sdk/middleware-host-header": "^3.972.10", "@aws-sdk/middleware-logger": "^3.972.10", "@aws-sdk/middleware-recursion-detection": "^3.972.11", "@aws-sdk/middleware-user-agent": "^3.972.37", "@aws-sdk/region-config-resolver": "^3.972.13", "@aws-sdk/token-providers": "^3.1040.0", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-endpoints": "^3.996.8", "@aws-sdk/util-user-agent-browser": "^3.972.10", "@aws-sdk/util-user-agent-node": "^3.973.23", "@smithy/config-resolver": "^4.4.17", "@smithy/core": "^3.23.17", "@smithy/eventstream-serde-browser": "^4.2.14", "@smithy/eventstream-serde-config-resolver": "^4.3.14", "@smithy/eventstream-serde-node": "^4.2.14", "@smithy/fetch-http-handler": "^5.3.17", "@smithy/hash-node": "^4.2.14", "@smithy/invalid-dependency": "^4.2.14", "@smithy/middleware-content-length": "^4.2.14", "@smithy/middleware-endpoint": "^4.4.32", "@smithy/middleware-retry": "^4.5.7", "@smithy/middleware-serde": "^4.2.20", "@smithy/middleware-stack": "^4.2.14", "@smithy/node-config-provider": "^4.3.14", "@smithy/node-http-handler": "^4.6.1", "@smithy/protocol-http": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.49", "@smithy/util-defaults-mode-node": "^4.2.54", "@smithy/util-endpoints": "^3.4.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-retry": "^4.3.6", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-XvqUjgrA+hS8bK/dU9tUhooxlYWLbIYNYg461gMcD2QQHAd+fXwqrImgcJ/pvU6LedguvTal1Vdd9Pf4I0O0Jg=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.4", "", {}, "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm": ["@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4", "", { "os": "linux", "cpu": "arm" }, "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm64": ["@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
+
+    "@nodable/entities": ["@nodable/entities@2.1.0", "", {}, "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA=="],
+
+    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.15.11", "", { "dependencies": { "@opencode-ai/sdk": "1.15.11", "effect": "4.0.0-beta.66", "zod": "4.1.8" }, "peerDependencies": { "@opentui/core": ">=0.2.15", "@opentui/keymap": ">=0.2.15", "@opentui/solid": ">=0.2.15" }, "optionalPeers": ["@opentui/core", "@opentui/keymap", "@opentui/solid"] }, "sha512-RDvYDCHO0+3OAGD590oDQqtryrENrUW04SjtoA4sgRV2efpZeBFjx3TnonBsXKq6nWqYg172nhltUEZsihGnXQ=="],
+
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.15.11", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-IyYyDVsO8SKbKbkSadHpDuYnYC+2vmEeLU+rW+rH2M54Sigq6l3gDHno16+U6SRut+lowbph7v/ry3WbV67V3w=="],
+
+    "@smithy/config-resolver": ["@smithy/config-resolver@4.5.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-HehAZr4sq2m+4zHgEqDvtWENy/B5yywMKA8Pl4gBcU3F4ekelpZqDLDxQHdJlguaKNyTq31cZYjLWomzdujQrA=="],
+
+    "@smithy/core": ["@smithy/core@3.24.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA=="],
+
+    "@smithy/eventstream-serde-browser": ["@smithy/eventstream-serde-browser@4.3.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-M9rMkTar7JcRrvUHsK1271AuWDmrISIPQpQ4TSHmYZ4KMisGnMH0gfjCWnBwdndR7skvvp/UheHhZGvO3Cr8/g=="],
+
+    "@smithy/eventstream-serde-config-resolver": ["@smithy/eventstream-serde-config-resolver@4.4.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-lUwPPu7DNNVJjeS+gV7g2rDHbW9X1wSRQIsIyzOgBtP7KDMefLhz0kz42AWAxZIFPcOO3pUbtq76LSkVcxLKRw=="],
+
+    "@smithy/eventstream-serde-node": ["@smithy/eventstream-serde-node@4.3.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-QydEYKqvdiS6dJb0tOfDiogt12FzzImt2FnL7gMD72hNrkiUAUKqtStRmkTrdzDKFJ46abe3yH94luCuhtnCkQ=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.4.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-SK3VMeH0fibgdTg2QeB+O4p7Yy/2E5HBOHJeC58FshkDdeuX8lOgO7PfjYfLyPLP1ch55j91cQqKBzDS0mRjSQ=="],
+
+    "@smithy/hash-node": ["@smithy/hash-node@4.3.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-/tUIDaB36qjLq/CIhMRIiFXCT7rVGBGAhFmMA9PbC/iW2u3QPNATZuFSdK0JBO3qeSPoHBeudFMmsbFq2Mf5EQ=="],
+
+    "@smithy/invalid-dependency": ["@smithy/invalid-dependency@4.3.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-c8C1GzrU4PcY1QT/HP0ILCTLutyVONT93kPSisOyHoZaXlKQZtV6+RKqolhBtPolGULf59vq2yseagU6+WY82w=="],
+
+    "@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@smithy/middleware-content-length": ["@smithy/middleware-content-length@4.3.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-lzOzJ4c0t3vkBut02CjdWNgduN3mUWjc1WK9TPr75KVV6OgVWico9wMDn9ZnQN97VJPYfweBW6Dm5CElvQl8BQ=="],
+
+    "@smithy/middleware-endpoint": ["@smithy/middleware-endpoint@4.5.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-8DnkSoUMQAcuT/DHdigsFPti8M/Dm6TPCAsrIQ/bUDGxRkrgGuI++3dXRr8CoUyc9r0kGSCcZHjJje407ydgBQ=="],
+
+    "@smithy/middleware-retry": ["@smithy/middleware-retry@4.6.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-fumMIfh5xOFjirylbSzmBX9bgQtrWFtQrosPfkjsJSBzqXVbQMNDGIC8oJBz4V3bokIm2F0CL3bziLtbXR7cbA=="],
+
+    "@smithy/middleware-serde": ["@smithy/middleware-serde@4.3.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-+7glfRrb7byruZCPAM53TvmK8cx/ghzAThB4EvPzHynAYobtISl0g+DzzSVEC0NQob5BunP9gC9GP+Fcz6H9yw=="],
+
+    "@smithy/middleware-stack": ["@smithy/middleware-stack@4.3.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-Yj4wjBQZXHePRIy9cBIKfCOn/kPjRlgDPGlr7DjIhwrnz8kWu7Ux7UwPr51P/wcug5oq4nWdBXSY4TV5afBdew=="],
+
+    "@smithy/node-config-provider": ["@smithy/node-config-provider@4.4.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-c2G9QJ4xVZLwAkAf+WQESSSCkKbtt33ytje1klGvTcBn6cKuqV28E+62wbRPHwuTikkB3LQ7CBnNrayCoJur5A=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3dA9TQ+ybRSZ/m0wnbZhiBy4Dezjgq1Ib/ZZrYTpJDBgpoLLU/SDzZc/g0x0MNAdOJe1wPcM+x2PBRmoOur+Sw=="],
+
+    "@smithy/protocol-http": ["@smithy/protocol-http@5.4.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-jOD+4WNWQLntiLJn3r82C7BLheEbRCKTbU5U5bskZmT7nwRiGkh0IghuHwHRZ1ZEFXpHltQxxp9/koOPsdluJg=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.4.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-QBJKWGqIknH0dc9LWpfH1mkdokAx6iXYN3UcQ3eY6uIEyScuoQAhfl94ge7ozUy9WgFUdE8xsvwBjaYBbWmPNA=="],
+
+    "@smithy/smithy-client": ["@smithy/smithy-client@4.13.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-pg9QRQESz3m/5HgAW/z9lA3ln8MSsCWNWc82MX40Djlxpcj/+7DZQ0yIk7tGWYJCVZog/9LBdNl1uEVRAhqm5Q=="],
+
+    "@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
+    "@smithy/url-parser": ["@smithy/url-parser@4.3.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-f7kUYrRdLiAHz10WXQXiUkuBFaL2c2ZBD2kSwZyQBh73lWFTvXwdpS9l5irQ/uldk8YMJpm66BozmqCg/3uZvA=="],
+
+    "@smithy/util-base64": ["@smithy/util-base64@4.4.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-2J8l+DoX3IIiP75X5SYkJ3mIgOkxW29MxOs7oPjbXLuInQ7UL6zLw2IJHbQ44+eKDBBhTjvt+GgwsTTNBGt8zA=="],
+
+    "@smithy/util-body-length-browser": ["@smithy/util-body-length-browser@4.3.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-nQtYwXg4spM6uc0Luq3yck+WXZ1VPfrYkC2SqkQ+YOGks0qR2bKKlSCjidSqfpq+VAY/RJe1O5V+CtBmnT63KQ=="],
+
+    "@smithy/util-body-length-node": ["@smithy/util-body-length-node@4.3.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-BAsAed9yWExECwNIi61Le6D8ZTY71MFEFrf3d4L2+uzcbTjFAWxOtymkA1vCV8bNZQN9TGgZo4c68JDsnjNShA=="],
+
+    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@smithy/util-defaults-mode-browser": ["@smithy/util-defaults-mode-browser@4.4.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-LbE6AGHhQOunqIN5UyWDMgpPwmUHUzrV2NtUOQ+lt6Stpipzo6S7uDyeGtO0GGgUD1balEPCNu8Xfl1AQNiruQ=="],
+
+    "@smithy/util-defaults-mode-node": ["@smithy/util-defaults-mode-node@4.3.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-72gNpNDQ2iIGbaNmeaF9I58shWsEuD5tNI7my5uXlm1CSPH5i8IKI/nzU50qqB8y+kgw/qTLGgsf0We5qeM/aA=="],
+
+    "@smithy/util-endpoints": ["@smithy/util-endpoints@3.5.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-NJhe8KmNjeZ7V+gJsQR5xw0IN47N8pBKosed40xfhelDuYkg8VQ5CVGDcHTEuJq3e3zQb21vnoOOReQothejhA=="],
+
+    "@smithy/util-middleware": ["@smithy/util-middleware@4.3.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-N1IR4bMHIDbqO3GxkJHgqNGsnrd7MNrj+EVqhFqKeRqSBV5I3KCjNllKfnbF9KV0YteGhfLqcMR5CYsPLJqpqw=="],
+
+    "@smithy/util-retry": ["@smithy/util-retry@4.4.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-W9Ovy9i02yGqtLlpqZNQuXNxXc5OPfXujnembxN/FxyBtGjJd8vKY0PQYEJ8FNybTOcXG+ZxsSsX23HOb3zQzg=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@4.3.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-l1d7I7YP2LjXjAZDC7eXqkzuEB75KfCANwhNj/knmT6+0a9XG3QasvI8kEn8WAI3tx/q8PdmSuuXcM+MTkk/7Q=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@types/node": ["@types/node@20.19.30", "https://registry.npmmirror.com/@types/node/-/node-20.19.30.tgz", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g=="],
 
@@ -38,6 +161,8 @@
 
     "ansi-styles": ["ansi-styles@6.2.3", "https://registry.npmmirror.com/ansi-styles/-/ansi-styles-6.2.3.tgz", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
+
     "braces": ["braces@3.0.3", "https://registry.npmmirror.com/braces/-/braces-3.0.3.tgz", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "bun-types": ["bun-types@1.3.6", "https://registry.npmmirror.com/bun-types/-/bun-types-1.3.6.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
@@ -50,13 +175,27 @@
 
     "commander": ["commander@14.0.2", "https://registry.npmmirror.com/commander/-/commander-14.0.2.tgz", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "effect": ["effect@4.0.0-beta.66", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-4arEr62cziFa8BBVDUwJCJJmaVepXf/kRg7KtC0h8+bufngscrHbwWFhr9c+HonwOF+31U3iD3xUJmw9KzX7Dw=="],
+
     "emoji-regex": ["emoji-regex@10.6.0", "https://registry.npmmirror.com/emoji-regex/-/emoji-regex-10.6.0.tgz", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "environment": ["environment@1.1.0", "https://registry.npmmirror.com/environment/-/environment-1.1.0.tgz", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 
     "eventemitter3": ["eventemitter3@5.0.4", "https://registry.npmmirror.com/eventemitter3/-/eventemitter3-5.0.4.tgz", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
+    "fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
+
+    "fast-xml-builder": ["fast-xml-builder@1.2.0", "", { "dependencies": { "path-expression-matcher": "^1.5.0", "xml-naming": "^0.1.0" } }, "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.7.3", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.7", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg=="],
+
     "fill-range": ["fill-range@7.1.1", "https://registry.npmmirror.com/fill-range/-/fill-range-7.1.1.tgz", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
 
     "get-east-asian-width": ["get-east-asian-width@1.4.0", "https://registry.npmmirror.com/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
 
@@ -64,9 +203,15 @@
 
     "husky": ["husky@9.1.7", "https://registry.npmmirror.com/husky/-/husky-9.1.7.tgz", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
+    "ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
+
     "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "https://registry.npmmirror.com/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
     "is-number": ["is-number@7.0.0", "https://registry.npmmirror.com/is-number/-/is-number-7.0.0.tgz", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "kubernetes-types": ["kubernetes-types@1.30.0", "", {}, "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q=="],
 
     "lint-staged": ["lint-staged@16.2.7", "https://registry.npmmirror.com/lint-staged/-/lint-staged-16.2.7.tgz", { "dependencies": { "commander": "^14.0.2", "listr2": "^9.0.5", "micromatch": "^4.0.8", "nano-spawn": "^2.0.0", "pidtree": "^0.6.0", "string-argv": "^0.3.2", "yaml": "^2.8.1" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-lDIj4RnYmK7/kXMya+qJsmkRFkGolciXjrsZ6PC25GdTfWOAWetR0ZbsNXRAj1EHHImRSalc+whZFg56F5DVow=="],
 
@@ -78,9 +223,21 @@
 
     "mimic-function": ["mimic-function@5.0.1", "https://registry.npmmirror.com/mimic-function/-/mimic-function-5.0.1.tgz", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
+    "msgpackr": ["msgpackr@1.11.12", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg=="],
+
+    "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
+
+    "multipasta": ["multipasta@0.2.7", "", {}, "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA=="],
+
     "nano-spawn": ["nano-spawn@2.0.0", "https://registry.npmmirror.com/nano-spawn/-/nano-spawn-2.0.0.tgz", {}, "sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw=="],
 
+    "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
+
     "onetime": ["onetime@7.0.0", "https://registry.npmmirror.com/onetime/-/onetime-7.0.0.tgz", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
+
+    "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "picomatch": ["picomatch@2.3.1", "https://registry.npmmirror.com/picomatch/-/picomatch-2.3.1.tgz", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
@@ -92,11 +249,17 @@
 
     "proper-lockfile": ["proper-lockfile@4.1.2", "https://registry.npmmirror.com/proper-lockfile/-/proper-lockfile-4.1.2.tgz", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
 
+    "pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
+
     "restore-cursor": ["restore-cursor@5.1.0", "https://registry.npmmirror.com/restore-cursor/-/restore-cursor-5.1.0.tgz", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
     "retry": ["retry@0.12.0", "https://registry.npmmirror.com/retry/-/retry-0.12.0.tgz", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
     "rfdc": ["rfdc@1.4.1", "https://registry.npmmirror.com/rfdc/-/rfdc-1.4.1.tgz", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
     "signal-exit": ["signal-exit@3.0.7", "https://registry.npmmirror.com/signal-exit/-/signal-exit-3.0.7.tgz", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
@@ -108,19 +271,37 @@
 
     "strip-ansi": ["strip-ansi@7.1.2", "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-7.1.2.tgz", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
+    "strnum": ["strnum@2.3.0", "", {}, "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q=="],
+
     "to-regex-range": ["to-regex-range@5.0.1", "https://registry.npmmirror.com/to-regex-range/-/to-regex-range-5.0.1.tgz", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "toml": ["toml@4.1.1", "", {}, "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "typescript": ["typescript@5.9.3", "https://registry.npmmirror.com/typescript/-/typescript-5.9.3.tgz", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@6.21.0", "https://registry.npmmirror.com/undici-types/-/undici-types-6.21.0.tgz", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
+    "uuid": ["uuid@13.0.2", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
     "wrap-ansi": ["wrap-ansi@9.0.2", "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-9.0.2.tgz", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "xml-naming": ["xml-naming@0.1.0", "", {}, "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw=="],
 
     "yaml": ["yaml@2.8.2", "https://registry.npmmirror.com/yaml/-/yaml-2.8.2.tgz", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
     "zod": ["zod@3.25.76", "https://registry.npmmirror.com/zod/-/zod-3.25.76.tgz", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
     "@opencode-ai/plugin/zod": ["zod@4.1.8", "https://registry.npmmirror.com/zod/-/zod-4.1.8.tgz", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
+
+    "effect/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "restore-cursor/signal-exit": ["signal-exit@4.1.0", "https://registry.npmmirror.com/signal-exit/-/signal-exit-4.1.0.tgz", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@aws/codewhisperer-streaming-client": "^1.0.34",
-        "@opencode-ai/plugin": "^1.14.39",
+        "@opencode-ai/plugin": "^1.15.11",
         "proper-lockfile": "^4.1.2",
         "zod": "^3.24.0"
       },
@@ -547,9 +547,9 @@
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
-      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
       "cpu": [
         "arm64"
       ],
@@ -560,9 +560,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
-      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
       "cpu": [
         "x64"
       ],
@@ -573,9 +573,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
-      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
       "cpu": [
         "arm"
       ],
@@ -586,9 +586,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
-      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
       "cpu": [
         "arm64"
       ],
@@ -599,9 +599,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
-      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
       "cpu": [
         "x64"
       ],
@@ -612,9 +612,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
-      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
       "cpu": [
         "x64"
       ],
@@ -637,21 +637,25 @@
       "license": "MIT"
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.14.39",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.14.39.tgz",
-      "integrity": "sha512-h3p3qCZLjodiKquCI9/YSDxgUoHTQ0/AK7t71tLWkUpEUicPZWsixdn3lk53/uLU+Wh+qp5FV+GTZWAXkKmAkw==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.15.11.tgz",
+      "integrity": "sha512-RDvYDCHO0+3OAGD590oDQqtryrENrUW04SjtoA4sgRV2efpZeBFjx3TnonBsXKq6nWqYg172nhltUEZsihGnXQ==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/sdk": "1.14.39",
-        "effect": "4.0.0-beta.59",
+        "@opencode-ai/sdk": "1.15.11",
+        "effect": "4.0.0-beta.66",
         "zod": "4.1.8"
       },
       "peerDependencies": {
-        "@opentui/core": ">=0.2.2",
-        "@opentui/solid": ">=0.2.2"
+        "@opentui/core": ">=0.2.15",
+        "@opentui/keymap": ">=0.2.15",
+        "@opentui/solid": ">=0.2.15"
       },
       "peerDependenciesMeta": {
         "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/keymap": {
           "optional": true
         },
         "@opentui/solid": {
@@ -669,9 +673,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.14.39",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.14.39.tgz",
-      "integrity": "sha512-hguOA5huhys7zwCR3ESbSHyQNuJBNtfrxUxYZF/s/6trRW+imqGmDtC/RsOSNuk7GE06ZnvOTwb4T2WhXYIBxw==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.15.11.tgz",
+      "integrity": "sha512-IyYyDVsO8SKbKbkSadHpDuYnYC+2vmEeLU+rW+rH2M54Sigq6l3gDHno16+U6SRut+lowbph7v/ry3WbV67V3w==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
@@ -1481,9 +1485,9 @@
       }
     },
     "node_modules/effect": {
-      "version": "4.0.0-beta.59",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.59.tgz",
-      "integrity": "sha512-xyUDLeHSe8d6lWGOvR6Fgn2HL6gYeTZ/S4Jzk9uc4ZUxMPPsNZlNXrvk0C7/utQFzeX7uAWcVnG2BjbA0SRoAA==",
+      "version": "4.0.0-beta.66",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.66.tgz",
+      "integrity": "sha512-4arEr62cziFa8BBVDUwJCJJmaVepXf/kRg7KtC0h8+bufngscrHbwWFhr9c+HonwOF+31U3iD3xUJmw9KzX7Dw==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
@@ -1496,19 +1500,6 @@
         "toml": "^4.1.1",
         "uuid": "^13.0.0",
         "yaml": "^2.8.3"
-      }
-    },
-    "node_modules/effect/node_modules/uuid": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
-      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/emoji-regex": {
@@ -1539,9 +1530,9 @@
       "license": "MIT"
     },
     "node_modules/fast-check": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
-      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
       "funding": [
         {
           "type": "individual",
@@ -1776,9 +1767,9 @@
       }
     },
     "node_modules/msgpackr-extract": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
-      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1789,12 +1780,12 @@
         "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
       },
       "optionalDependencies": {
-        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
       }
     },
     "node_modules/multipasta": {
@@ -2121,6 +2112,19 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zhafron/opencode-kiro-auth",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zhafron/opencode-kiro-auth",
-      "version": "1.10.1",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@aws/codewhisperer-streaming-client": "^1.0.34",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@aws/codewhisperer-streaming-client": "^1.0.34",
-    "@opencode-ai/plugin": "^1.14.39",
+    "@opencode-ai/plugin": "^1.15.11",
     "proper-lockfile": "^4.1.2",
     "zod": "^3.24.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zhafron/opencode-kiro-auth",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "description": "OpenCode plugin for AWS Kiro (CodeWhisperer) providing access to Claude models",
   "type": "module",
   "main": "dist/index.js",

--- a/src/__tests__/auth-bootstrap.test.ts
+++ b/src/__tests__/auth-bootstrap.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { bootstrapAuthIfNeeded } from '../plugin/auth-bootstrap.js'
+
+const originalHome = process.env.HOME
+const originalXdgDataHome = process.env.XDG_DATA_HOME
+const originalKiroCliDbPath = process.env.KIROCLI_DB_PATH
+
+afterEach(() => {
+  if (originalHome === undefined) delete process.env.HOME
+  else process.env.HOME = originalHome
+
+  if (originalXdgDataHome === undefined) delete process.env.XDG_DATA_HOME
+  else process.env.XDG_DATA_HOME = originalXdgDataHome
+
+  if (originalKiroCliDbPath === undefined) delete process.env.KIROCLI_DB_PATH
+  else process.env.KIROCLI_DB_PATH = originalKiroCliDbPath
+})
+
+function setupBootstrapFixture() {
+  const home = mkdtempSync(join(tmpdir(), 'kiro-auth-bootstrap-'))
+  process.env.HOME = home
+  process.env.XDG_DATA_HOME = join(home, '.local', 'share')
+
+  const cliDbPath = join(home, 'kiro-cli.sqlite3')
+  writeFileSync(cliDbPath, '')
+  process.env.KIROCLI_DB_PATH = cliDbPath
+
+  const authDir = join(home, '.local', 'share', 'opencode')
+  const authPath = join(authDir, 'auth.json')
+  mkdirSync(authDir, { recursive: true })
+
+  return { home, authPath }
+}
+
+describe('bootstrapAuthIfNeeded', () => {
+  test('does not rewrite malformed auth.json', () => {
+    const { home, authPath } = setupBootstrapFixture()
+    writeFileSync(authPath, '{"github":')
+
+    bootstrapAuthIfNeeded('kiro')
+
+    expect(readFileSync(authPath, 'utf-8')).toBe('{"github":')
+    rmSync(home, { recursive: true, force: true })
+  })
+
+  test('adds placeholder while preserving existing auth providers', () => {
+    const { home, authPath } = setupBootstrapFixture()
+    writeFileSync(authPath, JSON.stringify({ github: { type: 'api', key: 'existing' } }, null, 2))
+
+    bootstrapAuthIfNeeded('kiro')
+
+    expect(JSON.parse(readFileSync(authPath, 'utf-8'))).toEqual({
+      github: { type: 'api', key: 'existing' },
+      kiro: { type: 'api', key: 'kiro-bootstrap-placeholder' }
+    })
+    rmSync(home, { recursive: true, force: true })
+  })
+
+  test('preserves restrictive auth.json permissions when rewriting', () => {
+    const { home, authPath } = setupBootstrapFixture()
+    writeFileSync(authPath, JSON.stringify({ github: { type: 'api', key: 'existing' } }, null, 2))
+    chmodSync(authPath, 0o600)
+
+    bootstrapAuthIfNeeded('kiro')
+
+    expect(statSync(authPath).mode & 0o777).toBe(0o600)
+    rmSync(home, { recursive: true, force: true })
+  })
+})

--- a/src/__tests__/constants.test.ts
+++ b/src/__tests__/constants.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { isLongContextModel, SUPPORTED_MODELS } from '../constants.js'
+import { isLongContextModel, normalizeRegion, SUPPORTED_MODELS } from '../constants.js'
 
 describe('isLongContextModel', () => {
   test('returns true for all 1m model variants', () => {
@@ -22,5 +22,11 @@ describe('isLongContextModel', () => {
     expect(isLongContextModel('unknown-model')).toBe(false)
     expect(isLongContextModel('')).toBe(false)
     expect(isLongContextModel('claude-sonnet-4-6')).toBe(false)
+  })
+})
+
+describe('normalizeRegion', () => {
+  test('accepts configured AWS regions with the installed Zod enum shape', () => {
+    expect(normalizeRegion('us-west-2')).toBe('us-west-2')
   })
 })

--- a/src/__tests__/openai-converter.test.ts
+++ b/src/__tests__/openai-converter.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test'
+import { convertToOpenAI } from '../plugin/streaming/openai-converter.js'
+
+describe('convertToOpenAI', () => {
+  test('skips Anthropic-only events instead of emitting empty choices', () => {
+    expect(
+      convertToOpenAI({ type: 'content_block_stop', index: 0 }, 'chatcmpl-test', 'auto')
+    ).toBeNull()
+    expect(convertToOpenAI({ type: 'message_stop' }, 'chatcmpl-test', 'auto')).toBeNull()
+  })
+
+  test('skips empty reasoning deltas instead of emitting empty choices', () => {
+    const chunk = convertToOpenAI(
+      {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'thinking_delta', thinking: '' }
+      },
+      'chatcmpl-test',
+      'auto'
+    )
+
+    expect(chunk).toBeNull()
+  })
+})

--- a/src/__tests__/plugin-module.test.ts
+++ b/src/__tests__/plugin-module.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, test } from 'bun:test'
+import pluginModule from '../index.js'
+
+describe('package plugin module', () => {
+  test('uses the kiro provider id in the default export', () => {
+    expect(pluginModule.id).toBe('kiro')
+  })
+})

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,7 @@
 import { RegionSchema } from './plugin/config/schema'
 import type { KiroRegion } from './plugin/types'
 
-const VALID_REGIONS: readonly KiroRegion[] = Object.values(RegionSchema.Values)
+const VALID_REGIONS: readonly KiroRegion[] = RegionSchema.options
 
 export function isValidRegion(region: string): region is KiroRegion {
   return VALID_REGIONS.includes(region as KiroRegion)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -50,8 +50,11 @@ export const KIRO_CONSTANTS = {
 }
 
 export const MODEL_MAPPING: Record<string, string> = {
+  // Claude Haiku
   'claude-haiku-4-5': 'claude-haiku-4.5',
   'claude-haiku-4-5-thinking': 'claude-haiku-4.5',
+  // Claude Sonnet
+  'claude-sonnet-4': 'claude-sonnet-4',
   'claude-sonnet-4-5': 'claude-sonnet-4.5',
   'claude-sonnet-4-5-thinking': 'claude-sonnet-4.5',
   'claude-sonnet-4-5-1m': 'claude-sonnet-4.5-1m',
@@ -60,6 +63,7 @@ export const MODEL_MAPPING: Record<string, string> = {
   'claude-sonnet-4-6-thinking': 'claude-sonnet-4.6',
   'claude-sonnet-4-6-1m': 'claude-sonnet-4.6-1m',
   'claude-sonnet-4-6-1m-thinking': 'claude-sonnet-4.6-1m',
+  // Claude Opus
   'claude-opus-4-5': 'claude-opus-4.5',
   'claude-opus-4-5-thinking': 'claude-opus-4.5',
   'claude-opus-4-6': 'claude-opus-4.6',
@@ -68,17 +72,20 @@ export const MODEL_MAPPING: Record<string, string> = {
   'claude-opus-4-6-1m-thinking': 'claude-opus-4.6-1m',
   'claude-opus-4-7': 'claude-opus-4.7',
   'claude-opus-4-7-thinking': 'claude-opus-4.7',
-  'claude-sonnet-4': 'claude-sonnet-4',
+  // Auto
+  auto: 'auto',
+  // Open weight models
+  'deepseek-3.2': 'deepseek-3.2',
+  'glm-5': 'glm-5',
+  'minimax-m2.5': 'minimax-m2.5',
+  'minimax-m2.1': 'minimax-m2.1',
+  'qwen3-coder-next': 'qwen3-coder-next',
+  // Legacy / internal mappings kept for backwards compatibility
   'claude-3-7-sonnet': 'CLAUDE_3_7_SONNET_20250219_V1_0',
   'nova-swe': 'AGI_NOVA_SWE_V1_5',
   'gpt-oss-120b': 'OPENAI_GPT_OSS_120B_1_0',
   'minimax-m2': 'MINIMAX_MINIMAX_M2',
-  'kimi-k2-thinking': 'MOONSHOT_KIMI_K2_THINKING',
-  auto: 'auto',
-  'deepseek-3.2': 'deepseek-3.2',
-  'minimax-m2.5': 'minimax-m2.5',
-  'minimax-m2.1': 'minimax-m2.1',
-  'qwen3-coder-next': 'qwen3-coder-next'
+  'kimi-k2-thinking': 'MOONSHOT_KIMI_K2_THINKING'
 }
 
 export const SUPPORTED_MODELS = Object.keys(MODEL_MAPPING)

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,4 @@ export { KiroOAuthPlugin } from './plugin.js'
 export type { KiroConfig } from './plugin/config/index.js'
 export type { KiroAuthMethod, KiroRegion, ManagedAccount } from './plugin/types.js'
 
-export default { id: 'kiro-auth', server: (await import('./plugin.js')).KiroOAuthPlugin }
+export default { id: 'kiro', server: (await import('./plugin.js')).KiroOAuthPlugin }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,70 +1,15 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { homedir } from 'node:os'
-import { join } from 'node:path'
 import { KIRO_CONSTANTS } from './constants.js'
 import { AuthHandler } from './core/auth/auth-handler.js'
 import { RequestHandler } from './core/request/request-handler.js'
 import { AccountCache } from './infrastructure/database/account-cache.js'
 import { AccountRepository } from './infrastructure/database/account-repository.js'
 import { AccountManager } from './plugin/accounts.js'
+import { bootstrapAuthIfNeeded } from './plugin/auth-bootstrap.js'
 import { loadConfig } from './plugin/config/index.js'
-import * as logger from './plugin/logger.js'
-import { getCliDbPath } from './plugin/sync/kiro-cli-parser.js'
 
 type ToastFunction = (message: string, variant: string) => void
 
 const KIRO_PROVIDER_ID = 'kiro'
-
-/**
- * OpenCode only calls the auth loader when there is a stored auth entry for the
- * provider in auth.json. The plugin syncs credentials from the Kiro IDE's local
- * SQLite database, so it doesn't need the user to go through an OAuth flow first.
- *
- * This function writes a minimal placeholder entry into auth.json so that
- * OpenCode will call the loader on the next startup, at which point the real
- * credentials are synced from the Kiro CLI DB.
- */
-function bootstrapAuthIfNeeded(providerId: string): void {
-  try {
-    const cliDbPath = getCliDbPath()
-    if (!existsSync(cliDbPath)) {
-      logger.log('Bootstrap: Kiro CLI DB not found, skipping')
-      return
-    }
-
-    const authPath = join(
-      process.platform === 'win32'
-        ? process.env.LOCALAPPDATA || join(homedir(), 'AppData', 'Local')
-        : join(homedir(), '.local', 'share'),
-      'opencode',
-      'auth.json'
-    )
-
-    let auth: Record<string, any> = {}
-    if (existsSync(authPath)) {
-      try {
-        auth = JSON.parse(readFileSync(authPath, 'utf-8'))
-      } catch {}
-    }
-
-    if (auth[providerId]) {
-      // Already has an entry — loader will be called normally
-      return
-    }
-
-    logger.log(`Bootstrap: writing placeholder auth entry for provider "${providerId}"`)
-    auth[providerId] = {
-      type: 'api',
-      key: 'kiro-bootstrap-placeholder'
-    }
-
-    mkdirSync(join(authPath, '..'), { recursive: true })
-    writeFileSync(authPath, JSON.stringify(auth, null, 2), 'utf-8')
-    logger.log('Bootstrap: auth.json updated — loader will run on next request')
-  } catch (e) {
-    logger.warn(`Bootstrap failed: ${e instanceof Error ? e.message : String(e)}`)
-  }
-}
 
 export const createKiroPlugin =
   (id: string) =>

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,3 +1,6 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
 import { KIRO_CONSTANTS } from './constants.js'
 import { AuthHandler } from './core/auth/auth-handler.js'
 import { RequestHandler } from './core/request/request-handler.js'
@@ -5,10 +8,63 @@ import { AccountCache } from './infrastructure/database/account-cache.js'
 import { AccountRepository } from './infrastructure/database/account-repository.js'
 import { AccountManager } from './plugin/accounts.js'
 import { loadConfig } from './plugin/config/index.js'
+import * as logger from './plugin/logger.js'
+import { getCliDbPath } from './plugin/sync/kiro-cli-parser.js'
 
 type ToastFunction = (message: string, variant: string) => void
 
-const KIRO_PROVIDER_ID = 'kiro-auth'
+const KIRO_PROVIDER_ID = 'kiro'
+
+/**
+ * OpenCode only calls the auth loader when there is a stored auth entry for the
+ * provider in auth.json. The plugin syncs credentials from the Kiro IDE's local
+ * SQLite database, so it doesn't need the user to go through an OAuth flow first.
+ *
+ * This function writes a minimal placeholder entry into auth.json so that
+ * OpenCode will call the loader on the next startup, at which point the real
+ * credentials are synced from the Kiro CLI DB.
+ */
+function bootstrapAuthIfNeeded(providerId: string): void {
+  try {
+    const cliDbPath = getCliDbPath()
+    if (!existsSync(cliDbPath)) {
+      logger.log('Bootstrap: Kiro CLI DB not found, skipping')
+      return
+    }
+
+    const authPath = join(
+      process.platform === 'win32'
+        ? process.env.LOCALAPPDATA || join(homedir(), 'AppData', 'Local')
+        : join(homedir(), '.local', 'share'),
+      'opencode',
+      'auth.json'
+    )
+
+    let auth: Record<string, any> = {}
+    if (existsSync(authPath)) {
+      try {
+        auth = JSON.parse(readFileSync(authPath, 'utf-8'))
+      } catch {}
+    }
+
+    if (auth[providerId]) {
+      // Already has an entry — loader will be called normally
+      return
+    }
+
+    logger.log(`Bootstrap: writing placeholder auth entry for provider "${providerId}"`)
+    auth[providerId] = {
+      type: 'api',
+      key: 'kiro-bootstrap-placeholder'
+    }
+
+    mkdirSync(join(authPath, '..'), { recursive: true })
+    writeFileSync(authPath, JSON.stringify(auth, null, 2), 'utf-8')
+    logger.log('Bootstrap: auth.json updated — loader will run on next request')
+  } catch (e) {
+    logger.warn(`Bootstrap failed: ${e instanceof Error ? e.message : String(e)}`)
+  }
+}
 
 export const createKiroPlugin =
   (id: string) =>
@@ -28,11 +84,29 @@ export const createKiroPlugin =
 
     const requestHandler = new RequestHandler(accountManager, config, repository, client)
 
+    // Compute the base URL once so both the config hook and auth loader use the same value
+    const baseURL = KIRO_CONSTANTS.BASE_URL.replace('/generateAssistantResponse', '').replace(
+      '{{region}}',
+      config.default_region || 'us-east-1'
+    )
+
     return {
       config: async (input: any) => {
+        // Ensure there's an auth entry so OpenCode calls the loader on startup.
+        // This is a no-op if the entry already exists.
+        bootstrapAuthIfNeeded(id)
+
         if (!input.provider) input.provider = {}
         if (!input.provider[id]) input.provider[id] = {}
+        // Always set npm and api — these must be present regardless of whether
+        // the user has already defined the provider in their opencode.json.
         input.provider[id].npm = '@ai-sdk/openai-compatible'
+        // Set the base URL at the provider level. OpenCode reads provider.api as
+        // model.api.url, which resolveSDK() uses to construct the endpoint URL.
+        // Only set if not already overridden by the user.
+        if (!input.provider[id].api) {
+          input.provider[id].api = baseURL
+        }
         if (!input.provider[id].models) {
           input.provider[id].models = {
             auto: {
@@ -101,10 +175,10 @@ export const createKiroPlugin =
 
           return {
             apiKey: '',
-            baseURL: KIRO_CONSTANTS.BASE_URL.replace('/generateAssistantResponse', '').replace(
-              '{{region}}',
-              config.default_region || 'us-east-1'
-            ),
+            // Provide baseURL explicitly so the @ai-sdk/openai-compatible provider
+            // always has a valid URL. The custom fetch below intercepts all Kiro
+            // API calls, so this value is only used for URL construction.
+            baseURL,
             fetch: (input: any, init?: any) => requestHandler.handle(input, init, showToast)
           }
         },
@@ -122,7 +196,11 @@ export const createKiroPlugin =
               ...modelInfo,
               api: {
                 ...(modelInfo.api || {}),
-                npm: '@ai-sdk/openai-compatible'
+                npm: '@ai-sdk/openai-compatible',
+                // Ensure url is always set. modelInfo.api.url should already be
+                // populated from the config hook's provider.api field, but we
+                // set it explicitly as a fallback for any edge cases.
+                url: modelInfo.api?.url || baseURL
               }
             }
           }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -114,6 +114,12 @@ export const createKiroPlugin =
               limit: { context: 200000, output: 64000 },
               modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
             },
+            // Claude Sonnet
+            'claude-sonnet-4': {
+              name: 'Claude Sonnet 4.0 (1.3x)',
+              limit: { context: 200000, output: 64000 },
+              modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
+            },
             'claude-sonnet-4-5': {
               name: 'Claude Sonnet 4.5 (1.3x)',
               limit: { context: 200000, output: 64000 },
@@ -124,16 +130,13 @@ export const createKiroPlugin =
               limit: { context: 1000000, output: 64000 },
               modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
             },
-            'claude-sonnet-4': {
-              name: 'Claude Sonnet 4.0 (1.3x)',
-              limit: { context: 200000, output: 64000 },
-              modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
-            },
+            // Claude Haiku
             'claude-haiku-4-5': {
               name: 'Claude Haiku 4.5 (0.4x)',
               limit: { context: 200000, output: 64000 },
               modalities: { input: ['text', 'image'], output: ['text'] }
             },
+            // Claude Opus
             'claude-opus-4-5': {
               name: 'Claude Opus 4.5 (2.2x)',
               limit: { context: 200000, output: 64000 },
@@ -148,6 +151,17 @@ export const createKiroPlugin =
               name: 'Claude Opus 4.7 (2.2x)',
               limit: { context: 1000000, output: 64000 },
               modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
+            },
+            // Open weight models
+            'deepseek-3.2': {
+              name: 'DeepSeek 3.2 (0.25x)',
+              limit: { context: 128000, output: 64000 },
+              modalities: { input: ['text'], output: ['text'] }
+            },
+            'glm-5': {
+              name: 'GLM-5 (0.5x)',
+              limit: { context: 200000, output: 64000 },
+              modalities: { input: ['text'], output: ['text'] }
             },
             'minimax-m2.5': {
               name: 'MiniMax M2.5 (0.25x)',

--- a/src/plugin/auth-bootstrap.ts
+++ b/src/plugin/auth-bootstrap.ts
@@ -1,0 +1,86 @@
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync
+} from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+import * as logger from './logger.js'
+import { getCliDbPath } from './sync/kiro-cli-parser.js'
+
+function getOpenCodeAuthPath(): string {
+  const dataRoot =
+    process.platform === 'win32'
+      ? process.env.LOCALAPPDATA || join(homedir(), 'AppData', 'Local')
+      : process.env.XDG_DATA_HOME || join(homedir(), '.local', 'share')
+
+  return join(dataRoot, 'opencode', 'auth.json')
+}
+
+function readAuthFile(authPath: string): Record<string, any> | null {
+  if (!existsSync(authPath)) return {}
+
+  try {
+    const parsed = JSON.parse(readFileSync(authPath, 'utf-8'))
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      logger.warn('Bootstrap: auth.json is not an object, skipping placeholder auth setup')
+      return null
+    }
+    return parsed
+  } catch (e) {
+    logger.warn(
+      `Bootstrap: invalid auth.json, skipping placeholder auth setup: ${e instanceof Error ? e.message : String(e)}`
+    )
+    return null
+  }
+}
+
+function writeAuthFile(authPath: string, auth: Record<string, any>): void {
+  mkdirSync(dirname(authPath), { recursive: true })
+  const mode = existsSync(authPath) ? statSync(authPath).mode & 0o777 : 0o600
+  const tempPath = `${authPath}.${process.pid}.${Date.now()}.tmp`
+  writeFileSync(tempPath, JSON.stringify(auth, null, 2), { encoding: 'utf-8', mode })
+  chmodSync(tempPath, mode)
+  renameSync(tempPath, authPath)
+}
+
+/**
+ * OpenCode only calls the auth loader when there is a stored auth entry for the
+ * provider in auth.json. The plugin syncs credentials from the Kiro IDE's local
+ * SQLite database, so it doesn't need the user to go through an OAuth flow first.
+ *
+ * This writes a minimal placeholder entry into auth.json so OpenCode calls the
+ * loader on the next startup, where real credentials are synced from Kiro CLI DB.
+ */
+export function bootstrapAuthIfNeeded(providerId: string): void {
+  try {
+    const cliDbPath = getCliDbPath()
+    if (!existsSync(cliDbPath)) {
+      logger.log('Bootstrap: Kiro CLI DB not found, skipping')
+      return
+    }
+
+    const authPath = getOpenCodeAuthPath()
+    const auth = readAuthFile(authPath)
+    if (!auth) return
+
+    if (auth[providerId]) {
+      return
+    }
+
+    logger.log(`Bootstrap: writing placeholder auth entry for provider "${providerId}"`)
+    auth[providerId] = {
+      type: 'api',
+      key: 'kiro-bootstrap-placeholder'
+    }
+
+    writeAuthFile(authPath, auth)
+    logger.log('Bootstrap: auth.json updated — loader will run on next request')
+  } catch (e) {
+    logger.warn(`Bootstrap failed: ${e instanceof Error ? e.message : String(e)}`)
+  }
+}

--- a/src/plugin/streaming/openai-converter.ts
+++ b/src/plugin/streaming/openai-converter.ts
@@ -17,11 +17,15 @@ export function convertToOpenAI(event: StreamEvent, id: string, model: string): 
         finish_reason: null
       })
     } else if (event.delta.type === 'thinking_delta') {
-      base.choices.push({
-        index: 0,
-        delta: { reasoning_content: event.delta.thinking },
-        finish_reason: null
-      })
+      // reasoning_content is supported by some OpenAI-compatible clients;
+      // emit it but also skip if empty to avoid noise.
+      if (event.delta.thinking) {
+        base.choices.push({
+          index: 0,
+          delta: { reasoning_content: event.delta.thinking },
+          finish_reason: null
+        })
+      }
     } else if (event.delta.type === 'input_json_delta') {
       base.choices.push({
         index: 0,
@@ -62,7 +66,15 @@ export function convertToOpenAI(event: StreamEvent, id: string, model: string): 
       completion_tokens: event.usage?.output_tokens || 0,
       total_tokens: (event.usage?.input_tokens || 0) + (event.usage?.output_tokens || 0)
     }
+  } else {
+    // Skip Anthropic-specific events that @ai-sdk/openai-compatible doesn't understand
+    // (content_block_start for text/thinking, content_block_stop, message_stop, etc.)
+    // Returning null signals the caller to skip this event.
+    return null
   }
+
+  // Don't emit chunks with empty choices — the SDK may mishandle them.
+  if (base.choices.length === 0) return null
 
   return base
 }

--- a/src/plugin/streaming/sdk-stream-transformer.ts
+++ b/src/plugin/streaming/sdk-stream-transformer.ts
@@ -46,7 +46,10 @@ export async function* transformSdkStream(
 
         if (!thinkingRequested) {
           for (const ev of createTextDeltaEvents(text, streamState)) {
-            yield convertToOpenAI(ev, conversationId, model)
+            {
+              const _c = convertToOpenAI(ev, conversationId, model)
+              if (_c !== null) yield _c
+            }
           }
           continue
         }
@@ -118,7 +121,8 @@ export async function* transformSdkStream(
         }
 
         for (const ev of deltaEvents) {
-          yield convertToOpenAI(ev, conversationId, model)
+          const chunk = convertToOpenAI(ev, conversationId, model)
+          if (chunk !== null) yield chunk
         }
       } else if (event.toolUseEvent) {
         const tc = event.toolUseEvent
@@ -160,22 +164,32 @@ export async function* transformSdkStream(
 
     if (thinkingRequested && streamState.buffer) {
       if (streamState.inThinking) {
-        for (const ev of createThinkingDeltaEvents(streamState.buffer, streamState))
-          yield convertToOpenAI(ev, conversationId, model)
+        for (const ev of createThinkingDeltaEvents(streamState.buffer, streamState)) {
+          const _c = convertToOpenAI(ev, conversationId, model)
+          if (_c !== null) yield _c
+        }
         streamState.buffer = ''
-        for (const ev of createThinkingDeltaEvents('', streamState))
-          yield convertToOpenAI(ev, conversationId, model)
-        for (const ev of stopBlock(streamState.thinkingBlockIndex, streamState))
-          yield convertToOpenAI(ev, conversationId, model)
+        for (const ev of createThinkingDeltaEvents('', streamState)) {
+          const _c = convertToOpenAI(ev, conversationId, model)
+          if (_c !== null) yield _c
+        }
+        for (const ev of stopBlock(streamState.thinkingBlockIndex, streamState)) {
+          const _c = convertToOpenAI(ev, conversationId, model)
+          if (_c !== null) yield _c
+        }
       } else {
-        for (const ev of createTextDeltaEvents(streamState.buffer, streamState))
-          yield convertToOpenAI(ev, conversationId, model)
+        for (const ev of createTextDeltaEvents(streamState.buffer, streamState)) {
+          const _c = convertToOpenAI(ev, conversationId, model)
+          if (_c !== null) yield _c
+        }
         streamState.buffer = ''
       }
     }
 
-    for (const ev of stopBlock(streamState.textBlockIndex, streamState))
-      yield convertToOpenAI(ev, conversationId, model)
+    for (const ev of stopBlock(streamState.textBlockIndex, streamState)) {
+      const _c = convertToOpenAI(ev, conversationId, model)
+      if (_c !== null) yield _c
+    }
 
     const bracketToolCalls = parseBracketToolCalls(totalContent)
     if (bracketToolCalls.length > 0) {
@@ -195,20 +209,23 @@ export async function* transformSdkStream(
         if (!tc) continue
         const blockIndex = baseIndex + i
 
-        yield convertToOpenAI(
-          {
-            type: 'content_block_start',
-            index: blockIndex,
-            content_block: {
-              type: 'tool_use',
-              id: tc.toolUseId,
-              name: tc.name,
-              input: {}
-            }
-          },
-          conversationId,
-          model
-        )
+        {
+          const _c = convertToOpenAI(
+            {
+              type: 'content_block_start',
+              index: blockIndex,
+              content_block: {
+                type: 'tool_use',
+                id: tc.toolUseId,
+                name: tc.name,
+                input: {}
+              }
+            },
+            conversationId,
+            model
+          )
+          if (_c !== null) yield _c
+        }
 
         let inputJson: string
         try {
@@ -218,24 +235,30 @@ export async function* transformSdkStream(
           inputJson = tc.input
         }
 
-        yield convertToOpenAI(
-          {
-            type: 'content_block_delta',
-            index: blockIndex,
-            delta: {
-              type: 'input_json_delta',
-              partial_json: inputJson
-            }
-          },
-          conversationId,
-          model
-        )
+        {
+          const _c = convertToOpenAI(
+            {
+              type: 'content_block_delta',
+              index: blockIndex,
+              delta: {
+                type: 'input_json_delta',
+                partial_json: inputJson
+              }
+            },
+            conversationId,
+            model
+          )
+          if (_c !== null) yield _c
+        }
 
-        yield convertToOpenAI(
-          { type: 'content_block_stop', index: blockIndex },
-          conversationId,
-          model
-        )
+        {
+          const _c = convertToOpenAI(
+            { type: 'content_block_stop', index: blockIndex },
+            conversationId,
+            model
+          )
+          if (_c !== null) yield _c
+        }
       }
     }
 
@@ -247,22 +270,28 @@ export async function* transformSdkStream(
       inputTokens = Math.max(0, totalTokens - outputTokens)
     }
 
-    yield convertToOpenAI(
-      {
-        type: 'message_delta',
-        delta: { stop_reason: toolCalls.length > 0 ? 'tool_use' : 'end_turn' },
-        usage: {
-          input_tokens: inputTokens,
-          output_tokens: outputTokens,
-          cache_creation_input_tokens: 0,
-          cache_read_input_tokens: 0
-        }
-      },
-      conversationId,
-      model
-    )
+    {
+      const _c = convertToOpenAI(
+        {
+          type: 'message_delta',
+          delta: { stop_reason: toolCalls.length > 0 ? 'tool_use' : 'end_turn' },
+          usage: {
+            input_tokens: inputTokens,
+            output_tokens: outputTokens,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0
+          }
+        },
+        conversationId,
+        model
+      )
+      if (_c !== null) yield _c
+    }
 
-    yield convertToOpenAI({ type: 'message_stop' }, conversationId, model)
+    {
+      const _c = convertToOpenAI({ type: 'message_stop' }, conversationId, model)
+      if (_c !== null) yield _c
+    }
   } catch (e) {
     throw e
   }

--- a/src/plugin/streaming/stream-transformer.ts
+++ b/src/plugin/streaming/stream-transformer.ts
@@ -60,7 +60,10 @@ export async function* transformKiroStream(
 
           if (!thinkingRequested) {
             for (const ev of createTextDeltaEvents(event.data, streamState)) {
-              yield convertToOpenAI(ev, conversationId, model)
+              {
+                const _c = convertToOpenAI(ev, conversationId, model)
+                if (_c !== null) yield _c
+              }
             }
             continue
           }
@@ -136,7 +139,10 @@ export async function* transformKiroStream(
           }
 
           for (const ev of deltaEvents) {
-            yield convertToOpenAI(ev, conversationId, model)
+            {
+              const _c = convertToOpenAI(ev, conversationId, model)
+              if (_c !== null) yield _c
+            }
           }
         } else if (event.type === 'toolUse') {
           const tc = event.data
@@ -189,22 +195,32 @@ export async function* transformKiroStream(
 
     if (thinkingRequested && streamState.buffer) {
       if (streamState.inThinking) {
-        for (const ev of createThinkingDeltaEvents(streamState.buffer, streamState))
-          yield convertToOpenAI(ev, conversationId, model)
+        for (const ev of createThinkingDeltaEvents(streamState.buffer, streamState)) {
+          const _c = convertToOpenAI(ev, conversationId, model)
+          if (_c !== null) yield _c
+        }
         streamState.buffer = ''
-        for (const ev of createThinkingDeltaEvents('', streamState))
-          yield convertToOpenAI(ev, conversationId, model)
-        for (const ev of stopBlock(streamState.thinkingBlockIndex, streamState))
-          yield convertToOpenAI(ev, conversationId, model)
+        for (const ev of createThinkingDeltaEvents('', streamState)) {
+          const _c = convertToOpenAI(ev, conversationId, model)
+          if (_c !== null) yield _c
+        }
+        for (const ev of stopBlock(streamState.thinkingBlockIndex, streamState)) {
+          const _c = convertToOpenAI(ev, conversationId, model)
+          if (_c !== null) yield _c
+        }
       } else {
-        for (const ev of createTextDeltaEvents(streamState.buffer, streamState))
-          yield convertToOpenAI(ev, conversationId, model)
+        for (const ev of createTextDeltaEvents(streamState.buffer, streamState)) {
+          const _c = convertToOpenAI(ev, conversationId, model)
+          if (_c !== null) yield _c
+        }
         streamState.buffer = ''
       }
     }
 
-    for (const ev of stopBlock(streamState.textBlockIndex, streamState))
-      yield convertToOpenAI(ev, conversationId, model)
+    for (const ev of stopBlock(streamState.textBlockIndex, streamState)) {
+      const _c = convertToOpenAI(ev, conversationId, model)
+      if (_c !== null) yield _c
+    }
 
     const bracketToolCalls = parseBracketToolCalls(totalContent)
     if (bracketToolCalls.length > 0) {
@@ -225,20 +241,23 @@ export async function* transformKiroStream(
 
         const blockIndex = baseIndex + i
 
-        yield convertToOpenAI(
-          {
-            type: 'content_block_start',
-            index: blockIndex,
-            content_block: {
-              type: 'tool_use',
-              id: tc.toolUseId,
-              name: tc.name,
-              input: {}
-            }
-          },
-          conversationId,
-          model
-        )
+        {
+          const _c = convertToOpenAI(
+            {
+              type: 'content_block_start',
+              index: blockIndex,
+              content_block: {
+                type: 'tool_use',
+                id: tc.toolUseId,
+                name: tc.name,
+                input: {}
+              }
+            },
+            conversationId,
+            model
+          )
+          if (_c !== null) yield _c
+        }
 
         let inputJson: string
         try {
@@ -248,24 +267,30 @@ export async function* transformKiroStream(
           inputJson = tc.input
         }
 
-        yield convertToOpenAI(
-          {
-            type: 'content_block_delta',
-            index: blockIndex,
-            delta: {
-              type: 'input_json_delta',
-              partial_json: inputJson
-            }
-          },
-          conversationId,
-          model
-        )
+        {
+          const _c = convertToOpenAI(
+            {
+              type: 'content_block_delta',
+              index: blockIndex,
+              delta: {
+                type: 'input_json_delta',
+                partial_json: inputJson
+              }
+            },
+            conversationId,
+            model
+          )
+          if (_c !== null) yield _c
+        }
 
-        yield convertToOpenAI(
-          { type: 'content_block_stop', index: blockIndex },
-          conversationId,
-          model
-        )
+        {
+          const _c = convertToOpenAI(
+            { type: 'content_block_stop', index: blockIndex },
+            conversationId,
+            model
+          )
+          if (_c !== null) yield _c
+        }
       }
     }
 
@@ -277,22 +302,28 @@ export async function* transformKiroStream(
       inputTokens = Math.max(0, totalTokens - outputTokens)
     }
 
-    yield convertToOpenAI(
-      {
-        type: 'message_delta',
-        delta: { stop_reason: toolCalls.length > 0 ? 'tool_use' : 'end_turn' },
-        usage: {
-          input_tokens: inputTokens,
-          output_tokens: outputTokens,
-          cache_creation_input_tokens: 0,
-          cache_read_input_tokens: 0
-        }
-      },
-      conversationId,
-      model
-    )
+    {
+      const _c = convertToOpenAI(
+        {
+          type: 'message_delta',
+          delta: { stop_reason: toolCalls.length > 0 ? 'tool_use' : 'end_turn' },
+          usage: {
+            input_tokens: inputTokens,
+            output_tokens: outputTokens,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0
+          }
+        },
+        conversationId,
+        model
+      )
+      if (_c !== null) yield _c
+    }
 
-    yield convertToOpenAI({ type: 'message_stop' }, conversationId, model)
+    {
+      const _c = convertToOpenAI({ type: 'message_stop' }, conversationId, model)
+      if (_c !== null) yield _c
+    }
   } finally {
     reader.releaseLock()
   }


### PR DESCRIPTION
- **Provider ID mismatch** — plugin registered as `kiro-auth` but config uses `kiro`; OpenCode silently skipped the auth loader entirely
- **`undefined/chat/completions` URL error** — OpenCode ≥1.15 reads `model.api.url` before `options.baseURL`; field was empty for custom providers, fixed by setting `provider.api` in the config hook
- **Auth loader never called** — OpenCode skips the loader if no `auth.json` entry exists; added auto-bootstrap to write a placeholder on first run
- **Streaming returning no output** — stream transformers were emitting Anthropic-protocol events with empty `choices` arrays; `@ai-sdk/openai-compatible` treated the stream as empty, fixed by filtering unmappable events
- **Model list out of date** — added `glm-5` and `claude-opus-4-7`, corrected Sonnet 4.6 and Opus 4.6 context limits from 200K to 1M

Bump to version `1.11.0` and fix #76 