### PR TITLE
feat: add configurable thinking budget with variant support

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,14 @@ Edit `~/.config/opencode/kiro.json`:
   "token_expiry_buffer_ms": 120000,
   "usage_sync_max_retries": 3,
   "usage_tracking_enabled": true,
-  "enable_log_api_request": false
+  "enable_log_api_request": false,
+  "default_thinking_budget": 20000,
+  "thinking_budgets": {
+    "low": 8192,
+    "medium": 16384,
+    "high": 24576,
+    "max": 32768
+  }
 }
 ```
 
@@ -319,6 +326,11 @@ Edit `~/.config/opencode/kiro.json`:
 - `auth_server_port_range`: Legacy/ignored (no local auth server).
 - `usage_tracking_enabled`: Enable usage tracking and toast notifications.
 - `enable_log_api_request`: Enable detailed API request logging.
+- `default_thinking_budget`: Default thinking token budget for thinking models when no
+  variant is specified (default: `20000`).
+- `thinking_budgets`: Per-variant thinking budgets. Maps OpenCode's `reasoningEffort`
+  variants to token budgets. Defaults: `low: 8192`, `medium: 16384`, `high: 24576`,
+  `max: 32768`.
 
 ## Storage
 

--- a/src/core/request/request-handler.ts
+++ b/src/core/request/request-handler.ts
@@ -80,7 +80,7 @@ export class RequestHandler {
     const body = init?.body ? JSON.parse(init.body) : {}
     const model = this.extractModel(url) || body.model || 'claude-sonnet-4-5'
     const think = model.endsWith('-thinking') || !!body.providerOptions?.thinkingConfig
-    const budget = body.providerOptions?.thinkingConfig?.thinkingBudget || 20000
+    const budget = this.resolveThinkingBudget(body)
 
     let retry = 0
     let consecutiveNullAccounts = 0
@@ -209,6 +209,34 @@ export class RequestHandler {
 
   private extractModel(url: string): string | null {
     return url.match(/models\/([^/:]+)/)?.[1] || null
+  }
+
+  /**
+   * Resolves the thinking budget from multiple sources in priority order:
+   * 1. Explicit thinkingConfig.thinkingBudget from providerOptions (if passed by OpenCode)
+   * 2. Mapped from reasoningEffort variant (low/medium/high/max) using config values
+   * 3. Default thinking budget from config
+   */
+  private resolveThinkingBudget(body: any): number {
+    // Priority 1: Explicit thinkingBudget from providerOptions
+    const explicitBudget = body.providerOptions?.thinkingConfig?.thinkingBudget
+    if (typeof explicitBudget === 'number' && explicitBudget > 0) {
+      return explicitBudget
+    }
+
+    // Priority 2: Map reasoningEffort variant to thinking budget
+    // OpenCode sends reasoningEffort for @ai-sdk/openai-compatible providers
+    const reasoningEffort = body.providerOptions?.reasoningEffort
+    if (reasoningEffort && this.config.thinking_budgets) {
+      const budgets = this.config.thinking_budgets
+      const effort = reasoningEffort.toLowerCase()
+      if (effort in budgets) {
+        return budgets[effort as keyof typeof budgets]
+      }
+    }
+
+    // Priority 3: Default from config
+    return this.config.default_thinking_budget ?? 20000
   }
 
   private prepareSdkRequest(

--- a/src/plugin/config/schema.ts
+++ b/src/plugin/config/schema.ts
@@ -41,6 +41,15 @@ export const RegionSchema = z.enum([
 ])
 export type Region = z.infer<typeof RegionSchema>
 
+// Thinking budget configuration schema for named variants
+export const ThinkingBudgetConfigSchema = z.object({
+  low: z.number().min(1024).max(128000).default(8192),
+  medium: z.number().min(1024).max(128000).default(16384),
+  high: z.number().min(1024).max(128000).default(24576),
+  max: z.number().min(1024).max(128000).default(32768)
+})
+export type ThinkingBudgetConfig = z.infer<typeof ThinkingBudgetConfigSchema>
+
 export const KiroConfigSchema = z.object({
   $schema: z.string().optional(),
 
@@ -70,7 +79,20 @@ export const KiroConfigSchema = z.object({
 
   usage_tracking_enabled: z.boolean().default(true),
   auto_sync_kiro_cli: z.boolean().default(true),
-  enable_log_api_request: z.boolean().default(false)
+  enable_log_api_request: z.boolean().default(false),
+
+  // Thinking budget configuration
+  // Default budget used when no variant is specified or detected from providerOptions
+  default_thinking_budget: z.number().min(1024).max(128000).default(20000),
+
+  // Per-variant thinking budgets, mapped from providerOptions.reasoningEffort
+  // These match OpenCode's variant names (low, medium, high, max)
+  thinking_budgets: ThinkingBudgetConfigSchema.default({
+    low: 8192,
+    medium: 16384,
+    high: 24576,
+    max: 32768
+  })
 })
 
 export type KiroConfig = z.infer<typeof KiroConfigSchema>
@@ -88,5 +110,12 @@ export const DEFAULT_CONFIG: KiroConfig = {
   auth_server_port_range: 10,
   usage_tracking_enabled: true,
   auto_sync_kiro_cli: true,
-  enable_log_api_request: false
+  enable_log_api_request: false,
+  default_thinking_budget: 20000,
+  thinking_budgets: {
+    low: 8192,
+    medium: 16384,
+    high: 24576,
+    max: 32768
+  }
 }


### PR DESCRIPTION
## Summary

Add support for configuring thinking token budgets via `kiro.json`, fixing the issue where OpenCode's variant selection (low/medium/high/max) had no effect on the actual thinking budget.

## Problem

Currently, the thinking budget is hardcoded to 20000 tokens:

```ts
const budget = body.providerOptions?.thinkingConfig?.thinkingBudget || 20000;
```

OpenCode's variant system for `@ai-sdk/openai-compatible` providers maps variants to `reasoningEffort` (a string like "low", "medium", "high", "max"), not `thinkingConfig.thinkingBudget`. This means the plugin never receives the budget value configured in opencode.json variants, and users always get 20k thinking tokens regardless of their variant selection.

## Solution

Add two new configuration options to `kiro.json`:

- `default_thinking_budget`: Fallback budget when no variant is specified (default: 20000)
- `thinking_budgets`: Per-variant budgets mapped from OpenCode's `reasoningEffort`:
  - `low`: 8192
  - `medium`: 16384
  - `high`: 24576
  - `max`: 32768

The plugin now resolves thinking budget in priority order:
1. Explicit `thinkingConfig.thinkingBudget` from providerOptions (backward compatible)
2. Mapped from `reasoningEffort` variant using configured budgets
3. Default thinking budget from config

## Example Configuration

```json
{
  "default_thinking_budget": 20000,
  "thinking_budgets": {
    "low": 8192,
    "medium": 16384,
    "high": 24576,
    "max": 32768
  }
}
```

## Changes

- `src/plugin/config/schema.ts`: Added `ThinkingBudgetConfigSchema`, `default_thinking_budget`, and `thinking_budgets` config options
- `src/core/request/request-handler.ts`: Added `resolveThinkingBudget()` method with priority-based resolution
- `README.md`: Documented the new configuration options