### PR TITLE
ci: nightly master tarball workflow

### DIFF
--- a/.github/workflows/master-tarball.yml
+++ b/.github/workflows/master-tarball.yml
@@ -1,0 +1,70 @@
+name: Build and publish tarball
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  tarball:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: oven-sh/setup-bun@v2
+
+      - run: bun install
+
+      - run: bun test
+
+      - run: bun run typecheck
+
+      - run: bun run build
+
+      - name: Pack tarball
+        run: npm pack
+
+      - name: Rename tarball to fixed name
+        run: mv *.tgz opencode-kiro-auth.tgz
+
+      - name: Check if release exists
+        id: check_release
+        run: |
+          if gh release view "_master" >/dev/null 2>&1; then
+            echo "release_exists=true" >> $GITHUB_ENV
+          else
+            echo "release_exists=false" >> $GITHUB_ENV
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create release if missing
+        if: env.release_exists != 'true'
+        run: |
+          gh release create "_master" \
+            --target master \
+            --prerelease \
+            --title "Nightly Build master" \
+            --notes "Nightly build. Commit: ${{ github.sha }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Ensure _master tag points at HEAD
+        run: |
+          git tag -f _master HEAD
+          git push origin _master --force
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Delete old tarball asset
+        run: gh release delete-asset _master opencode-kiro-auth.tgz --yes || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload tarball
+        run: gh release upload _master opencode-kiro-auth.tgz --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 *.tsbuildinfo
 .vscode/*
 .sisyphus
+*.tgz


### PR DESCRIPTION
## Summary

Add a GitHub Action that builds and publishes a plugin tarball to a rolling
`_master` prerelease on every push to `master`, so users can install the latest
build directly from a stable URL without waiting for an npm release.

## Changes

- `.github/workflows/master-tarball.yml` — on push to `master` (and manual
  dispatch): `bun install`, `bun test`, `bun run typecheck`, `bun run build`,
  then `npm pack` and upload the tarball as `opencode-kiro-auth.tgz` to the
  `_master` prerelease, keeping the tag pointed at `HEAD`.
- `.github/workflows/release.yml` — bump `actions/checkout` from v4 to v5.
- `.gitignore` — ignore packed `*.tgz` tarballs.

## Usage

Install the nightly build in `opencode.json`:

```json
{
  "plugin": [
    "https://github.com/<owner>/opencode-kiro-auth/releases/download/_master/opencode-kiro-auth.tgz"
  ]
}
```

## Testing

- Workflow runs the full `bun test` + `typecheck` + `build` gate before packing,
  so a broken build never publishes a tarball.