### PR TITLE
feat: add auto-thinking model, and add thinking model variants to default model list

### DIFF
--- a/src/__tests__/model-resolution.test.ts
+++ b/src/__tests__/model-resolution.test.ts
@@ -5,6 +5,7 @@ import { resolveKiroModel } from '../plugin/models.js'
 describe('resolveKiroModel', () => {
   test('resolves newly advertised model slugs', () => {
     expect(resolveKiroModel('auto')).toBe('auto')
+    expect(resolveKiroModel('auto-thinking')).toBe('auto')
     expect(resolveKiroModel('deepseek-3.2')).toBe('deepseek-3.2')
     expect(resolveKiroModel('minimax-m2.5')).toBe('minimax-m2.5')
     expect(resolveKiroModel('minimax-m2.1')).toBe('minimax-m2.1')

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -74,6 +74,7 @@ export const MODEL_MAPPING: Record<string, string> = {
   'claude-opus-4-7-thinking': 'claude-opus-4.7',
   // Auto
   auto: 'auto',
+  'auto-thinking': 'auto',
   // Open weight models
   'deepseek-3.2': 'deepseek-3.2',
   'glm-5': 'glm-5',

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -59,6 +59,12 @@ export const createKiroPlugin =
               limit: { context: 200000, output: 64000 },
               modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
             },
+            'auto-thinking': {
+              name: 'Auto Thinking (1.0x)',
+              reasoning: true,
+              limit: { context: 200000, output: 64000 },
+              modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
+            },
             // Claude Sonnet
             'claude-sonnet-4': {
               name: 'Claude Sonnet 4.0 (1.3x)',
@@ -70,8 +76,20 @@ export const createKiroPlugin =
               limit: { context: 200000, output: 64000 },
               modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
             },
+            'claude-sonnet-4-5-thinking': {
+              name: 'Claude Sonnet 4.5 Thinking (1.3x)',
+              reasoning: true,
+              limit: { context: 200000, output: 64000 },
+              modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
+            },
             'claude-sonnet-4-6': {
               name: 'Claude Sonnet 4.6 (1.3x)',
+              limit: { context: 1000000, output: 64000 },
+              modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
+            },
+            'claude-sonnet-4-6-thinking': {
+              name: 'Claude Sonnet 4.6 Thinking (1.3x)',
+              reasoning: true,
               limit: { context: 1000000, output: 64000 },
               modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
             },
@@ -81,9 +99,21 @@ export const createKiroPlugin =
               limit: { context: 200000, output: 64000 },
               modalities: { input: ['text', 'image'], output: ['text'] }
             },
+            'claude-haiku-4-5-thinking': {
+              name: 'Claude Haiku 4.5 Thinking (0.4x)',
+              reasoning: true,
+              limit: { context: 200000, output: 64000 },
+              modalities: { input: ['text', 'image'], output: ['text'] }
+            },
             // Claude Opus
             'claude-opus-4-5': {
               name: 'Claude Opus 4.5 (2.2x)',
+              limit: { context: 200000, output: 64000 },
+              modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
+            },
+            'claude-opus-4-5-thinking': {
+              name: 'Claude Opus 4.5 Thinking (2.2x)',
+              reasoning: true,
               limit: { context: 200000, output: 64000 },
               modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
             },
@@ -92,8 +122,20 @@ export const createKiroPlugin =
               limit: { context: 1000000, output: 64000 },
               modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
             },
+            'claude-opus-4-6-thinking': {
+              name: 'Claude Opus 4.6 Thinking (2.2x)',
+              reasoning: true,
+              limit: { context: 1000000, output: 64000 },
+              modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
+            },
             'claude-opus-4-7': {
               name: 'Claude Opus 4.7 (2.2x)',
+              limit: { context: 1000000, output: 64000 },
+              modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
+            },
+            'claude-opus-4-7-thinking': {
+              name: 'Claude Opus 4.7 Thinking (2.2x)',
+              reasoning: true,
               limit: { context: 1000000, output: 64000 },
               modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
             },


### PR DESCRIPTION
## Problem

The `-thinking` suffixed models are supported in MODEL_MAPPING (e.g. claude-sonnet-4-6-thinking → claude-sonnet-4.6), and the request handler correctly detects the suffix to inject `<thinking_mode>enabled</thinking_mode>`. 

However:

1. `auto-thinking` was missing from MODEL_MAPPING, so selecting it threw Unsupported model
1. None of the `-thinking` variants appeared in the default model list in `plugin.ts`, so opencode didn't expose them in the model picker unless users manually registered them in opencode.json with `reasoning: true`

## Solution

- `src/constants.ts` — add 'auto-thinking': 'auto' to MODEL_MAPPING
- `src/plugin.ts` — add all -thinking variants to the default model list with reasoning: true
- `src/__tests__/model-resolution.test.ts` — add test for auto-thinking resolution

## Verification
- `bun run typecheck`
- `bun run build`
- `bun test`
- Confirmed kiro/auto-thinking resolves and produces thinking output in opencode.