### PR TITLE
Fix stale Kiro CLI account sync and add Opus 4.8

### DIFF
--- a/src/__tests__/kiro-cli-sync.test.ts
+++ b/src/__tests__/kiro-cli-sync.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'bun:test'
+import { mergeAccounts } from '../plugin/storage/locked-operations.js'
+import { getStaleKiroCliAccountIds } from '../plugin/sync/stale-accounts.js'
+import type { ManagedAccount } from '../plugin/types.js'
+
+function account(overrides: Partial<ManagedAccount> = {}): ManagedAccount {
+  return {
+    id: 'account-id',
+    email: 'user@example.com',
+    authMethod: 'idc',
+    region: 'us-east-1',
+    clientId: 'client-current',
+    clientSecret: 'secret',
+    profileArn: 'arn:aws:codewhisperer:us-east-1:123:profile/current',
+    refreshToken: 'refresh',
+    accessToken: 'access',
+    expiresAt: Date.now() + 3600000,
+    rateLimitResetTime: 0,
+    isHealthy: true,
+    failCount: 0,
+    ...overrides
+  }
+}
+
+describe('Kiro CLI account sync', () => {
+  test('healthy CLI credentials recover an account with a previous permanent refresh error', () => {
+    const existing = account({
+      isHealthy: false,
+      failCount: 10,
+      unhealthyReason: 'Refresh failed: HTTP_401',
+      recoveryTime: Date.now() + 3600000,
+      accessToken: 'stale-access'
+    })
+
+    const incoming = account({
+      accessToken: 'fresh-access',
+      isHealthy: true,
+      failCount: 0,
+      unhealthyReason: undefined,
+      recoveryTime: undefined
+    })
+
+    const merged = mergeAccounts([existing], [incoming])[0]!
+
+    expect(merged.isHealthy).toBe(true)
+    expect(merged.failCount).toBe(0)
+    expect(merged.unhealthyReason).toBeUndefined()
+    expect(merged.recoveryTime).toBeUndefined()
+    expect(merged.accessToken).toBe('fresh-access')
+  })
+
+  test('deactivates stale cached CLI account variants after a successful CLI import', () => {
+    const synced = {
+      id: 'current-id',
+      email: 'user@example.com',
+      authMethod: 'idc' as const,
+      clientId: 'client-current',
+      profileArn: 'arn:aws:codewhisperer:us-east-1:123:profile/current'
+    }
+
+    const staleSameProfile = {
+      id: 'old-id',
+      email: 'user@example.com',
+      auth_method: 'idc',
+      client_id: 'client-old',
+      profile_arn: synced.profileArn,
+      last_sync: Date.now() - 1000
+    }
+    const stalePreviouslySynced = {
+      id: 'old-cli-synced-id',
+      email: 'old@example.com',
+      auth_method: 'idc',
+      client_id: 'client-old-2',
+      profile_arn: 'arn:aws:codewhisperer:us-east-1:123:profile/old',
+      last_sync: Date.now() - 1000
+    }
+    const manualOtherAccount = {
+      id: 'manual-id',
+      email: 'other@example.com',
+      auth_method: 'desktop',
+      client_id: 'manual-client',
+      profile_arn: 'arn:aws:codewhisperer:us-east-1:123:profile/manual',
+      last_sync: 0
+    }
+
+    expect(
+      getStaleKiroCliAccountIds(
+        [synced, staleSameProfile, stalePreviouslySynced, manualOtherAccount],
+        [synced]
+      )
+    ).toEqual(['old-id', 'old-cli-synced-id'])
+  })
+})

--- a/src/__tests__/model-resolution.test.ts
+++ b/src/__tests__/model-resolution.test.ts
@@ -14,6 +14,8 @@ describe('resolveKiroModel', () => {
   test('keeps existing supported Claude slugs intact', () => {
     expect(resolveKiroModel('claude-sonnet-4-5')).toBe('claude-sonnet-4.5')
     expect(resolveKiroModel('claude-sonnet-4')).toBe('claude-sonnet-4')
+    expect(resolveKiroModel('claude-opus-4-8')).toBe('claude-opus-4.8')
+    expect(resolveKiroModel('claude-opus-4-8-thinking')).toBe('claude-opus-4.8')
   })
 
   test('rejects removed qwen3-coder-480b slug', () => {

--- a/src/__tests__/sdk-client.test.ts
+++ b/src/__tests__/sdk-client.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test'
+import { clearSdkClientCache, createSdkClient } from '../plugin/sdk-client'
+import type { KiroAuthDetails } from '../plugin/types'
+
+function auth(): KiroAuthDetails {
+  return {
+    refresh: 'refresh-token',
+    access: 'access-token',
+    expires: Date.now() + 3600000,
+    authMethod: 'idc',
+    region: 'us-east-1',
+    email: 'user@example.com'
+  }
+}
+
+describe('SDK client', () => {
+  test('uses Kiro CLI-style standard SDK retries for throttling', async () => {
+    clearSdkClientCache()
+
+    const client = createSdkClient(auth(), 'us-east-1')
+
+    expect(await client.config.maxAttempts()).toBe(3)
+    const retryMode = client.config.retryMode
+    expect(typeof retryMode === 'function' ? await retryMode() : retryMode).toBe('standard')
+
+    clearSdkClientCache()
+  })
+})

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -72,6 +72,8 @@ export const MODEL_MAPPING: Record<string, string> = {
   'claude-opus-4-6-1m-thinking': 'claude-opus-4.6-1m',
   'claude-opus-4-7': 'claude-opus-4.7',
   'claude-opus-4-7-thinking': 'claude-opus-4.7',
+  'claude-opus-4-8': 'claude-opus-4.8',
+  'claude-opus-4-8-thinking': 'claude-opus-4.8',
   // Auto
   auto: 'auto',
   // Open weight models

--- a/src/core/request/request-handler.ts
+++ b/src/core/request/request-handler.ts
@@ -29,6 +29,7 @@ export class RequestHandler {
   private retryStrategy: RetryStrategy
   private reauthInFlight: Promise<boolean> | null = null
   private lastFailedReauthAt = 0
+  private static kiroRequestQueue: Promise<void> = Promise.resolve()
 
   constructor(
     private accountManager: AccountManager,
@@ -51,7 +52,24 @@ export class RequestHandler {
       return fetch(input, init)
     }
 
-    return this.handleKiroRequest(url, init, showToast)
+    return this.enqueueKiroRequest(() => this.handleKiroRequest(url, init, showToast))
+  }
+
+  private async enqueueKiroRequest<T>(run: () => Promise<T>): Promise<T> {
+    const previous = RequestHandler.kiroRequestQueue
+    let release!: () => void
+
+    RequestHandler.kiroRequestQueue = new Promise((resolve) => {
+      release = resolve
+    })
+
+    await previous.catch(() => {})
+
+    try {
+      return await run()
+    } finally {
+      release()
+    }
   }
 
   private async handleKiroRequest(

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -97,6 +97,16 @@ export const createKiroPlugin =
               limit: { context: 1000000, output: 64000 },
               modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
             },
+            'claude-opus-4-8': {
+              name: 'Claude Opus 4.8 (2.2x)',
+              limit: { context: 1000000, output: 64000 },
+              modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
+            },
+            'claude-opus-4-8-thinking': {
+              name: 'Claude Opus 4.8 Thinking (2.2x)',
+              limit: { context: 1000000, output: 64000 },
+              modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
+            },
             // Open weight models
             'deepseek-3.2': {
               name: 'DeepSeek 3.2 (0.25x)',

--- a/src/plugin/sdk-client.ts
+++ b/src/plugin/sdk-client.ts
@@ -3,6 +3,7 @@ import { KIRO_CONSTANTS } from '../constants.js'
 import type { KiroAuthDetails } from './types'
 
 const clientCache = new Map<string, { client: CodeWhispererStreamingClient; token: string }>()
+const KIRO_CLI_MAX_ATTEMPTS = 3
 
 export function createSdkClient(
   auth: KiroAuthDetails,
@@ -20,7 +21,8 @@ export function createSdkClient(
     region,
     endpoint: `https://q.${region}.amazonaws.com`,
     token: () => Promise.resolve({ token }),
-    maxAttempts: 1,
+    maxAttempts: KIRO_CLI_MAX_ATTEMPTS,
+    retryMode: 'standard',
     customUserAgent: [[KIRO_CONSTANTS.USER_AGENT]]
   })
 

--- a/src/plugin/storage/locked-operations.ts
+++ b/src/plugin/storage/locked-operations.ts
@@ -63,8 +63,10 @@ export function mergeAccounts(
     const existingAcc = accountMap.get(acc.id)
 
     if (existingAcc) {
+      const incomingHasPermanentError = isPermanentError(acc.unhealthyReason)
       const hasPermanentError =
-        isPermanentError(existingAcc.unhealthyReason) || isPermanentError(acc.unhealthyReason)
+        isPermanentError(existingAcc.unhealthyReason) || incomingHasPermanentError
+      const incomingRecovered = acc.isHealthy && !incomingHasPermanentError
 
       accountMap.set(acc.id, {
         ...existingAcc,
@@ -76,8 +78,18 @@ export function mergeAccounts(
           existingAcc.rateLimitResetTime || 0,
           acc.rateLimitResetTime || 0
         ),
-        isHealthy: hasPermanentError ? false : existingAcc.isHealthy || acc.isHealthy,
-        failCount: Math.max(existingAcc.failCount || 0, acc.failCount || 0),
+        isHealthy: incomingRecovered
+          ? true
+          : hasPermanentError
+            ? false
+            : existingAcc.isHealthy || acc.isHealthy,
+        unhealthyReason: incomingRecovered
+          ? undefined
+          : acc.unhealthyReason || existingAcc.unhealthyReason,
+        recoveryTime: incomingRecovered ? undefined : acc.recoveryTime || existingAcc.recoveryTime,
+        failCount: incomingRecovered
+          ? acc.failCount || 0
+          : Math.max(existingAcc.failCount || 0, acc.failCount || 0),
         lastSync: Math.max(existingAcc.lastSync || 0, acc.lastSync || 0)
       })
     } else {

--- a/src/plugin/storage/sqlite.ts
+++ b/src/plugin/storage/sqlite.ts
@@ -137,6 +137,39 @@ export class KiroDatabase {
     })
   }
 
+  async markAccountsUnhealthy(ids: string[], reason: string): Promise<void> {
+    if (ids.length === 0) return
+
+    await withDatabaseLock(this.path, async () => {
+      const now = Date.now()
+
+      this.db.run('BEGIN TRANSACTION')
+      try {
+        const stmt = this.db.prepare(
+          `
+            UPDATE accounts
+            SET is_healthy = 0,
+                unhealthy_reason = ?,
+                recovery_time = NULL,
+                fail_count = 10,
+                rate_limit_reset = 0,
+                last_sync = ?
+            WHERE id = ?
+          `
+        )
+
+        for (const id of ids) {
+          stmt.run(reason, now, id)
+        }
+
+        this.db.run('COMMIT')
+      } catch (e) {
+        this.db.run('ROLLBACK')
+        throw e
+      }
+    })
+  }
+
   private rowToAccount(row: any): ManagedAccount {
     return {
       id: row.id,

--- a/src/plugin/sync/kiro-cli.ts
+++ b/src/plugin/sync/kiro-cli.ts
@@ -13,6 +13,11 @@ import {
   safeJsonParse
 } from './kiro-cli-parser'
 import { readActiveProfileArnFromKiroCli } from './kiro-cli-profile'
+import {
+  getStaleKiroCliAccountIds,
+  STALE_CLI_ACCOUNT_REASON,
+  type SyncedCliAccount
+} from './stale-accounts'
 
 export async function syncFromKiroCli() {
   const dbPath = getCliDbPath()
@@ -38,6 +43,7 @@ export async function syncFromKiroCli() {
     )
     const deviceReg = safeJsonParse(deviceRegRow?.value)
     const regCreds = deviceReg ? findClientCredsRecursive(deviceReg) : {}
+    const syncedAccounts: SyncedCliAccount[] = []
 
     for (const row of rows) {
       if (row.key.includes(':token')) {
@@ -196,8 +202,23 @@ export async function syncFromKiroCli() {
           limitCount,
           lastSync: Date.now()
         })
+
+        syncedAccounts.push({
+          id,
+          email: resolvedEmail,
+          authMethod,
+          clientId,
+          profileArn
+        })
       }
     }
+
+    const staleIds = getStaleKiroCliAccountIds(kiroDb.getAccounts(), syncedAccounts)
+    if (staleIds.length > 0) {
+      await kiroDb.markAccountsUnhealthy(staleIds, STALE_CLI_ACCOUNT_REASON)
+      logger.warn('Kiro CLI sync: deactivated stale cached accounts', { count: staleIds.length })
+    }
+
     cliDb.close()
   } catch (e) {
     logger.error('Sync failed', e)

--- a/src/plugin/sync/stale-accounts.ts
+++ b/src/plugin/sync/stale-accounts.ts
@@ -1,0 +1,46 @@
+import { isPermanentError } from '../health'
+
+export type SyncedCliAccount = {
+  id: string
+  email: string
+  authMethod: 'idc' | 'desktop'
+  clientId?: string
+  profileArn?: string
+}
+
+export const STALE_CLI_ACCOUNT_REASON =
+  'InvalidTokenException: Replaced by active Kiro CLI account during sync'
+
+export function getStaleKiroCliAccountIds(
+  accounts: any[],
+  syncedAccounts: SyncedCliAccount[]
+): string[] {
+  if (syncedAccounts.length === 0) return []
+
+  const syncedIds = new Set(syncedAccounts.map((acc) => acc.id))
+
+  return accounts
+    .filter((account) => {
+      if (!account?.id || syncedIds.has(account.id)) return false
+
+      const authMethod = account.auth_method || account.authMethod
+      const email = account.email
+      const clientId = account.client_id || account.clientId
+      const profileArn = account.profile_arn || account.profileArn
+      const lastSync = account.last_sync || account.lastSync || 0
+      const unhealthyReason = account.unhealthy_reason || account.unhealthyReason
+
+      return syncedAccounts.some((synced) => {
+        const sameAuthMethod = authMethod === synced.authMethod
+        const sameEmail = !!email && email === synced.email
+        const sameClient = !!clientId && clientId === synced.clientId
+        const sameProfile = !!profileArn && profileArn === synced.profileArn
+        const sameIdentity = sameEmail || sameClient || sameProfile
+
+        if (sameAuthMethod && sameIdentity) return true
+        if (sameAuthMethod && lastSync > 0) return true
+        return isPermanentError(unhealthyReason) && sameIdentity
+      })
+    })
+    .map((account) => account.id)
+}


### PR DESCRIPTION
## Summary
- let healthy Kiro CLI imports recover accounts that were previously marked permanently unhealthy
- deactivate stale cached Kiro CLI account variants after a successful CLI sync so old refresh tokens are not selected again
- add Claude Opus 4.8 and Opus 4.8 Thinking model mappings/provider entries

## Tests
- bun test --reporter=junit --reporter-outfile=/tmp/opencode-kiro-auth-junit.xml (17 tests, 63 assertions, 0 failures)
- npm run typecheck
- npm run build