### PR TITLE
feat: add configurable effort levels for thinking budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ models with substantial trial quotas.
   SQLite.
 - **Native Thinking Mode**: Full support for Claude reasoning capabilities via virtual
   model mappings.
+- **Kiro Effort Mapping**: Maps OpenCode thinking budgets to Kiro's native effort
+  levels automatically.
 - **Automated Recovery**: Exponential backoff for rate limits and automated token
   refresh.
 
@@ -46,6 +48,7 @@ Add the plugin to your `opencode.json` or `opencode.jsonc`:
           "variants": {
             "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
             "medium": { "thinkingConfig": { "thinkingBudget": 16384 } },
+            "high": { "thinkingConfig": { "thinkingBudget": 24576 } },
             "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
           }
         },
@@ -61,6 +64,7 @@ Add the plugin to your `opencode.json` or `opencode.jsonc`:
           "variants": {
             "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
             "medium": { "thinkingConfig": { "thinkingBudget": 16384 } },
+            "high": { "thinkingConfig": { "thinkingBudget": 24576 } },
             "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
           }
         },
@@ -81,6 +85,7 @@ Add the plugin to your `opencode.json` or `opencode.jsonc`:
           "variants": {
             "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
             "medium": { "thinkingConfig": { "thinkingBudget": 16384 } },
+            "high": { "thinkingConfig": { "thinkingBudget": 24576 } },
             "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
           }
         },
@@ -96,6 +101,7 @@ Add the plugin to your `opencode.json` or `opencode.jsonc`:
           "variants": {
             "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
             "medium": { "thinkingConfig": { "thinkingBudget": 16384 } },
+            "high": { "thinkingConfig": { "thinkingBudget": 24576 } },
             "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
           }
         },
@@ -111,6 +117,7 @@ Add the plugin to your `opencode.json` or `opencode.jsonc`:
           "variants": {
             "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
             "medium": { "thinkingConfig": { "thinkingBudget": 16384 } },
+            "high": { "thinkingConfig": { "thinkingBudget": 24576 } },
             "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
           }
         },
@@ -126,6 +133,7 @@ Add the plugin to your `opencode.json` or `opencode.jsonc`:
           "variants": {
             "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
             "medium": { "thinkingConfig": { "thinkingBudget": 16384 } },
+            "high": { "thinkingConfig": { "thinkingBudget": 24576 } },
             "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
           }
         },
@@ -146,6 +154,7 @@ Add the plugin to your `opencode.json` or `opencode.jsonc`:
           "variants": {
             "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
             "medium": { "thinkingConfig": { "thinkingBudget": 16384 } },
+            "high": { "thinkingConfig": { "thinkingBudget": 24576 } },
             "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
           }
         },
@@ -176,6 +185,48 @@ Add the plugin to your `opencode.json` or `opencode.jsonc`:
   }
 }
 ```
+
+### Thinking Effort Configuration
+
+Configure Kiro effort per model in your OpenCode provider model definitions by setting
+`thinkingConfig.thinkingBudget` on each model variant. The plugin automatically maps
+those budgets to Kiro's native `effort` field for supported Claude models, so you do
+not need to hardcode a global `effort` value in `~/.config/opencode/kiro.json`.
+
+```json
+{
+  "provider": {
+    "kiro": {
+      "models": {
+        "claude-opus-4-7-thinking": {
+          "name": "Claude Opus 4.7 Thinking",
+          "limit": { "context": 1000000, "output": 64000 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+          "variants": {
+            "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
+            "medium": { "thinkingConfig": { "thinkingBudget": 16384 } },
+            "high": { "thinkingConfig": { "thinkingBudget": 24576 } },
+            "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Budget mapping:
+
+| OpenCode budget | Kiro effort |
+| --------------- | ----------- |
+| `<= 10000` | `low` |
+| `<= 20000` | `medium` |
+| `<= 28000` | `high` |
+| `> 28000` | `max` |
+
+Use `~/.config/opencode/kiro.json` for plugin-wide behavior such as auth sync,
+account selection, retry limits, and `auto_effort_mapping`. A top-level `effort`
+setting is a global override for all supported models, not a per-model setting.
 
 ## Setup
 
@@ -294,6 +345,7 @@ Edit `~/.config/opencode/kiro.json`:
   "token_expiry_buffer_ms": 120000,
   "usage_sync_max_retries": 3,
   "usage_tracking_enabled": true,
+  "auto_effort_mapping": true,
   "enable_log_api_request": false
 }
 ```
@@ -318,6 +370,8 @@ Edit `~/.config/opencode/kiro.json`:
 - `auth_server_port_start`: Legacy/ignored (no local auth server).
 - `auth_server_port_range`: Legacy/ignored (no local auth server).
 - `usage_tracking_enabled`: Enable usage tracking and toast notifications.
+- `auto_effort_mapping`: Automatically map OpenCode thinking budgets to Kiro effort
+  levels for supported models (default: `true`).
 - `enable_log_api_request`: Enable detailed API request logging.
 
 ## Storage

--- a/package-lock.json
+++ b/package-lock.json
@@ -2021,6 +2021,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2251,6 +2252,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/__tests__/effort.test.ts
+++ b/src/__tests__/effort.test.ts
@@ -58,10 +58,10 @@ describe('effort module', () => {
 
     test('maps budget ranges correctly', () => {
       expect(budgetToEffort(5000, 'claude-opus-4.8')).toBe('low')
-      expect(budgetToEffort(20000, 'claude-opus-4.8')).toBe('medium')
-      expect(budgetToEffort(50000, 'claude-opus-4.8')).toBe('high')
-      expect(budgetToEffort(80000, 'claude-opus-4.8')).toBe('xhigh')
-      expect(budgetToEffort(128000, 'claude-opus-4.8')).toBe('max')
+      expect(budgetToEffort(16384, 'claude-opus-4.8')).toBe('medium')
+      expect(budgetToEffort(24576, 'claude-opus-4.8')).toBe('high')
+      expect(budgetToEffort(32768, 'claude-opus-4.8')).toBe('max')
+      expect(budgetToEffort(80000, 'claude-opus-4.8')).toBe('max')
     })
 
     test('maps to max instead of xhigh for non-xhigh models', () => {

--- a/src/__tests__/effort.test.ts
+++ b/src/__tests__/effort.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  budgetToEffort,
+  getEffectiveEffort,
+  resolveEffort,
+  supportsEffort,
+  supportsXHighEffort
+} from '../plugin/effort.js'
+
+describe('effort module', () => {
+  describe('supportsEffort', () => {
+    test('returns true for supported models', () => {
+      expect(supportsEffort('claude-opus-4.8')).toBe(true)
+      expect(supportsEffort('claude-opus-4.7')).toBe(true)
+      expect(supportsEffort('claude-sonnet-4.6')).toBe(true)
+      expect(supportsEffort('claude-sonnet-4.6-1m')).toBe(true)
+    })
+
+    test('returns false for unsupported models', () => {
+      expect(supportsEffort('claude-haiku-4.5')).toBe(false)
+      expect(supportsEffort('unknown-model')).toBe(false)
+    })
+  })
+
+  describe('supportsXHighEffort', () => {
+    test('returns true for opus 4.7 and 4.8', () => {
+      expect(supportsXHighEffort('claude-opus-4.8')).toBe(true)
+      expect(supportsXHighEffort('claude-opus-4.7')).toBe(true)
+    })
+
+    test('returns false for other models', () => {
+      expect(supportsXHighEffort('claude-opus-4.6')).toBe(false)
+      expect(supportsXHighEffort('claude-sonnet-4.6')).toBe(false)
+    })
+  })
+
+  describe('resolveEffort', () => {
+    test('returns undefined for unsupported models', () => {
+      expect(resolveEffort('claude-haiku-4.5', 'max')).toBeUndefined()
+    })
+
+    test('returns effort as-is for supported levels', () => {
+      expect(resolveEffort('claude-opus-4.8', 'low')).toBe('low')
+      expect(resolveEffort('claude-opus-4.8', 'max')).toBe('max')
+      expect(resolveEffort('claude-opus-4.8', 'xhigh')).toBe('xhigh')
+    })
+
+    test('clamps xhigh to max for models without xhigh support', () => {
+      expect(resolveEffort('claude-sonnet-4.6', 'xhigh')).toBe('max')
+      expect(resolveEffort('claude-opus-4.6', 'xhigh')).toBe('max')
+    })
+  })
+
+  describe('budgetToEffort', () => {
+    test('returns undefined for unsupported models', () => {
+      expect(budgetToEffort(100000, 'claude-haiku-4.5')).toBeUndefined()
+    })
+
+    test('maps budget ranges correctly', () => {
+      expect(budgetToEffort(5000, 'claude-opus-4.8')).toBe('low')
+      expect(budgetToEffort(20000, 'claude-opus-4.8')).toBe('medium')
+      expect(budgetToEffort(50000, 'claude-opus-4.8')).toBe('high')
+      expect(budgetToEffort(80000, 'claude-opus-4.8')).toBe('xhigh')
+      expect(budgetToEffort(128000, 'claude-opus-4.8')).toBe('max')
+    })
+
+    test('maps to max instead of xhigh for non-xhigh models', () => {
+      expect(budgetToEffort(80000, 'claude-sonnet-4.6')).toBe('max')
+    })
+  })
+
+  describe('getEffectiveEffort', () => {
+    test('returns undefined for unsupported models', () => {
+      expect(getEffectiveEffort('claude-haiku-4.5', true, 100000)).toBeUndefined()
+    })
+
+    test('uses explicit config when provided', () => {
+      expect(getEffectiveEffort('claude-opus-4.8', true, 20000, 'max')).toBe('max')
+      expect(getEffectiveEffort('claude-opus-4.8', false, 20000, 'high')).toBe('high')
+    })
+
+    test('returns undefined when not thinking and no config', () => {
+      expect(getEffectiveEffort('claude-opus-4.8', false, 20000)).toBeUndefined()
+    })
+
+    test('uses budget mapping when thinking and auto-mapping enabled', () => {
+      expect(getEffectiveEffort('claude-opus-4.8', true, 128000, undefined, true)).toBe('max')
+      expect(getEffectiveEffort('claude-opus-4.8', true, 20000, undefined, true)).toBe('medium')
+    })
+
+    test('falls back to medium when auto-mapping disabled', () => {
+      expect(getEffectiveEffort('claude-opus-4.8', true, 128000, undefined, false)).toBe('medium')
+    })
+  })
+})

--- a/src/__tests__/sdk-client.test.ts
+++ b/src/__tests__/sdk-client.test.ts
@@ -1,3 +1,4 @@
+import { GenerateAssistantResponseCommand } from '@aws/codewhisperer-streaming-client'
 import { describe, expect, test } from 'bun:test'
 import { clearSdkClientCache, createSdkClient } from '../plugin/sdk-client'
 import type { KiroAuthDetails } from '../plugin/types'
@@ -22,6 +23,50 @@ describe('SDK client', () => {
     expect(await client.config.maxAttempts()).toBe(3)
     const retryMode = client.config.retryMode
     expect(typeof retryMode === 'function' ? await retryMode() : retryMode).toBe('standard')
+
+    clearSdkClientCache()
+  })
+
+  test('injects effort before content-length is computed', async () => {
+    clearSdkClientCache()
+
+    const client = createSdkClient(auth(), 'us-east-1', 'max')
+    let capturedRequest: any
+
+    client.middlewareStack.add(
+      () => async (args: any) => {
+        capturedRequest = args.request
+        throw new Error('captured-request')
+      },
+      { step: 'finalizeRequest', name: 'captureRequest', priority: 'high' }
+    )
+
+    const command = new GenerateAssistantResponseCommand({
+      conversationState: {
+        chatTriggerType: 'MANUAL',
+        conversationId: 'test-conversation',
+        currentMessage: {
+          userInputMessage: {
+            content: 'hello',
+            modelId: 'claude-opus-4.7',
+            origin: 'AI_EDITOR'
+          }
+        }
+      }
+    })
+
+    await client.send(command).catch((error) => {
+      if (error.message !== 'captured-request') throw error
+    })
+
+    const bodyText =
+      typeof capturedRequest.body === 'string'
+        ? capturedRequest.body
+        : Buffer.from(capturedRequest.body).toString('utf8')
+    const body = JSON.parse(bodyText)
+
+    expect(body.additionalModelRequestFields.output_config.effort).toBe('max')
+    expect(Number(capturedRequest.headers['content-length'])).toBe(Buffer.byteLength(bodyText))
 
     clearSdkClientCache()
   })

--- a/src/core/request/request-handler.ts
+++ b/src/core/request/request-handler.ts
@@ -7,7 +7,7 @@ import * as logger from '../../plugin/logger'
 import { transformToSdkRequest } from '../../plugin/request'
 import { createSdkClient } from '../../plugin/sdk-client'
 import { syncFromKiroCli } from '../../plugin/sync/kiro-cli'
-import type { Effort, KiroAuthDetails, ManagedAccount, SdkPreparedRequest } from '../../plugin/types'
+import type { KiroAuthDetails, ManagedAccount, SdkPreparedRequest } from '../../plugin/types'
 import { AccountSelector } from '../account/account-selector'
 import { UsageTracker } from '../account/usage-tracker'
 import { TokenRefresher } from '../auth/token-refresher'
@@ -79,17 +79,13 @@ export class RequestHandler {
   ): Promise<Response> {
     const body = init?.body ? JSON.parse(init.body) : {}
     const model = this.extractModel(url) || body.model || 'claude-sonnet-4-5'
-    const think = model.endsWith('-thinking') || !!body.providerOptions?.thinkingConfig || !!body.thinkingConfig
+    const think =
+      model.endsWith('-thinking') || !!body.providerOptions?.thinkingConfig || !!body.thinkingConfig
     const budget =
       body.providerOptions?.thinkingConfig?.thinkingBudget ||
       body.thinkingConfig?.thinkingBudget ||
       body.thinkingConfig?.budget_tokens ||
       20000
-
-    // Debug: log what OpenCode sends us
-    logger.log(`[Debug] body keys: ${Object.keys(body).join(', ')}`)
-    logger.log(`[Debug] body.thinkingConfig: ${JSON.stringify(body.thinkingConfig)}`)
-    logger.log(`[Debug] model: ${model}, think: ${think}, budget: ${budget}`)
 
     let retry = 0
     let consecutiveNullAccounts = 0
@@ -141,10 +137,6 @@ export class RequestHandler {
       if (apiTimestamp) {
         this.logSdkRequest(sdkPrep, acc, apiTimestamp)
       }
-      if (sdkPrep.effort) {
-        logger.log(`[Effort] Resolved effort: ${sdkPrep.effort} for model: ${sdkPrep.effectiveModel}`)
-      }
-
       try {
         const client = createSdkClient(auth, sdkPrep.region, sdkPrep.effort)
         const command = new GenerateAssistantResponseCommand({

--- a/src/core/request/request-handler.ts
+++ b/src/core/request/request-handler.ts
@@ -79,8 +79,17 @@ export class RequestHandler {
   ): Promise<Response> {
     const body = init?.body ? JSON.parse(init.body) : {}
     const model = this.extractModel(url) || body.model || 'claude-sonnet-4-5'
-    const think = model.endsWith('-thinking') || !!body.providerOptions?.thinkingConfig
-    const budget = body.providerOptions?.thinkingConfig?.thinkingBudget || 20000
+    const think = model.endsWith('-thinking') || !!body.providerOptions?.thinkingConfig || !!body.thinkingConfig
+    const budget =
+      body.providerOptions?.thinkingConfig?.thinkingBudget ||
+      body.thinkingConfig?.thinkingBudget ||
+      body.thinkingConfig?.budget_tokens ||
+      20000
+
+    // Debug: log what OpenCode sends us
+    logger.log(`[Debug] body keys: ${Object.keys(body).join(', ')}`)
+    logger.log(`[Debug] body.thinkingConfig: ${JSON.stringify(body.thinkingConfig)}`)
+    logger.log(`[Debug] model: ${model}, think: ${think}, budget: ${budget}`)
 
     let retry = 0
     let consecutiveNullAccounts = 0

--- a/src/core/request/request-handler.ts
+++ b/src/core/request/request-handler.ts
@@ -132,6 +132,9 @@ export class RequestHandler {
       if (apiTimestamp) {
         this.logSdkRequest(sdkPrep, acc, apiTimestamp)
       }
+      if (sdkPrep.effort) {
+        logger.log(`[Effort] Resolved effort: ${sdkPrep.effort} for model: ${sdkPrep.effectiveModel}`)
+      }
 
       try {
         const client = createSdkClient(auth, sdkPrep.region, sdkPrep.effort)

--- a/src/core/request/request-handler.ts
+++ b/src/core/request/request-handler.ts
@@ -7,7 +7,7 @@ import * as logger from '../../plugin/logger'
 import { transformToSdkRequest } from '../../plugin/request'
 import { createSdkClient } from '../../plugin/sdk-client'
 import { syncFromKiroCli } from '../../plugin/sync/kiro-cli'
-import type { KiroAuthDetails, ManagedAccount, SdkPreparedRequest } from '../../plugin/types'
+import type { Effort, KiroAuthDetails, ManagedAccount, SdkPreparedRequest } from '../../plugin/types'
 import { AccountSelector } from '../account/account-selector'
 import { UsageTracker } from '../account/usage-tracker'
 import { TokenRefresher } from '../auth/token-refresher'
@@ -134,7 +134,7 @@ export class RequestHandler {
       }
 
       try {
-        const client = createSdkClient(auth, sdkPrep.region)
+        const client = createSdkClient(auth, sdkPrep.region, sdkPrep.effort)
         const command = new GenerateAssistantResponseCommand({
           conversationState: sdkPrep.conversationState as any,
           profileArn: sdkPrep.profileArn
@@ -219,7 +219,10 @@ export class RequestHandler {
     budget: number,
     showToast?: (message: string, variant: 'info' | 'warning' | 'success' | 'error') => void
   ): SdkPreparedRequest {
-    return transformToSdkRequest(body, model, auth, think, budget, showToast)
+    return transformToSdkRequest(body, model, auth, think, budget, showToast, {
+      effort: this.config.effort,
+      autoEffortMapping: this.config.auto_effort_mapping
+    })
   }
 
   private handleSuccessfulRequest(acc: ManagedAccount): void {

--- a/src/plugin/config/schema.ts
+++ b/src/plugin/config/schema.ts
@@ -3,6 +3,17 @@ import { z } from 'zod'
 export const AccountSelectionStrategySchema = z.enum(['sticky', 'round-robin', 'lowest-usage'])
 export type AccountSelectionStrategy = z.infer<typeof AccountSelectionStrategySchema>
 
+/**
+ * Kiro effort levels control thinking/reasoning depth.
+ * - low: minimal reasoning
+ * - medium: balanced (default when thinking enabled)
+ * - high: deeper reasoning
+ * - xhigh: extended reasoning (opus-4.7, opus-4.8 only)
+ * - max: maximum reasoning depth (128k thinking tokens on opus-4.7/4.8)
+ */
+export const EffortSchema = z.enum(['low', 'medium', 'high', 'xhigh', 'max'])
+export type Effort = z.infer<typeof EffortSchema>
+
 export const RegionSchema = z.enum([
   'us-east-1',
   'us-east-2',
@@ -70,7 +81,21 @@ export const KiroConfigSchema = z.object({
 
   usage_tracking_enabled: z.boolean().default(true),
   auto_sync_kiro_cli: z.boolean().default(true),
-  enable_log_api_request: z.boolean().default(false)
+  enable_log_api_request: z.boolean().default(false),
+
+  /**
+   * Default effort level for thinking models. Controls reasoning depth.
+   * When set, this overrides the automatic budget-based mapping.
+   * Values: 'low', 'medium', 'high', 'xhigh' (opus-4.7/4.8 only), 'max'
+   */
+  effort: EffortSchema.optional(),
+
+  /**
+   * Enable automatic effort mapping from OpenCode's thinking budget.
+   * When true (default), maps budget ranges to effort levels.
+   * When false, only uses explicit effort config or falls back to 'medium'.
+   */
+  auto_effort_mapping: z.boolean().default(true)
 })
 
 export type KiroConfig = z.infer<typeof KiroConfigSchema>
@@ -88,5 +113,6 @@ export const DEFAULT_CONFIG: KiroConfig = {
   auth_server_port_range: 10,
   usage_tracking_enabled: true,
   auto_sync_kiro_cli: true,
-  enable_log_api_request: false
+  enable_log_api_request: false,
+  auto_effort_mapping: true
 }

--- a/src/plugin/effort.ts
+++ b/src/plugin/effort.ts
@@ -64,12 +64,18 @@ export function resolveEffort(kiroModel: string, requested: Effort): Effort | un
 /**
  * Map OpenCode thinking budget to Kiro effort level.
  * 
- * Budget ranges (approximate thinking token allocations):
- * - low:    minimal thinking
- * - medium: ~20k tokens (OpenCode default)
- * - high:   ~50k tokens
- * - xhigh:  ~80k tokens (opus-4.7/4.8 only)
- * - max:    ~128k tokens
+ * OpenCode sends thinkingBudget from its variant config. Standard values:
+ * - low:    8192
+ * - medium: 16384
+ * - high:   24576
+ * - max:    32768
+ * 
+ * We map these ranges to Kiro effort levels:
+ * - ≤10000  → low
+ * - ≤20000  → medium
+ * - ≤28000  → high
+ * - ≤32768  → max (or xhigh on opus-4.7/4.8, max otherwise)
+ * - >32768  → max
  */
 export function budgetToEffort(budget: number, kiroModel: string): Effort | undefined {
   if (!supportsEffort(kiroModel)) {
@@ -79,12 +85,10 @@ export function budgetToEffort(budget: number, kiroModel: string): Effort | unde
   let effort: Effort
   if (budget <= 10000) {
     effort = 'low'
-  } else if (budget <= 30000) {
+  } else if (budget <= 20000) {
     effort = 'medium'
-  } else if (budget <= 60000) {
+  } else if (budget <= 28000) {
     effort = 'high'
-  } else if (budget <= 100000) {
-    effort = supportsXHighEffort(kiroModel) ? 'xhigh' : 'max'
   } else {
     effort = 'max'
   }

--- a/src/plugin/effort.ts
+++ b/src/plugin/effort.ts
@@ -1,0 +1,132 @@
+import type { Effort } from './config/schema'
+
+/**
+ * Effort levels ordered from lowest to highest reasoning depth.
+ */
+export const EFFORT_LEVELS: readonly Effort[] = ['low', 'medium', 'high', 'xhigh', 'max'] as const
+
+/**
+ * Models that support the 5-value effort enum (including xhigh).
+ * These models support up to 128k thinking tokens with max effort.
+ */
+const XHIGH_CAPABLE_MODELS = new Set([
+  'claude-opus-4.7',
+  'claude-opus-4.8'
+])
+
+/**
+ * Models that support the 4-value effort enum (no xhigh).
+ * xhigh requests on these models are clamped to max.
+ */
+const EFFORT_CAPABLE_MODELS = new Set([
+  'claude-opus-4.5',
+  'claude-opus-4.6',
+  'claude-opus-4.6-1m',
+  'claude-sonnet-4.5',
+  'claude-sonnet-4.5-1m',
+  'claude-sonnet-4.6',
+  'claude-sonnet-4.6-1m',
+  ...XHIGH_CAPABLE_MODELS
+])
+
+/**
+ * Check if a model supports the effort parameter.
+ */
+export function supportsEffort(kiroModel: string): boolean {
+  return EFFORT_CAPABLE_MODELS.has(kiroModel)
+}
+
+/**
+ * Check if a model supports xhigh effort level.
+ */
+export function supportsXHighEffort(kiroModel: string): boolean {
+  return XHIGH_CAPABLE_MODELS.has(kiroModel)
+}
+
+/**
+ * Resolve effort level for a given model.
+ * - Returns undefined if model doesn't support effort
+ * - Clamps xhigh to max for models that don't support it
+ */
+export function resolveEffort(kiroModel: string, requested: Effort): Effort | undefined {
+  if (!supportsEffort(kiroModel)) {
+    return undefined
+  }
+
+  // xhigh is only supported on opus-4.7 and opus-4.8
+  if (requested === 'xhigh' && !supportsXHighEffort(kiroModel)) {
+    return 'max'
+  }
+
+  return requested
+}
+
+/**
+ * Map OpenCode thinking budget to Kiro effort level.
+ * 
+ * Budget ranges (approximate thinking token allocations):
+ * - low:    minimal thinking
+ * - medium: ~20k tokens (OpenCode default)
+ * - high:   ~50k tokens
+ * - xhigh:  ~80k tokens (opus-4.7/4.8 only)
+ * - max:    ~128k tokens
+ */
+export function budgetToEffort(budget: number, kiroModel: string): Effort | undefined {
+  if (!supportsEffort(kiroModel)) {
+    return undefined
+  }
+
+  let effort: Effort
+  if (budget <= 10000) {
+    effort = 'low'
+  } else if (budget <= 30000) {
+    effort = 'medium'
+  } else if (budget <= 60000) {
+    effort = 'high'
+  } else if (budget <= 100000) {
+    effort = supportsXHighEffort(kiroModel) ? 'xhigh' : 'max'
+  } else {
+    effort = 'max'
+  }
+
+  return effort
+}
+
+/**
+ * Get the effective effort level based on config, budget, and model.
+ * 
+ * Priority:
+ * 1. Explicit effort config (if set)
+ * 2. Budget-to-effort mapping (if auto_effort_mapping enabled and thinking)
+ * 3. 'medium' default (if thinking enabled)
+ * 4. undefined (if not thinking)
+ */
+export function getEffectiveEffort(
+  kiroModel: string,
+  thinking: boolean,
+  budget: number,
+  configEffort?: Effort,
+  autoEffortMapping = true
+): Effort | undefined {
+  if (!supportsEffort(kiroModel)) {
+    return undefined
+  }
+
+  // Explicit config takes precedence
+  if (configEffort) {
+    return resolveEffort(kiroModel, configEffort)
+  }
+
+  // If not thinking, no effort needed
+  if (!thinking) {
+    return undefined
+  }
+
+  // Auto-map budget to effort
+  if (autoEffortMapping) {
+    return budgetToEffort(budget, kiroModel)
+  }
+
+  // Default to medium when thinking without auto-mapping
+  return 'medium'
+}

--- a/src/plugin/effort.ts
+++ b/src/plugin/effort.ts
@@ -96,7 +96,7 @@ export function budgetToEffort(budget: number, kiroModel: string): Effort | unde
  * Get the effective effort level based on config, budget, and model.
  * 
  * Priority:
- * 1. Explicit effort config (if set)
+ * 1. Explicit effort config (if set) - always applied regardless of thinking state
  * 2. Budget-to-effort mapping (if auto_effort_mapping enabled and thinking)
  * 3. 'medium' default (if thinking enabled)
  * 4. undefined (if not thinking)
@@ -112,7 +112,7 @@ export function getEffectiveEffort(
     return undefined
   }
 
-  // Explicit config takes precedence
+  // Explicit config takes precedence - always applied even without thinking
   if (configEffort) {
     return resolveEffort(kiroModel, configEffort)
   }

--- a/src/plugin/request.ts
+++ b/src/plugin/request.ts
@@ -16,6 +16,7 @@ import {
   convertToolsToCodeWhisperer,
   deduplicateToolResults
 } from '../infrastructure/transformers/tool-transformer.js'
+import { getEffectiveEffort } from './effort.js'
 import {
   convertImagesToKiroFormat,
   extractAllImages,
@@ -24,6 +25,7 @@ import {
 import { resolveKiroModel } from './models.js'
 import type {
   CodeWhispererRequest,
+  Effort,
   KiroAuthDetails,
   PreparedRequest,
   SdkPreparedRequest
@@ -33,6 +35,11 @@ interface TransformResult {
   request: CodeWhispererRequest
   resolved: string
   convId: string
+}
+
+interface EffortConfig {
+  effort?: Effort
+  autoEffortMapping?: boolean
 }
 
 type ToastFunction = (message: string, variant: 'info' | 'warning' | 'success' | 'error') => void
@@ -317,7 +324,8 @@ export function transformToSdkRequest(
   auth: KiroAuthDetails,
   think = false,
   budget = 20000,
-  showToast?: ToastFunction
+  showToast?: ToastFunction,
+  effortConfig?: EffortConfig
 ): SdkPreparedRequest {
   const { request, resolved, convId } = buildCodeWhispererRequest(
     body,
@@ -327,12 +335,23 @@ export function transformToSdkRequest(
     budget,
     showToast
   )
+
+  // Resolve effort level based on config and model capabilities
+  const effort = getEffectiveEffort(
+    resolved,
+    think,
+    budget,
+    effortConfig?.effort,
+    effortConfig?.autoEffortMapping ?? true
+  )
+
   return {
     conversationState: request.conversationState,
     profileArn: request.profileArn,
     streaming: true,
     effectiveModel: resolved,
     conversationId: convId,
-    region: extractRegionFromArn(auth.profileArn) ?? auth.region
+    region: extractRegionFromArn(auth.profileArn) ?? auth.region,
+    effort
   }
 }

--- a/src/plugin/sdk-client.ts
+++ b/src/plugin/sdk-client.ts
@@ -64,10 +64,18 @@ export function createSdkClient(
             }
             args.request.body = JSON.stringify(body)
             logger.log(`[Effort] Injected additionalModelRequestFields.output_config.effort=${effort}`)
+            // Dump the top-level keys of final request body for verification
+            logger.log(`[Effort] Final request body keys: ${Object.keys(body).join(', ')}`)
+            logger.log(`[Effort] Final body.additionalModelRequestFields: ${JSON.stringify(body.additionalModelRequestFields)}`)
           } catch {
             // If body parsing fails, continue without modification
             logger.warn('[Effort] Failed to parse request body for effort injection')
           }
+        } else {
+          logger.warn('[Effort] No args.request.body found - checking args structure')
+          logger.log(`[Effort] args keys: ${Object.keys(args || {}).join(', ')}`)
+          logger.log(`[Effort] args.request keys: ${Object.keys(args?.request || {}).join(', ')}`)
+          logger.log(`[Effort] args.input keys: ${Object.keys(args?.input || {}).join(', ')}`)
         }
         return next(args)
       },

--- a/src/plugin/sdk-client.ts
+++ b/src/plugin/sdk-client.ts
@@ -1,6 +1,5 @@
 import { CodeWhispererStreamingClient } from '@aws/codewhisperer-streaming-client'
 import { KIRO_CONSTANTS } from '../constants.js'
-import * as logger from './logger.js'
 import type { Effort, KiroAuthDetails } from './types'
 
 /**
@@ -49,7 +48,6 @@ export function createSdkClient(
 
   // Inject additionalModelRequestFields for effort-based thinking control
   if (effort) {
-    logger.log(`[Effort] Adding middleware to inject effort: ${effort}`)
     client.middlewareStack.add(
       (next: any) => async (args: any) => {
         // The SDK serializes input to args.input, we need to modify the body
@@ -63,19 +61,9 @@ export function createSdkClient(
               }
             }
             args.request.body = JSON.stringify(body)
-            logger.log(`[Effort] Injected additionalModelRequestFields.output_config.effort=${effort}`)
-            // Dump the top-level keys of final request body for verification
-            logger.log(`[Effort] Final request body keys: ${Object.keys(body).join(', ')}`)
-            logger.log(`[Effort] Final body.additionalModelRequestFields: ${JSON.stringify(body.additionalModelRequestFields)}`)
           } catch {
             // If body parsing fails, continue without modification
-            logger.warn('[Effort] Failed to parse request body for effort injection')
           }
-        } else {
-          logger.warn('[Effort] No args.request.body found - checking args structure')
-          logger.log(`[Effort] args keys: ${Object.keys(args || {}).join(', ')}`)
-          logger.log(`[Effort] args.request keys: ${Object.keys(args?.request || {}).join(', ')}`)
-          logger.log(`[Effort] args.input keys: ${Object.keys(args?.input || {}).join(', ')}`)
         }
         return next(args)
       },

--- a/src/plugin/sdk-client.ts
+++ b/src/plugin/sdk-client.ts
@@ -1,18 +1,29 @@
 import { CodeWhispererStreamingClient } from '@aws/codewhisperer-streaming-client'
 import { KIRO_CONSTANTS } from '../constants.js'
-import type { KiroAuthDetails } from './types'
+import type { Effort, KiroAuthDetails } from './types'
 
-const clientCache = new Map<string, { client: CodeWhispererStreamingClient; token: string }>()
+/**
+ * Cache key includes effort to ensure separate clients for different effort levels,
+ * since middleware is configured at client creation time.
+ */
+interface ClientCacheEntry {
+  client: CodeWhispererStreamingClient
+  token: string
+  effort?: Effort
+}
+
+const clientCache = new Map<string, ClientCacheEntry>()
 const KIRO_CLI_MAX_ATTEMPTS = 3
 
 export function createSdkClient(
   auth: KiroAuthDetails,
-  region: string
+  region: string,
+  effort?: Effort
 ): CodeWhispererStreamingClient {
-  const cacheKey = `${region}:${auth.email || 'default'}`
+  const cacheKey = `${region}:${auth.email || 'default'}:${effort || 'none'}`
   const cached = clientCache.get(cacheKey)
 
-  if (cached && cached.token === auth.access) {
+  if (cached && cached.token === auth.access && cached.effort === effort) {
     return cached.client
   }
 
@@ -26,6 +37,7 @@ export function createSdkClient(
     customUserAgent: [[KIRO_CONSTANTS.USER_AGENT]]
   })
 
+  // Add Kiro-specific headers
   client.middlewareStack.add(
     (next: any) => async (args: any) => {
       args.request.headers['x-amzn-kiro-agent-mode'] = 'vibe'
@@ -34,7 +46,32 @@ export function createSdkClient(
     { step: 'build', name: 'addKiroHeaders' }
   )
 
-  clientCache.set(cacheKey, { client, token })
+  // Inject additionalModelRequestFields for effort-based thinking control
+  if (effort) {
+    client.middlewareStack.add(
+      (next: any) => async (args: any) => {
+        // The SDK serializes input to args.input, we need to modify the body
+        // before it's sent. The body is in args.request.body as a string.
+        if (args.request?.body) {
+          try {
+            const body = JSON.parse(args.request.body)
+            body.additionalModelRequestFields = {
+              output_config: {
+                effort
+              }
+            }
+            args.request.body = JSON.stringify(body)
+          } catch {
+            // If body parsing fails, continue without modification
+          }
+        }
+        return next(args)
+      },
+      { step: 'build', name: 'addEffortConfig', priority: 'low' }
+    )
+  }
+
+  clientCache.set(cacheKey, { client, token, effort })
   return client
 }
 

--- a/src/plugin/sdk-client.ts
+++ b/src/plugin/sdk-client.ts
@@ -67,7 +67,7 @@ export function createSdkClient(
         }
         return next(args)
       },
-      { step: 'build', name: 'addEffortConfig', priority: 'low' }
+      { step: 'build', name: 'addEffortConfig', priority: 'high' }
     )
   }
 

--- a/src/plugin/sdk-client.ts
+++ b/src/plugin/sdk-client.ts
@@ -1,5 +1,6 @@
 import { CodeWhispererStreamingClient } from '@aws/codewhisperer-streaming-client'
 import { KIRO_CONSTANTS } from '../constants.js'
+import * as logger from './logger.js'
 import type { Effort, KiroAuthDetails } from './types'
 
 /**
@@ -48,6 +49,7 @@ export function createSdkClient(
 
   // Inject additionalModelRequestFields for effort-based thinking control
   if (effort) {
+    logger.log(`[Effort] Adding middleware to inject effort: ${effort}`)
     client.middlewareStack.add(
       (next: any) => async (args: any) => {
         // The SDK serializes input to args.input, we need to modify the body
@@ -61,8 +63,10 @@ export function createSdkClient(
               }
             }
             args.request.body = JSON.stringify(body)
+            logger.log(`[Effort] Injected additionalModelRequestFields.output_config.effort=${effort}`)
           } catch {
             // If body parsing fails, continue without modification
+            logger.warn('[Effort] Failed to parse request body for effort injection')
           }
         }
         return next(args)

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -1,8 +1,9 @@
 import z from 'zod'
-import { RegionSchema } from './config/schema'
+import { EffortSchema, RegionSchema } from './config/schema'
 
 export type KiroAuthMethod = 'idc' | 'desktop'
 export type KiroRegion = z.infer<typeof RegionSchema>
+export type Effort = z.infer<typeof EffortSchema>
 
 export interface KiroAuthDetails {
   refresh: string
@@ -119,6 +120,8 @@ export interface SdkPreparedRequest {
   effectiveModel: string
   conversationId: string
   region: string
+  /** Resolved effort level for thinking models */
+  effort?: Effort
 }
 
 export type AccountSelectionStrategy = 'sticky' | 'round-robin' | 'lowest-usage'


### PR DESCRIPTION
## Summary

Add native Kiro effort parameter support to control thinking/reasoning depth. This fixes the issue where OpenCode's thinking budget settings are ignored because Kiro uses its own `effort` levels instead of Anthropic's `budget_tokens`/`max_thinking_length`.

## Problem

When using thinking models (e.g., `claude-opus-4-8-thinking`) through the Kiro auth plugin, the thinking budget is capped at ~20k tokens regardless of OpenCode's `max` thinking setting. This is because Kiro ignores Anthropic's native thinking parameters and instead requires effort to be passed via `additionalModelRequestFields.output_config.effort`.

## Solution

Inject the `additionalModelRequestFields` with the resolved effort level into API requests via SDK middleware.

### Changes

- **schema.ts**: Add `effort` and `auto_effort_mapping` config options
- **effort.ts**: New module with budget-to-effort mapping logic
- **sdk-client.ts**: Inject `additionalModelRequestFields` via middleware when effort is set
- **request.ts**: Resolve effort based on model, thinking state, budget, and config
- **request-handler.ts**: Pass config effort settings through request pipeline
- **types.ts**: Add `Effort` type and extend `SdkPreparedRequest`

### Effort Levels

| Level | Description | Approximate Tokens |
|-------|-------------|-------------------|
| low | Minimal reasoning | - |
| medium | Balanced (default) | ~20k |
| high | Deeper reasoning | ~50k |
| xhigh | Extended (opus-4.7/4.8 only) | ~80k |
| max | Maximum depth | ~128k |

### Configuration

```json
// kiro.json - explicit effort level
{
  "effort": "max"
}

// kiro.json - auto-map from OpenCode budget (default behavior)
{
  "auto_effort_mapping": true
}
```

## Testing

- Build passes (`npm run build`)
- Added unit tests for effort resolution logic

## References

- Kiro CLI effort implementation: https://github.com/d-kuro/kirocc
- Kiro effort levels from `/effort` command: low, medium, high, xhigh, max