### PR TITLE
feat: add Claude Opus 4.8 model mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,21 @@ Add the plugin to your `opencode.json` or `opencode.jsonc`:
             "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
           }
         },
+        "claude-opus-4-8": {
+          "name": "Claude Opus 4.8",
+          "limit": { "context": 1000000, "output": 64000 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
+        },
+        "claude-opus-4-8-thinking": {
+          "name": "Claude Opus 4.8 Thinking",
+          "limit": { "context": 1000000, "output": 64000 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+          "variants": {
+            "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
+            "medium": { "thinkingConfig": { "thinkingBudget": 16384 } },
+            "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
+          }
+        },
         "claude-sonnet-4-5-1m": {
           "name": "Claude Sonnet 4.5 (1M Context)",
           "limit": { "context": 1000000, "output": 64000 },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -72,6 +72,8 @@ export const MODEL_MAPPING: Record<string, string> = {
   'claude-opus-4-6-1m-thinking': 'claude-opus-4.6-1m',
   'claude-opus-4-7': 'claude-opus-4.7',
   'claude-opus-4-7-thinking': 'claude-opus-4.7',
+  'claude-opus-4-8': 'claude-opus-4.8',
+  'claude-opus-4-8-thinking': 'claude-opus-4.8',
   // Auto
   auto: 'auto',
   // Open weight models

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -97,6 +97,11 @@ export const createKiroPlugin =
               limit: { context: 1000000, output: 64000 },
               modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
             },
+            'claude-opus-4-8': {
+              name: 'Claude Opus 4.8 (2.2x)',
+              limit: { context: 1000000, output: 64000 },
+              modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
+            },
             // Open weight models
             'deepseek-3.2': {
               name: 'DeepSeek 3.2 (0.25x)',


### PR DESCRIPTION
## Summary
- Add `claude-opus-4-8` and `claude-opus-4-8-thinking` to `MODEL_MAPPING` in `src/constants.ts`, mirroring the existing 4-7 entries.
- Register the base `claude-opus-4-8` model (1M context, 64K output) in the `provider.models` config hook in `src/plugin.ts`.
- Document `claude-opus-4-8` and `claude-opus-4-8-thinking` (with thinking variants) in `README.md`.

Per the Kiro changelog (May 29, 2026), Opus 4.8 ships with a 1M context window, 128K max output, and a 2.2x credit multiplier. The plugin's mapping previously stopped at 4-7, so requests for 4-8 were rejected by `resolveKiroModel` before reaching the backend.

The issue author confirmed the `claude-opus-4-8` -> `claude-opus-4.8` mapping works end to end against v1.11.0.

Closes #98

## Test plan
- [x] `bun test` — 15/15 pass
- [x] `bun run typecheck` — clean
- [ ] Manual verification: select `claude-opus-4-8` in OpenCode and confirm requests succeed