### PR TITLE
feat: add kiro_web_search tool

### DIFF
--- a/src/__tests__/web-search.test.ts
+++ b/src/__tests__/web-search.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test'
+import { formatWebSearchResults, type WebSearchResult } from '../plugin/web-search.js'
+
+describe('formatWebSearchResults', () => {
+  test('returns a friendly message when there are no results', () => {
+    expect(formatWebSearchResults([])).toBe('No results found.')
+  })
+
+  test('renders title as a markdown link with the URL', () => {
+    const results: WebSearchResult[] = [
+      { title: 'Servoy', url: 'https://servoy.com', snippet: 'Low-code platform' }
+    ]
+    const out = formatWebSearchResults(results)
+    expect(out).toContain('[Servoy](https://servoy.com)')
+    expect(out).toContain('Low-code platform')
+  })
+
+  test('includes domain and publish date when present', () => {
+    const results: WebSearchResult[] = [
+      {
+        title: 'Node 24',
+        url: 'https://nodejs.org',
+        snippet: 'Release',
+        domain: 'nodejs.org',
+        publishedDate: Date.UTC(2026, 0, 15)
+      }
+    ]
+    const out = formatWebSearchResults(results)
+    expect(out).toContain('nodejs.org')
+    expect(out).toContain('2026-01-15')
+  })
+
+  test('numbers multiple results in order', () => {
+    const results: WebSearchResult[] = [
+      { title: 'A', url: 'https://a.test', snippet: '' },
+      { title: 'B', url: 'https://b.test', snippet: '' }
+    ]
+    const out = formatWebSearchResults(results)
+    expect(out.indexOf('1. [A]')).toBeLessThan(out.indexOf('2. [B]'))
+  })
+
+  test('omits the meta line when neither domain nor date is present', () => {
+    const results: WebSearchResult[] = [{ title: 'X', url: 'https://x.test', snippet: 'hi' }]
+    const out = formatWebSearchResults(results)
+    expect(out).toBe('1. [X](https://x.test)\n   hi')
+  })
+})

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,3 +1,4 @@
+import { tool } from '@opencode-ai/plugin'
 import { KIRO_CONSTANTS } from './constants.js'
 import { AuthHandler } from './core/auth/auth-handler.js'
 import { RequestHandler } from './core/request/request-handler.js'
@@ -6,10 +7,61 @@ import { AccountRepository } from './infrastructure/database/account-repository.
 import { AccountManager } from './plugin/accounts.js'
 import { bootstrapAuthIfNeeded } from './plugin/auth-bootstrap.js'
 import { loadConfig } from './plugin/config/index.js'
+import { formatWebSearchResults, kiroWebSearch } from './plugin/web-search.js'
 
 type ToastFunction = (message: string, variant: string) => void
 
 const KIRO_PROVIDER_ID = 'kiro'
+
+// Register Kiro's server-side web search as a custom tool, when enabled and the
+// active account is Pro (has a profileArn). Returns an empty object otherwise so
+// nothing is advertised to the model on free accounts.
+//
+// The description is adapted from Kiro's own web_search tool spec so the model
+// gets the same guidance on when to search and how to attribute results.
+const WEB_SEARCH_DESCRIPTION = `Search the web using Kiro's built-in search engine. Returns titles, URLs, snippets, domains, and publish dates for a query. Billed as Kiro credits.
+
+## When to Use
+- The user asks for current or up-to-date information (pricing, versions, release notes, recent events, library APIs).
+- Verifying facts that may have changed recently, or details likely newer than the model's training data.
+- Looking up specifics of a library, framework, or tool that can't be reliably inferred from the codebase or context.
+
+## When NOT to Use
+- Basic concepts, historical facts, or well-established programming syntax the model already knows.
+- Anything answerable from the current repository, files, or conversation. Search the codebase first.
+
+## Query Tips
+- Keep queries focused; the query MUST be 200 characters or fewer (longer queries are rejected).
+- Rephrase the user's request into effective keywords. Run multiple focused searches for complex questions rather than one broad query.
+- The snippets often contain enough to answer directly; only fetch a full page (via a separate fetch tool) when you need more detail.
+
+## Using Results & Attribution
+- Prioritize the most recently published, authoritative sources (prefer official docs over blogs; use the domain to judge authority).
+- ALWAYS cite sources with inline links in the format [description](url).
+- Paraphrase and summarize; do not reproduce more than ~30 consecutive words verbatim from any single source. Preserve factual accuracy while condensing.`
+
+function buildTools(config: any, accountManager: AccountManager): Record<string, any> {
+  if (!config.web_search_enabled) return {}
+  const account = accountManager.getCurrentOrNext()
+  if (!account?.profileArn) return {}
+
+  return {
+    kiro_web_search: tool({
+      description: WEB_SEARCH_DESCRIPTION,
+      args: {
+        query: tool.schema.string().describe('The search query. Must be 200 characters or fewer.')
+      },
+      async execute(args: { query: string }) {
+        try {
+          const results = await kiroWebSearch(accountManager, args.query)
+          return formatWebSearchResults(results)
+        } catch (e) {
+          return `Web search failed: ${e instanceof Error ? e.message : String(e)}`
+        }
+      }
+    })
+  }
+}
 
 export const createKiroPlugin =
   (id: string) =>
@@ -176,7 +228,8 @@ export const createKiroPlugin =
 
           return normalized
         }
-      }
+      },
+      tool: buildTools(config, accountManager)
     }
   }
 

--- a/src/plugin/config/schema.ts
+++ b/src/plugin/config/schema.ts
@@ -95,7 +95,14 @@ export const KiroConfigSchema = z.object({
    * When true (default), maps budget ranges to effort levels.
    * When false, only uses explicit effort config or falls back to 'medium'.
    */
-  auto_effort_mapping: z.boolean().default(true)
+  auto_effort_mapping: z.boolean().default(true),
+
+  // Expose Kiro's server-side web search as a `kiro_web_search` tool. Kiro runs
+  // the search on its own infrastructure (billed as Kiro credits) and returns
+  // structured results. Requires a Pro account (profileArn); on free Builder ID
+  // accounts the tool is not registered. Disable to avoid overlap with other
+  // search tools/MCP servers.
+  web_search_enabled: z.boolean().default(true)
 })
 
 export type KiroConfig = z.infer<typeof KiroConfigSchema>
@@ -114,5 +121,6 @@ export const DEFAULT_CONFIG: KiroConfig = {
   usage_tracking_enabled: true,
   auto_sync_kiro_cli: true,
   enable_log_api_request: false,
-  auto_effort_mapping: true
+  auto_effort_mapping: true,
+  web_search_enabled: true
 }

--- a/src/plugin/web-search.ts
+++ b/src/plugin/web-search.ts
@@ -1,0 +1,110 @@
+import { KIRO_CONSTANTS } from '../constants.js'
+import { accessTokenExpired } from '../kiro/auth.js'
+import type { AccountManager } from './accounts.js'
+import * as logger from './logger.js'
+import { refreshAccessToken } from './token.js'
+import type { KiroAuthDetails } from './types'
+
+// Kiro exposes a server-side web search via the CodeWhisperer InvokeMCP target.
+// It speaks JSON-RPC (tools/call) and requires a profileArn, so it is only
+// available to Pro accounts. The query is capped at 200 characters by the API.
+const MCP_TARGET = 'AmazonCodeWhispererStreamingService.InvokeMCP'
+const MAX_QUERY_LENGTH = 200
+const REQUEST_TIMEOUT_MS = 30_000
+
+export interface WebSearchResult {
+  title: string
+  url: string
+  snippet: string
+  domain?: string
+  publishedDate?: number
+}
+
+interface McpResponse {
+  result?: { content?: Array<{ type: string; text: string }> }
+  error?: { code: number; message: string }
+}
+
+/**
+ * Call Kiro's server-side `web_search` MCP tool with a fresh access token.
+ * Returns parsed results, or throws with a readable message on failure.
+ */
+export async function kiroWebSearch(
+  accountManager: AccountManager,
+  query: string
+): Promise<WebSearchResult[]> {
+  const account = accountManager.getCurrentOrNext()
+  if (!account) throw new Error('No healthy Kiro account available')
+  if (!account.profileArn) {
+    throw new Error('Web search requires a Kiro Pro account (no profileArn on this account)')
+  }
+
+  let auth: KiroAuthDetails = accountManager.toAuthDetails(account)
+  if (accessTokenExpired(auth)) {
+    auth = await refreshAccessToken(auth)
+    accountManager.updateFromAuth(account, auth)
+  }
+
+  const trimmed = query.length > MAX_QUERY_LENGTH ? query.slice(0, MAX_QUERY_LENGTH) : query
+  const url = KIRO_CONSTANTS.BASE_URL.replace('/generateAssistantResponse', '/').replace(
+    '{{region}}',
+    auth.region
+  )
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${auth.access}`,
+      'Content-Type': 'application/x-amz-json-1.0',
+      'X-Amz-Target': MCP_TARGET,
+      'x-amzn-kiro-agent-mode': 'vibe'
+    },
+    body: JSON.stringify({
+      profileArn: auth.profileArn,
+      jsonrpc: '2.0',
+      id: '1',
+      method: 'tools/call',
+      params: { name: 'web_search', arguments: { query: trimmed } }
+    }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+  })
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    throw new Error(`Kiro web search failed: HTTP ${res.status} ${body.slice(0, 200)}`)
+  }
+
+  const data = (await res.json()) as McpResponse
+  if (data.error) {
+    throw new Error(`Kiro web search error: ${data.error.message}`)
+  }
+
+  const text = data.result?.content?.find((c) => c.type === 'text')?.text
+  if (!text) return []
+
+  try {
+    const parsed = JSON.parse(text) as { results?: WebSearchResult[] }
+    return parsed.results ?? []
+  } catch (e) {
+    logger.warn('Kiro web search: failed to parse results payload', e)
+    return []
+  }
+}
+
+/** Render results as compact markdown for the model to consume. */
+export function formatWebSearchResults(results: WebSearchResult[]): string {
+  if (results.length === 0) return 'No results found.'
+  return results
+    .map((r, i) => {
+      const lines = [`${i + 1}. [${r.title}](${r.url})`]
+      const meta: string[] = []
+      if (r.domain) meta.push(r.domain)
+      if (typeof r.publishedDate === 'number') {
+        meta.push(new Date(r.publishedDate).toISOString().slice(0, 10))
+      }
+      if (meta.length) lines.push(`   ${meta.join(' · ')}`)
+      if (r.snippet) lines.push(`   ${r.snippet}`)
+      return lines.join('\n')
+    })
+    .join('\n\n')
+}


### PR DESCRIPTION
## Summary

Expose Kiro's server-side web search as an OpenCode custom tool named
`kiro_web_search`. This is the same `web_search` tool the Kiro CLI uses — Kiro
runs the search on its own infrastructure and bills it as credits, returning
structured results (title, url, snippet, domain, publish date).

## Problem

OpenCode users on this plugin have no access to Kiro's built-in web search. Kiro
CLI exposes it, but the plugin only implemented `generateAssistantResponse` and
never wired up the search tool, so users had to rely on external search MCP
servers.

## Solution

Register a custom tool via the OpenCode `tool` helper. Its `execute` calls
Kiro's `InvokeMCP` endpoint (JSON-RPC `tools/call` with `name: "web_search"`) —
the exact protocol observed from the Kiro CLI — reusing the plugin's existing
auth/token/endpoint infrastructure.

### Changes

- `src/plugin/web-search.ts` (new) — `kiroWebSearch()` performs a fresh-token
  `InvokeMCP` call with a 30s timeout; `formatWebSearchResults()` renders
  results as markdown (title link, domain · date, snippet).
- `src/plugin.ts` — register `kiro_web_search` via the `tool` helper.
- `src/plugin/config/schema.ts` — add the `web_search_enabled` config flag.

### Design notes

- **Pro accounts only**: `InvokeMCP` requires a `profileArn` and 400s without
  one, so the tool is only registered when the active account has one. On free
  Builder ID accounts it is not advertised to the model.
- **Named `kiro_web_search`**: the `kiro_` prefix avoids collisions with other
  `web_search` tools/MCP servers and makes it clear this variant costs Kiro
  credits. The name sent to Kiro is still the server-side `web_search`.
- **`web_fetch` intentionally omitted**: Kiro does not expose `web_fetch` as a
  server-side tool (the CLI fetches URLs client-side), and OpenCode already ships
  a built-in fetch tool, so this PR leaves fetching to OpenCode.
- **Configurable**: set `"web_search_enabled": false` in `kiro.json` to disable
  and avoid overlap with an existing search MCP.
- The tool description is adapted from Kiro's own `web_search` spec, guiding the
  model on when to search vs. use the codebase, the 200-character query cap, and
  inline source attribution.

## Configuration

```json
// kiro.json
{
  "web_search_enabled": true
}
```

## Testing

- `bun test` — all pass (adds unit tests for result formatting)
- `bun run typecheck` — clean
- `bun run build` — clean
- Live end-to-end verification: the model invokes `kiro_web_search`, results
  return with correct URLs, and answers include inline source links.