### PR TITLE
Add Claude Sonnet 5 model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,38 @@ Add the plugin to your `opencode.json` or `opencode.jsonc`:
             "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
           }
         },
+        "claude-sonnet-5": {
+          "name": "Claude Sonnet 5",
+          "limit": { "context": 1000000, "output": 64000 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
+        },
+        "claude-sonnet-5-thinking": {
+          "name": "Claude Sonnet 5 Thinking",
+          "limit": { "context": 1000000, "output": 64000 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+          "variants": {
+            "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
+            "medium": { "thinkingConfig": { "thinkingBudget": 16384 } },
+            "high": { "thinkingConfig": { "thinkingBudget": 24576 } },
+            "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
+          }
+        },
+        "claude-sonnet-5-1m": {
+          "name": "Claude Sonnet 5 (1M Context)",
+          "limit": { "context": 1000000, "output": 64000 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
+        },
+        "claude-sonnet-5-1m-thinking": {
+          "name": "Claude Sonnet 5 (1M Context) Thinking",
+          "limit": { "context": 1000000, "output": 64000 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+          "variants": {
+            "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
+            "medium": { "thinkingConfig": { "thinkingBudget": 16384 } },
+            "high": { "thinkingConfig": { "thinkingBudget": 24576 } },
+            "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
+          }
+        },
         "claude-haiku-4-5": {
           "name": "Claude Haiku 4.5",
           "limit": { "context": 200000, "output": 64000 },

--- a/src/__tests__/effort.test.ts
+++ b/src/__tests__/effort.test.ts
@@ -14,6 +14,8 @@ describe('effort module', () => {
       expect(supportsEffort('claude-opus-4.7')).toBe(true)
       expect(supportsEffort('claude-sonnet-4.6')).toBe(true)
       expect(supportsEffort('claude-sonnet-4.6-1m')).toBe(true)
+      expect(supportsEffort('claude-sonnet-5')).toBe(true)
+      expect(supportsEffort('claude-sonnet-5-1m')).toBe(true)
     })
 
     test('returns false for unsupported models', () => {

--- a/src/__tests__/model-resolution.test.ts
+++ b/src/__tests__/model-resolution.test.ts
@@ -18,6 +18,13 @@ describe('resolveKiroModel', () => {
     expect(resolveKiroModel('claude-opus-4-8-thinking')).toBe('claude-opus-4.8')
   })
 
+  test('resolves claude-sonnet-5 slugs', () => {
+    expect(resolveKiroModel('claude-sonnet-5')).toBe('claude-sonnet-5')
+    expect(resolveKiroModel('claude-sonnet-5-thinking')).toBe('claude-sonnet-5')
+    expect(resolveKiroModel('claude-sonnet-5-1m')).toBe('claude-sonnet-5-1m')
+    expect(resolveKiroModel('claude-sonnet-5-1m-thinking')).toBe('claude-sonnet-5-1m')
+  })
+
   test('rejects removed qwen3-coder-480b slug', () => {
     expect(() => resolveKiroModel('qwen3-coder-480b')).toThrow(
       'Unsupported model: qwen3-coder-480b'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -63,6 +63,10 @@ export const MODEL_MAPPING: Record<string, string> = {
   'claude-sonnet-4-6-thinking': 'claude-sonnet-4.6',
   'claude-sonnet-4-6-1m': 'claude-sonnet-4.6-1m',
   'claude-sonnet-4-6-1m-thinking': 'claude-sonnet-4.6-1m',
+  'claude-sonnet-5': 'claude-sonnet-5',
+  'claude-sonnet-5-thinking': 'claude-sonnet-5',
+  'claude-sonnet-5-1m': 'claude-sonnet-5-1m',
+  'claude-sonnet-5-1m-thinking': 'claude-sonnet-5-1m',
   // Claude Opus
   'claude-opus-4-5': 'claude-opus-4.5',
   'claude-opus-4-5-thinking': 'claude-opus-4.5',

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -75,6 +75,11 @@ export const createKiroPlugin =
               limit: { context: 1000000, output: 64000 },
               modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
             },
+            'claude-sonnet-5': {
+              name: 'Claude Sonnet 5 (1.3x)',
+              limit: { context: 1000000, output: 64000 },
+              modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
+            },
             // Claude Haiku
             'claude-haiku-4-5': {
               name: 'Claude Haiku 4.5 (0.4x)',

--- a/src/plugin/effort.ts
+++ b/src/plugin/effort.ts
@@ -23,6 +23,8 @@ const EFFORT_CAPABLE_MODELS = new Set([
   'claude-sonnet-4.5-1m',
   'claude-sonnet-4.6',
   'claude-sonnet-4.6-1m',
+  'claude-sonnet-5',
+  'claude-sonnet-5-1m',
   ...XHIGH_CAPABLE_MODELS
 ])
 


### PR DESCRIPTION
## Summary

Adds support for the `claude-sonnet-5` model family, following the same pattern already established for `claude-sonnet-4-6`.

## Changes

- **`src/constants.ts`**: Added `claude-sonnet-5`, `claude-sonnet-5-thinking`, `claude-sonnet-5-1m`, `claude-sonnet-5-1m-thinking` to `MODEL_MAPPING`, resolving to Kiro's `claude-sonnet-5` / `claude-sonnet-5-1m` model IDs.
- **`src/plugin/effort.ts`**: Added `claude-sonnet-5` and `claude-sonnet-5-1m` to `EFFORT_CAPABLE_MODELS` (4-value effort enum, no `xhigh` — same tier as `claude-sonnet-4.6`).
- **`src/plugin.ts`**: Added a `claude-sonnet-5` default model definition (1M context, text/image/pdf input) to the plugin's default model list.
- **`README.md`**: Added `claude-sonnet-5`, `claude-sonnet-5-thinking`, `claude-sonnet-5-1m`, `claude-sonnet-5-1m-thinking` entries to the installation example JSON.
- **Tests**: Added `resolveKiroModel` coverage for all four new slugs and `supportsEffort` coverage for `claude-sonnet-5` / `claude-sonnet-5-1m`.

## Testing

- `npm run typecheck` — passes
- `npm run build` — passes
- `bun test` — 35 pass, 0 fail
- `npx prettier --check 'src/**/*.ts'` — passes
- Manually verified end-to-end: installed the built plugin locally via `opencode.json` (`"plugin": ["/path/to/opencode-kiro-auth"]`), authenticated via Kiro, and confirmed OpenCode successfully routed a live request through `kiro/claude-sonnet-5`.

No breaking changes — existing model mappings and effort resolution are untouched.
