### PR TITLE
Modernize Kiro provider integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 *.tsbuildinfo
 .vscode/*
 .sisyphus
+.opencode/

--- a/README.md
+++ b/README.md
@@ -4,398 +4,242 @@
 [![npm downloads](https://img.shields.io/npm/dm/@zhafron/opencode-kiro-auth)](https://www.npmjs.com/package/@zhafron/opencode-kiro-auth)
 [![license](https://img.shields.io/npm/l/@zhafron/opencode-kiro-auth)](https://www.npmjs.com/package/@zhafron/opencode-kiro-auth)
 
-OpenCode plugin for AWS Kiro (CodeWhisperer) providing access to Claude Sonnet and Haiku
-models with substantial trial quotas.
+OpenCode provider plugin for Kiro and Amazon Q Developer authentication. It exposes
+Kiro-supported models through OpenCode while using AWS Builder ID, IAM Identity Center,
+or an existing `kiro-cli` session for credentials.
 
-## Features
+## Requirements
 
-- **Multiple Auth Methods**: Supports AWS Builder ID (IDC), IAM Identity Center (custom
-  Start URL), and Kiro Desktop (CLI-based) authentication.
-- **Auto-Sync Kiro CLI**: Automatically imports and synchronizes active sessions from
-  your local `kiro-cli` SQLite database.
-- **Gradual Context Truncation**: Intelligently prevents error 400 by reducing context
-  size dynamically during retries.
-- **Intelligent Account Rotation**: Prioritizes multi-account usage based on lowest
-  available quota.
-- **High-Performance Storage**: Efficient account and usage management using native Bun
-  SQLite.
-- **Native Thinking Mode**: Full support for Claude reasoning capabilities via virtual
-  model mappings.
-- **Kiro Effort Mapping**: Maps OpenCode thinking budgets to Kiro's native effort
-  levels automatically.
-- **Automated Recovery**: Exponential backoff for rate limits and automated token
-  refresh.
+- OpenCode `>= 1.15.0`
+- Bun, as used by OpenCode plugin runtime
+- `kiro-cli` recommended for the most reliable IAM Identity Center profile selection
 
-## Installation
+## Install
 
-Add the plugin to your `opencode.json` or `opencode.jsonc`:
-
-```json
-{
-  "plugin": ["@zhafron/opencode-kiro-auth"],
-  "provider": {
-    "kiro": {
-      "models": {
-        "claude-sonnet-4-5": {
-          "name": "Claude Sonnet 4.5",
-          "limit": { "context": 200000, "output": 64000 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
-        },
-        "claude-sonnet-4-5-thinking": {
-          "name": "Claude Sonnet 4.5 Thinking",
-          "limit": { "context": 200000, "output": 64000 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
-          "variants": {
-            "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
-            "medium": { "thinkingConfig": { "thinkingBudget": 16384 } },
-            "high": { "thinkingConfig": { "thinkingBudget": 24576 } },
-            "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
-          }
-        },
-        "claude-sonnet-4-6": {
-          "name": "Claude Sonnet 4.6",
-          "limit": { "context": 1000000, "output": 64000 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
-        },
-        "claude-sonnet-4-6-thinking": {
-          "name": "Claude Sonnet 4.6 Thinking",
-          "limit": { "context": 1000000, "output": 64000 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
-          "variants": {
-            "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
-            "medium": { "thinkingConfig": { "thinkingBudget": 16384 } },
-            "high": { "thinkingConfig": { "thinkingBudget": 24576 } },
-            "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
-          }
-        },
-        "claude-haiku-4-5": {
-          "name": "Claude Haiku 4.5",
-          "limit": { "context": 200000, "output": 64000 },
-          "modalities": { "input": ["text", "image"], "output": ["text"] }
-        },
-        "claude-opus-4-5": {
-          "name": "Claude Opus 4.5",
-          "limit": { "context": 200000, "output": 64000 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
-        },
-        "claude-opus-4-5-thinking": {
-          "name": "Claude Opus 4.5 Thinking",
-          "limit": { "context": 200000, "output": 64000 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
-          "variants": {
-            "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
-            "medium": { "thinkingConfig": { "thinkingBudget": 16384 } },
-            "high": { "thinkingConfig": { "thinkingBudget": 24576 } },
-            "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
-          }
-        },
-        "claude-opus-4-6": {
-          "name": "Claude Opus 4.6",
-          "limit": { "context": 1000000, "output": 64000 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
-        },
-        "claude-opus-4-6-thinking": {
-          "name": "Claude Opus 4.6 Thinking",
-          "limit": { "context": 1000000, "output": 64000 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
-          "variants": {
-            "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
-            "medium": { "thinkingConfig": { "thinkingBudget": 16384 } },
-            "high": { "thinkingConfig": { "thinkingBudget": 24576 } },
-            "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
-          }
-        },
-        "claude-opus-4-6-1m": {
-          "name": "Claude Opus 4.6 (1M Context)",
-          "limit": { "context": 1000000, "output": 64000 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
-        },
-        "claude-opus-4-6-1m-thinking": {
-          "name": "Claude Opus 4.6 (1M Context) Thinking",
-          "limit": { "context": 1000000, "output": 64000 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
-          "variants": {
-            "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
-            "medium": { "thinkingConfig": { "thinkingBudget": 16384 } },
-            "high": { "thinkingConfig": { "thinkingBudget": 24576 } },
-            "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
-          }
-        },
-        "claude-opus-4-7": {
-          "name": "Claude Opus 4.7",
-          "limit": { "context": 1000000, "output": 64000 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
-        },
-        "claude-opus-4-7-thinking": {
-          "name": "Claude Opus 4.7 Thinking",
-          "limit": { "context": 1000000, "output": 64000 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
-          "variants": {
-            "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
-            "medium": { "thinkingConfig": { "thinkingBudget": 16384 } },
-            "high": { "thinkingConfig": { "thinkingBudget": 24576 } },
-            "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
-          }
-        },
-        "claude-sonnet-4-5-1m": {
-          "name": "Claude Sonnet 4.5 (1M Context)",
-          "limit": { "context": 1000000, "output": 64000 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
-        },
-        "claude-sonnet-4-6-1m": {
-          "name": "Claude Sonnet 4.6 (1M Context)",
-          "limit": { "context": 1000000, "output": 64000 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
-        },
-        "claude-sonnet-4-6-1m-thinking": {
-          "name": "Claude Sonnet 4.6 (1M Context) Thinking",
-          "limit": { "context": 1000000, "output": 64000 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
-          "variants": {
-            "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
-            "medium": { "thinkingConfig": { "thinkingBudget": 16384 } },
-            "high": { "thinkingConfig": { "thinkingBudget": 24576 } },
-            "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
-          }
-        },
-        "auto": { "name": "Auto (1.0x)" },
-        "claude-sonnet-4": {
-          "name": "Claude Sonnet 4.0 (1.3x)",
-          "limit": { "context": 200000, "output": 64000 }
-        },
-        "deepseek-3.2": {
-          "name": "DeepSeek 3.2 (0.25x)",
-          "limit": { "context": 128000, "output": 64000 }
-        },
-        "glm-5": { "name": "GLM-5 (0.5x)", "limit": { "context": 200000, "output": 64000 } },
-        "minimax-m2.5": {
-          "name": "MiniMax 2.5 (0.25x)",
-          "limit": { "context": 200000, "output": 64000 }
-        },
-        "minimax-m2.1": {
-          "name": "MiniMax 2.1 (0.15x)",
-          "limit": { "context": 200000, "output": 64000 }
-        },
-        "qwen3-coder-next": {
-          "name": "Qwen3 Coder Next (0.05x)",
-          "limit": { "context": 256000, "output": 64000 }
-        }
-      }
-    }
-  }
-}
-```
-
-### Thinking Effort Configuration
-
-Configure Kiro effort per model in your OpenCode provider model definitions by setting
-`thinkingConfig.thinkingBudget` on each model variant. The plugin automatically maps
-those budgets to Kiro's native `effort` field for supported Claude models, so you do
-not need to hardcode a global `effort` value in `~/.config/opencode/kiro.json`.
-
-```json
-{
-  "provider": {
-    "kiro": {
-      "models": {
-        "claude-opus-4-7-thinking": {
-          "name": "Claude Opus 4.7 Thinking",
-          "limit": { "context": 1000000, "output": 64000 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
-          "variants": {
-            "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
-            "medium": { "thinkingConfig": { "thinkingBudget": 16384 } },
-            "high": { "thinkingConfig": { "thinkingBudget": 24576 } },
-            "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
-          }
-        }
-      }
-    }
-  }
-}
-```
-
-Budget mapping:
-
-| OpenCode budget | Kiro effort |
-| --------------- | ----------- |
-| `<= 10000` | `low` |
-| `<= 20000` | `medium` |
-| `<= 28000` | `high` |
-| `> 28000` | `max` |
-
-Use `~/.config/opencode/kiro.json` for plugin-wide behavior such as auth sync,
-account selection, retry limits, and `auto_effort_mapping`. A top-level `effort`
-setting is a global override for all supported models, not a per-model setting.
-
-## Setup
-
-1. **Authentication via Kiro CLI (Recommended)**:
-   - Perform login directly in your terminal using `kiro-cli login`.
-   - The plugin automatically bootstraps a minimal `kiro` placeholder in
-     OpenCode's `auth.json` when it detects the Kiro CLI database, then imports
-     and synchronizes your active session on startup.
-   - For AWS IAM Identity Center (SSO/IDC), the plugin imports both the token and device
-     registration (OIDC client credentials) from the `kiro-cli` database.
-2. **Direct Authentication**:
-   - Run `opencode auth login`.
-   - Select `Other`, type `kiro`, and press enter.
-   - You'll be prompted for your **IAM Identity Center Start URL** and **IAM Identity
-     Center region** (`sso_region`).
-     - Leave it blank to sign in with **AWS Builder ID**.
-     - Enter your company's Start URL (e.g. `https://your-company.awsapps.com/start`) to
-       use **IAM Identity Center (SSO)**.
-   - Note: the TUI `/connect` flow currently does **not** run plugin OAuth prompts
-     (Start URL / region), so Identity Center logins may fall back to Builder ID unless
-     you use `opencode auth login` (or preconfigure defaults in
-     `~/.config/opencode/kiro.json`).
-   - For **IAM Identity Center**, you may also need a **profile ARN** (`profileArn`).
-     - If `kiro-cli` is installed and you've selected a profile once
-       (`kiro-cli profile`), the plugin auto-detects it.
-     - Otherwise, set `idc_profile_arn` in `~/.config/opencode/kiro.json`.
-   - A browser window will open directly to AWS' verification URL (no local auth
-     server). If it doesn't, copy/paste the URL and enter the code printed by OpenCode.
-   - You can also pre-configure defaults in `~/.config/opencode/kiro.json` via
-     `idc_start_url` and `idc_region`.
-3. Configuration will be automatically managed at `~/.config/opencode/kiro.db`.
-
-## Local plugin development
-
-The simplest way to test local changes is to point OpenCode directly at your local repo
-path in `opencode.json` or `opencode.jsonc`:
-
-```json
-{
-  "plugin": ["/path/to/opencode-kiro-auth"]
-}
-```
-
-Then build and restart OpenCode to pick up changes:
+Recommended install:
 
 ```bash
-npm run build
+opencode plugin @zhafron/opencode-kiro-auth --global
 ```
 
-## Troubleshooting
+OpenCode's plugin installer reads this package's server and TUI entrypoints and updates
+both config files. If you configure it manually, add the server plugin to
+`~/.config/opencode/opencode.jsonc`:
 
-### Error: Status: 403 (AccessDeniedException / User is not authorized)
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["@zhafron/opencode-kiro-auth"]
+}
+```
 
-If you're using **IAM Identity Center** (a custom Start URL), the Q Developer /
-CodeWhisperer APIs typically require a **profile ARN**.
+And add the TUI plugin to `~/.config/opencode/tui.jsonc`:
 
-This plugin reads the active profile ARN from your local `kiro-cli` database
-(`state.key = api.codewhisperer.profile`) and sends it as `profileArn`.
+```jsonc
+{
+  "$schema": "https://opencode.ai/tui.json",
+  "plugin": ["@zhafron/opencode-kiro-auth"]
+}
+```
 
-Fix:
+The plugin registers provider ID `kiro`, sets `@ai-sdk/openai-compatible`, and injects
+the current built-in model catalog. You normally do not need to copy model definitions
+into your OpenCode config.
 
-1. Run `kiro-cli profile` and select a profile (e.g. `QDevProfile-us-east-1`).
-2. Retry `opencode auth login` (or restart OpenCode so it re-syncs).
+## Models
 
-### Error: No accounts
+The plugin injects the default Kiro model catalog automatically. Do not add model
+definitions to your OpenCode config unless you are intentionally overriding local
+display metadata.
 
-This happens when the plugin has no records in `~/.config/opencode/kiro.db`.
+The catalog includes Claude Sonnet 5 and all three GPT-5.6 tiers: `gpt-5.6-sol`,
+`gpt-5.6-terra`, and `gpt-5.6-luna`. Each GPT-5.6 model has a 272K context window;
+their Kiro credit multipliers are 2.4x, 1.2x, and 0.6x respectively.
 
-1. Ensure `kiro-cli login` succeeds.
-2. Ensure `auto_sync_kiro_cli` is `true` in `~/.config/opencode/kiro.json`.
-3. Retry the request; the plugin will attempt a Kiro CLI sync when it detects zero
-   accounts.
+For models that support configurable effort, the plugin exposes native OpenCode model
+variants. Use your configured variant-cycle keybinding to switch levels. GPT-5.6 Sol,
+Terra, and Luna and Opus 4.7/4.8 expose `low`, `medium`, `high`, `xhigh`, and `max`;
+Opus 4.6 and Sonnet 4.6 expose `low`, `medium`, `high`, and `max`. Kiro's UI label
+`Min` corresponds to the API value `low`.
 
-### Note: `/connect` vs `opencode auth login`
+For compatibility with older configs, the request layer still converts historical
+aliases where possible, including dotted Claude IDs, hyphenated Claude IDs,
+`*-thinking` IDs, and older `*-1m` IDs. These fallbacks are only for existing configs;
+new installs should use the injected provider catalog.
 
-If you need to enter provider-specific values for an OAuth login (like IAM Identity
-Center Start URL / region), use `opencode auth login`. The current TUI `/connect` flow
-may not display plugin OAuth prompts, so it can’t collect those inputs.
+## Authentication
 
-Note for IDC/SSO (ODIC): the plugin may temporarily create an account with a placeholder
-email if it cannot fetch the real email during sync (e.g. offline).
-It will replace it with the real email once usage/email lookup succeeds.
+### Recommended: sync from Kiro CLI
 
-### Kiro CLI (Google/GitHub OAuth) users: plugin sync does not start
+1. Run `kiro-cli login`.
+2. If you use IAM Identity Center, verify the selected Amazon Q Developer or
+   CodeWhisperer profile with `kiro-cli whoami --format json`.
+3. Start OpenCode.
 
-If you authenticated via `kiro-cli login` using Google or GitHub OAuth (not AWS Builder
-ID or IAM Identity Center), OpenCode still needs a stored `kiro` auth entry before it
-will call the plugin loader.
+When `auto_sync_kiro_cli` is enabled, the plugin reads the local `kiro-cli` SQLite
+session, imports access/refresh tokens and OIDC client credentials, imports the active
+profile ARN, and creates the minimal OpenCode auth placeholder needed for provider
+loader startup.
 
-The plugin now creates that minimal placeholder automatically when it detects the local
-Kiro CLI database. Restart OpenCode after `kiro-cli login`; the loader should then run
-and sync your actual tokens into `kiro.db`. The placeholder values are not used for API
-calls.
+### Direct OpenCode login
 
-If bootstrap is skipped because `auth.json` is malformed, fix the JSON first. The plugin
-will not overwrite malformed auth files because they may contain other provider
-credentials.
+Run:
 
-**Important:** Ensure `auto_sync_kiro_cli` is `true` in `~/.config/opencode/kiro.json`
-and that `kiro-cli login` succeeds.
+```bash
+opencode auth login --provider kiro
+```
 
-The plugin supports extensive configuration options.
-Edit `~/.config/opencode/kiro.json`:
+Choose `AWS Builder ID / IAM Identity Center`.
+
+- Leave Start URL blank for AWS Builder ID.
+- Enter your IAM Identity Center Start URL for organization SSO, for example
+  `https://d-xxxxxxxxxx.awsapps.com/start`.
+- Enter the IAM Identity Center region, also called `sso_region`.
+- For IAM Identity Center, set a profile ARN if usage or generation returns 403.
+
+The plugin uses the IAM Identity Center device authorization flow, opens the AWS
+verification page directly, caches OIDC public-client registration securely under
+`~/.config/opencode`, and refreshes access tokens without starting a local callback
+server.
+
+## Configuration
+
+User config lives at `~/.config/opencode/kiro.json`. A default file is created
+automatically.
 
 ```json
 {
   "auto_sync_kiro_cli": true,
   "account_selection_strategy": "lowest-usage",
   "default_region": "us-east-1",
-  "idc_start_url": "https://your-company.awsapps.com/start",
+  "idc_start_url": "https://d-xxxxxxxxxx.awsapps.com/start",
   "idc_region": "us-east-1",
-  "rate_limit_retry_delay_ms": 5000,
-  "rate_limit_max_retries": 3,
-  "max_request_iterations": 20,
-  "request_timeout_ms": 120000,
-  "token_expiry_buffer_ms": 120000,
-  "usage_sync_max_retries": 3,
+  "idc_profile_arn": "arn:aws:codewhisperer:us-east-1:123456789012:profile/XXXXXXXXXX",
   "usage_tracking_enabled": true,
-  "auto_effort_mapping": true,
-  "enable_log_api_request": false
+  "sdk_endpoint_mode": "auto",
+  "auto_effort_mapping": false,
+  "request_timeout_ms": 120000
 }
 ```
 
-### Configuration Options
+Environment overrides:
 
-- `auto_sync_kiro_cli`: Automatically sync sessions from Kiro CLI (default: `true`).
-- `account_selection_strategy`: Account rotation strategy (`sticky`, `round-robin`,
-  `lowest-usage`).
-- `default_region`: AWS region (`us-east-1`, `us-west-2`).
-- `idc_start_url`: Default IAM Identity Center Start URL (e.g.
-  `https://your-company.awsapps.com/start`). Leave unset/blank to default to AWS Builder
-  ID.
-- `idc_region`: IAM Identity Center (SSO OIDC) region (`sso_region`). Defaults to
-  `us-east-1`.
-- `rate_limit_retry_delay_ms`: Delay between rate limit retries (1000-60000ms).
-- `rate_limit_max_retries`: Maximum retry attempts for rate limits (0-10).
-- `max_request_iterations`: Maximum loop iterations to prevent hangs (10-1000).
-- `request_timeout_ms`: Request timeout in milliseconds (60000-600000ms).
-- `token_expiry_buffer_ms`: Token refresh buffer time (30000-300000ms).
-- `usage_sync_max_retries`: Retry attempts for usage sync (0-5).
-- `auth_server_port_start`: Legacy/ignored (no local auth server).
-- `auth_server_port_range`: Legacy/ignored (no local auth server).
-- `usage_tracking_enabled`: Enable usage tracking and toast notifications.
-- `auto_effort_mapping`: Automatically map OpenCode thinking budgets to Kiro effort
-  levels for supported models (default: `true`).
-- `enable_log_api_request`: Enable detailed API request logging.
+- `KIRO_IDC_START_URL`
+- `KIRO_IDC_REGION`
+- `KIRO_IDC_PROFILE_ARN`
+- `KIRO_DEFAULT_REGION`
+- `KIRO_AUTO_SYNC_KIRO_CLI`
+- `KIRO_ACCOUNT_SELECTION_STRATEGY`
+- `KIRO_USAGE_TRACKING_ENABLED`
+- `KIRO_SDK_ENDPOINT_MODE` (`auto`, `kiro-runtime`, or `legacy-q`)
+- `KIRO_ENABLE_LOG_API_REQUEST`
+- `KIRO_AUTO_EFFORT_MAPPING`
 
-## Storage
+## TUI Usage Panel
 
-**Linux/macOS:**
+The package exposes a separate TUI plugin at `@zhafron/opencode-kiro-auth/tui`.
+When the package is listed in `tui.jsonc`, OpenCode resolves that subpath automatically.
 
-- SQLite Database: `~/.config/opencode/kiro.db`
-- Plugin Config: `~/.config/opencode/kiro.json`
+The TUI plugin reads `~/.config/opencode/kiro.db` in readonly mode, refreshes every 15
+seconds, and shows:
 
-**Windows:**
+- `Kiro`
+- `Account: <email>`, disabled by default
+- `Plan: <plan>`, for example `Plan: KIRO PRO+`
+- `Credits: <used> / <limit>`, with used credits shown to two decimals
 
-- SQLite Database: `%APPDATA%\opencode\kiro.db`
-- Plugin Config: `%APPDATA%\opencode\kiro.json`
+Optional display fields can be configured in `tui.jsonc`:
 
-## Acknowledgements
+```jsonc
+{
+  "$schema": "https://opencode.ai/tui.json",
+  "plugin": [
+    [
+      "@zhafron/opencode-kiro-auth",
+      {
+        "show_account_email": true,
+        "show_plan": true,
+        "show_credits": true
+      }
+    ]
+  ]
+}
+```
 
-Special thanks to [AIClient-2-API](https://github.com/justlovemaki/AIClient-2-API) for
-providing the foundational Kiro authentication logic and request patterns.
+`show_account_email` defaults to `false`; `show_plan` and `show_credits` default to
+`true`.
 
-## Disclaimer
+OpenCode only shows the session sidebar automatically when the terminal is wider than
+120 columns. On narrower terminals, use the sidebar toggle from the command palette.
+The Kiro section is hidden for sessions whose active message provider is not `kiro`.
+If `kiro.db` contains multiple healthy Kiro credential rows, the panel shows the latest
+healthy row by `last_used`. With a single logged-in account, this matches the active
+account. OpenCode's TUI plugin API exposes session provider metadata, but not the exact
+Kiro account selected by the server plugin for the current request, so the displayed
+quota is best-effort only when multiple healthy credentials are stored.
+The TUI does not read access tokens, refresh tokens, client secrets, or OIDC
+credentials.
 
-This plugin is provided strictly for learning and educational purposes.
-It is an independent implementation and is not affiliated with, endorsed by, or
-supported by Amazon Web Services (AWS) or Anthropic.
-Use of this plugin is at your own risk.
+If the panel is empty:
 
-Feel free to open a PR to optimize this plugin further.
+1. Confirm the TUI config contains the plugin:
+
+   ```jsonc
+   {
+     "$schema": "https://opencode.ai/tui.json",
+     "plugin": ["@zhafron/opencode-kiro-auth"]
+   }
+   ```
+
+2. Confirm usage tracking is enabled in `~/.config/opencode/kiro.json`.
+3. Run one Kiro request or restart OpenCode so the server plugin can sync quota.
+4. Check `~/.config/opencode/kiro.db` for an `accounts` row with `used_count`,
+   `limit_count`, and `subscription_plan`.
+
+## Troubleshooting
+
+### No accounts
+
+Run `kiro-cli login`, verify IAM Identity Center state with
+`kiro-cli whoami --format json`, and keep `auto_sync_kiro_cli` enabled. The plugin
+imports CLI credentials during startup.
+
+### 403 AccessDeniedException
+
+IAM Identity Center accounts commonly require a Q Developer or CodeWhisperer profile
+ARN. Inspect the active profile with:
+
+```bash
+kiro-cli whoami --format json
+```
+
+Then restart OpenCode, or set `idc_profile_arn` in `~/.config/opencode/kiro.json`.
+
+### Stale `kiro-auth` provider config
+
+Older versions used provider ID `kiro-auth`. Current versions use `kiro`. The plugin
+migrates an existing `kiro-auth` auth entry to `kiro` when possible, but your OpenCode
+config should use `kiro` going forward.
+
+### Logs
+
+Plugin logs are written to:
+
+```text
+~/.config/opencode/kiro-logs/plugin.log
+```
+
+OpenCode logs are written to:
+
+```text
+~/.local/share/opencode/log
+```
+
+## Development
+
+```bash
+bun install
+bun run typecheck
+bun test
+bun run build
+```

--- a/bun.lock
+++ b/bun.lock
@@ -1,30 +1,32 @@
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {
       "name": "@zhafron/opencode-kiro-auth",
       "dependencies": {
-        "@aws/codewhisperer-streaming-client": "^1.0.34",
-        "@opencode-ai/plugin": "^1.15.11",
-        "libsql": "^0.5.29",
+        "@aws/codewhisperer-streaming-client": "^1.0.45",
+        "@opencode-ai/plugin": "1.15.11",
+        "@opentui/solid": "0.2.15",
+        "libsql": "0.5.29",
         "proper-lockfile": "^4.1.2",
-        "zod": "^3.24.0",
+        "solid-js": "1.9.12",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@types/node": "^20.0.0",
+        "@types/node": "^25.9.1",
         "@types/proper-lockfile": "^4.1.4",
-        "bun-types": "^1.3.6",
+        "bun-types": "^1.3.14",
         "husky": "^9.1.7",
-        "lint-staged": "^16.2.7",
-        "prettier": "^3.4.2",
-        "prettier-plugin-organize-imports": "^4.1.0",
-        "typescript": "^5.7.3",
+        "lint-staged": "^17.0.5",
+        "prettier": "^3.8.3",
+        "prettier-plugin-organize-imports": "^4.3.0",
+        "typescript": "^6.0.3",
       },
     },
   },
   "packages": {
-    "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],
+    "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
 
     "@aws-crypto/sha256-browser": ["@aws-crypto/sha256-browser@5.2.0", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw=="],
 
@@ -34,39 +36,103 @@
 
     "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
 
-    "@aws-sdk/core": ["@aws-sdk/core@3.974.14", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@aws-sdk/xml-builder": "^3.972.26", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.3", "@smithy/signature-v4": "^5.4.2", "@smithy/types": "^4.14.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw=="],
+    "@aws-sdk/core": ["@aws-sdk/core@3.975.2", "", { "dependencies": { "@aws-sdk/types": "^3.974.1", "@aws-sdk/xml-builder": "^3.972.35", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.29.3", "@smithy/signature-v4": "^5.6.3", "@smithy/types": "^4.16.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-iyeXwziyjJpixq5OmhsIyrSWx8vwcI7gDo4yRUC3EP7NQtOo9iAJiIEc3G+/HkhtNXqOhofiCK7Lc34Sq+fJWg=="],
 
-    "@aws-sdk/middleware-host-header": ["@aws-sdk/middleware-host-header@3.972.15", "", { "dependencies": { "@aws-sdk/core": "^3.974.14", "tslib": "^2.6.2" } }, "sha512-BMvPJcSE+e5Up4eRvIVDOp6Aiwh3ce0z9FJ8LsRBGE9d64j67HLdyqlDaUtzCjmhxDvxw+qIiAElu3+AOzhAnA=="],
+    "@aws-sdk/middleware-host-header": ["@aws-sdk/middleware-host-header@3.972.33", "", { "dependencies": { "@aws-sdk/core": "^3.975.2", "tslib": "^2.6.2" } }, "sha512-26d1lQUNxee2i6Q9pWnrf3PKZEbZDo2uXq49qr39zedmZjjxbHqH/3HrntqT+ewicXbvU9jHDd0R4L5f4atjug=="],
 
-    "@aws-sdk/middleware-logger": ["@aws-sdk/middleware-logger@3.972.14", "", { "dependencies": { "@aws-sdk/core": "^3.974.14", "tslib": "^2.6.2" } }, "sha512-f/9Rln5bNIoHwPVxSXmW5+8SnteHFwwuoR5Ce+SEis36fKw7pu84G2SpaWRpGqj7zbIAECFVJ+pDiGfQq5r4FQ=="],
+    "@aws-sdk/middleware-logger": ["@aws-sdk/middleware-logger@3.972.32", "", { "dependencies": { "@aws-sdk/core": "^3.975.2", "tslib": "^2.6.2" } }, "sha512-1ibxzLkANdabnOpzQab4JHDVV3hxGohM572na6+BXPPrcp6unL4kUBR9UneqkykioiPZovCf0nozyWJVL/fI7g=="],
 
-    "@aws-sdk/middleware-recursion-detection": ["@aws-sdk/middleware-recursion-detection@3.972.16", "", { "dependencies": { "@aws-sdk/core": "^3.974.14", "tslib": "^2.6.2" } }, "sha512-AGAe/c6Da/FEjtkR3LViqvaJdxaHQqcVpmf6UMBRQ3e8G2c6EWqjRidMw/FiQzWXUrmfjgXoVcc8QXc4kcuWLQ=="],
+    "@aws-sdk/middleware-recursion-detection": ["@aws-sdk/middleware-recursion-detection@3.972.34", "", { "dependencies": { "@aws-sdk/core": "^3.975.2", "tslib": "^2.6.2" } }, "sha512-Kwno9l0Y2kcOBuz9ltcxN8LYKi6rLt4vobIIWXzalGOT99MRPgNv6OT5kd1/hUknOjioH84ZwjXncM+an9FNRg=="],
 
-    "@aws-sdk/middleware-user-agent": ["@aws-sdk/middleware-user-agent@3.972.44", "", { "dependencies": { "@aws-sdk/core": "^3.974.14", "tslib": "^2.6.2" } }, "sha512-K9kryZwhKBsAdk1R6TCMSUDGF2XjMcC89Qm/6o8szdRSodN5MIlo3KzAV4vKyKTkOu/UwoB+Yrj78M+omPZzkA=="],
+    "@aws-sdk/middleware-user-agent": ["@aws-sdk/middleware-user-agent@3.972.62", "", { "dependencies": { "@aws-sdk/core": "^3.975.2", "tslib": "^2.6.2" } }, "sha512-bUffSXPRyCvvleVXWspBXofEpOfuePpDn0A4f1a5rm/gI7UNeVLmYBEvcLnNOhBFY75gjrGpf+EwpG0c8acTcQ=="],
 
-    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.12", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.14", "@aws-sdk/signature-v4-multi-region": "^3.996.29", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/fetch-http-handler": "^5.4.3", "@smithy/node-http-handler": "^4.7.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q=="],
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.32", "", { "dependencies": { "@aws-sdk/core": "^3.975.2", "@aws-sdk/signature-v4-multi-region": "^3.996.40", "@aws-sdk/types": "^3.974.1", "@smithy/core": "^3.29.3", "@smithy/fetch-http-handler": "^5.6.5", "@smithy/node-http-handler": "^4.9.5", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-6Yj2fr9XF67cndITea48rchTdVr3VGx6PN47bIKNinJAjLkmaIlz/4EBPCgJ8UmhVopiXmeAuPLI3+DXDDbMhQ=="],
 
-    "@aws-sdk/region-config-resolver": ["@aws-sdk/region-config-resolver@3.972.18", "", { "dependencies": { "@aws-sdk/core": "^3.974.14", "tslib": "^2.6.2" } }, "sha512-FQLLmG0RHPleDCQAkl10LNH5L+FDOcUKwnRHRhfH0NHhleo46j9u1q0UHlVbKYOBfB0LjQMQgioxrWvLqEZ5Bg=="],
+    "@aws-sdk/region-config-resolver": ["@aws-sdk/region-config-resolver@3.972.36", "", { "dependencies": { "@aws-sdk/core": "^3.975.2", "tslib": "^2.6.2" } }, "sha512-CNpT4MLGlVCsFNu6x7iaYDLK5LXqTm4RCPms1XO2xEuqSIbaV3XWv4zkiBMAzBSNmSeYzCDrrQ+ZRxoI2eKOJQ=="],
 
-    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.29", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@smithy/signature-v4": "^5.4.2", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Few9FoQqOt/0KSvZYP+qdW0dfOhfQ9N+gl2UUDvCPW6mkPKHli9LMbKxWj+wZ5zKPaOoqxuR3Hhy3OTpndkfSw=="],
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.40", "", { "dependencies": { "@aws-sdk/types": "^3.974.1", "@smithy/signature-v4": "^5.6.3", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-wrGZ/authosokclY1DXsiWT/1WjfCI22FuZGgdcilF+XLTXs5dCjAtiFYSPsEToZkbm3Lj2YP8PoWg0yoMNu0g=="],
 
-    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1055.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.14", "@aws-sdk/nested-clients": "^3.997.12", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-NSCniZ0HmeOWrX1k9aXZtKEST+JlNqOMNe87Vll1y25WlHOErNGgk8oFoMGnbiuWsG8ZS8zLby8fqVmrH8/ufQ=="],
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1087.0", "", { "dependencies": { "@aws-sdk/core": "^3.975.2", "@aws-sdk/nested-clients": "^3.997.32", "@aws-sdk/types": "^3.974.1", "@smithy/core": "^3.29.3", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-umM+qNq16f2fH+VLM5MqXW4ORNQAjk+TOSto73xbUHcKaU41L48j786r3UWQYlejeJk37NlvRYgxBT+MBkfaYQ=="],
 
-    "@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
+    "@aws-sdk/types": ["@aws-sdk/types@3.974.1", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-W0IQZR0eaBqlBFIIofMapaWkw1W0U+Xi4dvW+BqwmCEMd8Ng2U6IhkxuPSjMVnR8klLjfuS9PeZWUl1N6UaZdg=="],
 
-    "@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.996.13", "", { "dependencies": { "@aws-sdk/core": "^3.974.14", "@smithy/core": "^3.24.3", "tslib": "^2.6.2" } }, "sha512-uuAuMkEzZHfiOkIRj2xexSSgfvBnhbI+6pd+o/RET7EZXDG1wrC4PINCs0PTkswYhD6kOb+av4NG89CWLC5/4Q=="],
+    "@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.996.31", "", { "dependencies": { "@aws-sdk/core": "^3.975.2", "@smithy/core": "^3.29.3", "tslib": "^2.6.2" } }, "sha512-M1O7XN1aDXe9RC6kWm5bUTqu7N6d0ZTg5lcRX6S5r3AAJ4Oug1mJ++5HK2bSgGSmqYJR1a3IRGzYE91XdKMpXA=="],
 
-    "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.5", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ=="],
+    "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.8", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g=="],
 
-    "@aws-sdk/util-user-agent-browser": ["@aws-sdk/util-user-agent-browser@3.972.15", "", { "dependencies": { "@aws-sdk/core": "^3.974.14", "tslib": "^2.6.2" } }, "sha512-8/+GtB/BjIul7uGFXNztIeiQBZbb1eEl/+M8Q+l1qg9uKSGEZf4VtI+9VidrQ3BBE1J1GDkn5W/n+tuHhXSbOg=="],
+    "@aws-sdk/util-user-agent-browser": ["@aws-sdk/util-user-agent-browser@3.972.33", "", { "dependencies": { "@aws-sdk/core": "^3.975.2", "tslib": "^2.6.2" } }, "sha512-Vh+kkm3Gu4i8C3tveOrlTPNUZOJXbjNpumYpKcQDJsfl+PCCra8i7g8k4qDoqPZNuXVjXu8wST40O1IEYdP8ng=="],
 
-    "@aws-sdk/util-user-agent-node": ["@aws-sdk/util-user-agent-node@3.973.30", "", { "dependencies": { "@aws-sdk/core": "^3.974.14", "tslib": "^2.6.2" } }, "sha512-W5Pr3Kl9tyH7Pcht2sx90YeO2ennDIwzbBVfQ+bt6MQUNMtf+hPMic8O/IsSWRNn1qTgfuCjTYmB/UD4A75xBA=="],
+    "@aws-sdk/util-user-agent-node": ["@aws-sdk/util-user-agent-node@3.973.48", "", { "dependencies": { "@aws-sdk/core": "^3.975.2", "tslib": "^2.6.2" } }, "sha512-2k1N85vDQ731XGXBCzASCbO5qPDYYzRpZV8nj1gqOCbsWWnsY2f9dhTa47Q9FzPpfihktKzwWY4fyZZTZEdHZw=="],
 
-    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.26", "", { "dependencies": { "@smithy/types": "^4.14.2", "fast-xml-parser": "5.7.3", "tslib": "^2.6.2" } }, "sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g=="],
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.35", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-pXzaWe3evZhjxDXAlMnqISe/XefTCGwBJG4nFTXaWSgAnMkqPEhxEPqJNhhpGesEvKFhvNpnozJJ4GTL11bRYw=="],
 
     "@aws/codewhisperer-streaming-client": ["@aws/codewhisperer-streaming-client@1.0.45", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.7", "@aws-sdk/middleware-host-header": "^3.972.10", "@aws-sdk/middleware-logger": "^3.972.10", "@aws-sdk/middleware-recursion-detection": "^3.972.11", "@aws-sdk/middleware-user-agent": "^3.972.37", "@aws-sdk/region-config-resolver": "^3.972.13", "@aws-sdk/token-providers": "^3.1040.0", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-endpoints": "^3.996.8", "@aws-sdk/util-user-agent-browser": "^3.972.10", "@aws-sdk/util-user-agent-node": "^3.973.23", "@smithy/config-resolver": "^4.4.17", "@smithy/core": "^3.23.17", "@smithy/eventstream-serde-browser": "^4.2.14", "@smithy/eventstream-serde-config-resolver": "^4.3.14", "@smithy/eventstream-serde-node": "^4.2.14", "@smithy/fetch-http-handler": "^5.3.17", "@smithy/hash-node": "^4.2.14", "@smithy/invalid-dependency": "^4.2.14", "@smithy/middleware-content-length": "^4.2.14", "@smithy/middleware-endpoint": "^4.4.32", "@smithy/middleware-retry": "^4.5.7", "@smithy/middleware-serde": "^4.2.20", "@smithy/middleware-stack": "^4.2.14", "@smithy/node-config-provider": "^4.3.14", "@smithy/node-http-handler": "^4.6.1", "@smithy/protocol-http": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.49", "@smithy/util-defaults-mode-node": "^4.2.54", "@smithy/util-endpoints": "^3.4.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-retry": "^4.3.6", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-XvqUjgrA+hS8bK/dU9tUhooxlYWLbIYNYg461gMcD2QQHAd+fXwqrImgcJ/pvU6LedguvTal1Vdd9Pf4I0O0Jg=="],
 
-    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.4", "", {}, "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ=="],
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.3.0", "", {}, "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
+
+    "@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
+
+    "@babel/core": ["@babel/core@7.28.0", "", { "dependencies": { "@ampproject/remapping": "^2.2.0", "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.0", "@babel/helper-compilation-targets": "^7.27.2", "@babel/helper-module-transforms": "^7.27.3", "@babel/helpers": "^7.27.6", "@babel/parser": "^7.28.0", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.0", "@babel/types": "^7.28.0", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ=="],
+
+    "@babel/generator": ["@babel/generator@7.29.7", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ=="],
+
+    "@babel/helper-annotate-as-pure": ["@babel/helper-annotate-as-pure@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" } }, "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.29.7", "", { "dependencies": { "@babel/compat-data": "^7.29.7", "@babel/helper-validator-option": "^7.29.7", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g=="],
+
+    "@babel/helper-create-class-features-plugin": ["@babel/helper-create-class-features-plugin@7.29.7", "", { "dependencies": { "@babel/helper-annotate-as-pure": "^7.29.7", "@babel/helper-member-expression-to-functions": "^7.29.7", "@babel/helper-optimise-call-expression": "^7.29.7", "@babel/helper-replace-supers": "^7.29.7", "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7", "@babel/traverse": "^7.29.7", "semver": "^6.3.1" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
+
+    "@babel/helper-member-expression-to-functions": ["@babel/helper-member-expression-to-functions@7.29.7", "", { "dependencies": { "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.29.7", "", { "dependencies": { "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.29.7", "", { "dependencies": { "@babel/helper-module-imports": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7", "@babel/traverse": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg=="],
+
+    "@babel/helper-optimise-call-expression": ["@babel/helper-optimise-call-expression@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" } }, "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong=="],
+
+    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.29.7", "", {}, "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw=="],
+
+    "@babel/helper-replace-supers": ["@babel/helper-replace-supers@7.29.7", "", { "dependencies": { "@babel/helper-member-expression-to-functions": "^7.29.7", "@babel/helper-optimise-call-expression": "^7.29.7", "@babel/traverse": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ=="],
+
+    "@babel/helper-skip-transparent-expression-wrappers": ["@babel/helper-skip-transparent-expression-wrappers@7.29.7", "", { "dependencies": { "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.29.7", "", {}, "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw=="],
+
+    "@babel/helpers": ["@babel/helpers@7.29.7", "", { "dependencies": { "@babel/template": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg=="],
+
+    "@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
+
+    "@babel/plugin-syntax-jsx": ["@babel/plugin-syntax-jsx@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A=="],
+
+    "@babel/plugin-syntax-typescript": ["@babel/plugin-syntax-typescript@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA=="],
+
+    "@babel/plugin-transform-modules-commonjs": ["@babel/plugin-transform-modules-commonjs@7.29.7", "", { "dependencies": { "@babel/helper-module-transforms": "^7.29.7", "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ=="],
+
+    "@babel/plugin-transform-typescript": ["@babel/plugin-transform-typescript@7.29.7", "", { "dependencies": { "@babel/helper-annotate-as-pure": "^7.29.7", "@babel/helper-create-class-features-plugin": "^7.29.7", "@babel/helper-plugin-utils": "^7.29.7", "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7", "@babel/plugin-syntax-typescript": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw=="],
+
+    "@babel/preset-typescript": ["@babel/preset-typescript@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1", "@babel/helper-validator-option": "^7.27.1", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-transform-modules-commonjs": "^7.27.1", "@babel/plugin-transform-typescript": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ=="],
+
+    "@babel/template": ["@babel/template@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/types": "^7.29.7", "debug": "^4.3.1" } }, "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw=="],
+
+    "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@libsql/darwin-arm64": ["@libsql/darwin-arm64@0.5.29", "", { "os": "darwin", "cpu": "arm64" }, "sha512-K+2RIB1OGFPYQbfay48GakLhqf3ArcbHqPFu7EZiaUcRgFcdw8RoltsMyvbj5ix2fY0HV3Q3Ioa/ByvQdaSM0A=="],
 
@@ -100,236 +166,348 @@
 
     "@neon-rs/load": ["@neon-rs/load@0.0.4", "", {}, "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw=="],
 
-    "@nodable/entities": ["@nodable/entities@2.1.0", "", {}, "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA=="],
-
     "@opencode-ai/plugin": ["@opencode-ai/plugin@1.15.11", "", { "dependencies": { "@opencode-ai/sdk": "1.15.11", "effect": "4.0.0-beta.66", "zod": "4.1.8" }, "peerDependencies": { "@opentui/core": ">=0.2.15", "@opentui/keymap": ">=0.2.15", "@opentui/solid": ">=0.2.15" }, "optionalPeers": ["@opentui/core", "@opentui/keymap", "@opentui/solid"] }, "sha512-RDvYDCHO0+3OAGD590oDQqtryrENrUW04SjtoA4sgRV2efpZeBFjx3TnonBsXKq6nWqYg172nhltUEZsihGnXQ=="],
 
     "@opencode-ai/sdk": ["@opencode-ai/sdk@1.15.11", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-IyYyDVsO8SKbKbkSadHpDuYnYC+2vmEeLU+rW+rH2M54Sigq6l3gDHno16+U6SRut+lowbph7v/ry3WbV67V3w=="],
 
-    "@smithy/config-resolver": ["@smithy/config-resolver@4.5.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-HehAZr4sq2m+4zHgEqDvtWENy/B5yywMKA8Pl4gBcU3F4ekelpZqDLDxQHdJlguaKNyTq31cZYjLWomzdujQrA=="],
+    "@opentui/core": ["@opentui/core@0.2.15", "", { "dependencies": { "bun-ffi-structs": "0.2.2", "diff": "9.0.0", "marked": "17.0.1", "string-width": "7.2.0", "strip-ansi": "7.1.2", "yoga-layout": "3.2.1" }, "optionalDependencies": { "@opentui/core-darwin-arm64": "0.2.15", "@opentui/core-darwin-x64": "0.2.15", "@opentui/core-linux-arm64": "0.2.15", "@opentui/core-linux-x64": "0.2.15", "@opentui/core-win32-arm64": "0.2.15", "@opentui/core-win32-x64": "0.2.15" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-YGHttdZWScMcSvtYgZkLR6VhUO1OoUiQzwYjZgIusf5eCkPLD8PapH+PTMVqAiX16CHO6JxfMlkHv5qDiHAccQ=="],
 
-    "@smithy/core": ["@smithy/core@3.24.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA=="],
+    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.2.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-s25f9GmZd6wxNM5ExRmwwnLT+NLCKxnTWuO9aObOlqsXfLMGHQZrb6YwgAn/PSTua98KmH7GJCVWdPgZ/P+0RQ=="],
 
-    "@smithy/eventstream-serde-browser": ["@smithy/eventstream-serde-browser@4.3.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-M9rMkTar7JcRrvUHsK1271AuWDmrISIPQpQ4TSHmYZ4KMisGnMH0gfjCWnBwdndR7skvvp/UheHhZGvO3Cr8/g=="],
+    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.2.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-GyaipN+nOcEr8rcTO2mqKTGmOBk0C300I69fLtubD3BadHcMI1DVNlQrcf/J1mkQEuMYbmBTi/1hT1ybWGr2Mw=="],
 
-    "@smithy/eventstream-serde-config-resolver": ["@smithy/eventstream-serde-config-resolver@4.4.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-lUwPPu7DNNVJjeS+gV7g2rDHbW9X1wSRQIsIyzOgBtP7KDMefLhz0kz42AWAxZIFPcOO3pUbtq76LSkVcxLKRw=="],
+    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.2.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-h+uyufselGT4afKMP8Lg4yUl5Kp+DJBlhu3XpWXhphE5Pnq5+f0uGBr4P+34CNcWxMsDnvagSQLFRCS4rGrOWA=="],
 
-    "@smithy/eventstream-serde-node": ["@smithy/eventstream-serde-node@4.3.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-QydEYKqvdiS6dJb0tOfDiogt12FzzImt2FnL7gMD72hNrkiUAUKqtStRmkTrdzDKFJ46abe3yH94luCuhtnCkQ=="],
+    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.2.15", "", { "os": "linux", "cpu": "x64" }, "sha512-jx+NImPq4wSp3Apfe7tlixiEJNnRyECTRJRWhGF6ZJz4PwFfgK2UHZKYR0DZHbV8nYawoDNQPJDXEWcoZShnMg=="],
 
-    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.4.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-SK3VMeH0fibgdTg2QeB+O4p7Yy/2E5HBOHJeC58FshkDdeuX8lOgO7PfjYfLyPLP1ch55j91cQqKBzDS0mRjSQ=="],
+    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.2.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-2SQQLvf3sgmToxrNika9AdcccKrjPJEn5jW6sSv0oEixNBzUzW41vSZZG4LM/V3lL8eg0LoYDnRZeKLB4gwSqQ=="],
 
-    "@smithy/hash-node": ["@smithy/hash-node@4.3.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-/tUIDaB36qjLq/CIhMRIiFXCT7rVGBGAhFmMA9PbC/iW2u3QPNATZuFSdK0JBO3qeSPoHBeudFMmsbFq2Mf5EQ=="],
+    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.2.15", "", { "os": "win32", "cpu": "x64" }, "sha512-SVMVgnC7LVEm+yVZKdmmhRBj/xAT94PanT+UCcHxaCWK+OLmv/AX+ohHq2m0odup6iXcEqj+7mAltO9fgJLFIg=="],
 
-    "@smithy/invalid-dependency": ["@smithy/invalid-dependency@4.3.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-c8C1GzrU4PcY1QT/HP0ILCTLutyVONT93kPSisOyHoZaXlKQZtV6+RKqolhBtPolGULf59vq2yseagU6+WY82w=="],
+    "@opentui/solid": ["@opentui/solid@0.2.15", "", { "dependencies": { "@babel/core": "7.28.0", "@babel/preset-typescript": "7.27.1", "@opentui/core": "0.2.15", "babel-plugin-module-resolver": "5.0.2", "babel-preset-solid": "1.9.12", "entities": "7.0.1", "s-js": "^0.4.9" }, "peerDependencies": { "solid-js": "1.9.12" } }, "sha512-CViepAjsCWXwrLndMt+qlLo7cooVX7DXwSJHNizw7mfrRJtOPzSYJZCIk1vF4IJTWffCHygoYMe3uSeKvzAcbw=="],
+
+    "@smithy/config-resolver": ["@smithy/config-resolver@4.6.9", "", { "dependencies": { "@smithy/core": "^3.29.4", "tslib": "^2.6.2" } }, "sha512-lcnI5sHTIfvk5k8nxkQTCpNzyYrXQBIoo68oWYrlZ4Df/HT07y6J5HRZj7sPr9wF101uo51158NbqzQeLFfo5g=="],
+
+    "@smithy/core": ["@smithy/core@3.29.4", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-G1GRglAabzEhqghJMBAd54FkRS7SAFGHEwbhcI9r+O+LIMuFsLyXkLZkCoFSgAglRu8s/URVXJB0hglq3ZipIg=="],
+
+    "@smithy/eventstream-serde-browser": ["@smithy/eventstream-serde-browser@4.4.9", "", { "dependencies": { "@smithy/core": "^3.29.4", "tslib": "^2.6.2" } }, "sha512-etnQKvdV0d3GN1yT6b5ryZtpNJqiH+a4eXYA5okRMDvqLl1pZ/zoQ1sAStHv1fDsvawWI1580+sXp6i5evPdGg=="],
+
+    "@smithy/eventstream-serde-config-resolver": ["@smithy/eventstream-serde-config-resolver@4.5.9", "", { "dependencies": { "@smithy/core": "^3.29.4", "tslib": "^2.6.2" } }, "sha512-tIgvaIsek4oHnQmy6RIqAUZoWbPMLY9Tmmv9ayeK19Z+UX7JRBUHb6SRxlVFCKJoOTkro9Sk9kUwsV3W8SST7w=="],
+
+    "@smithy/eventstream-serde-node": ["@smithy/eventstream-serde-node@4.4.9", "", { "dependencies": { "@smithy/core": "^3.29.4", "tslib": "^2.6.2" } }, "sha512-kND6f56O7L+0KaWEAWxIOyC1xIb+CSjJAqWzK64Q4UktkjYODd5O9Fg7nDhh7Z12vzElz/Azh6n5mDbdqtBeng=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.6.6", "", { "dependencies": { "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-NHLgAlORUFZjn5ZfhYuyyKMlXA1WLYOdGxEhyNxrPpbJzoacGbl0chn1lN2KiZ8mpNVk0tV5607CSYlYs/OFgw=="],
+
+    "@smithy/hash-node": ["@smithy/hash-node@4.4.9", "", { "dependencies": { "@smithy/core": "^3.29.4", "tslib": "^2.6.2" } }, "sha512-75tzSJxMk1ypSzG4mk6JxM/5uMHha8aG4rW3E24VNyheI6oYDs+uUBGVGMbLTGaLZ2znvb/1zDgbL9q8HxKv+w=="],
+
+    "@smithy/invalid-dependency": ["@smithy/invalid-dependency@4.4.9", "", { "dependencies": { "@smithy/core": "^3.29.4", "tslib": "^2.6.2" } }, "sha512-TvR10A7r6R2myMKLsOigBP/IRX4h2gITkpUI08q9kjdBKOiuMoSa+9UMF8MF24NdL+gX4d5QxAfmOKsNN4vPUw=="],
 
     "@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
-    "@smithy/middleware-content-length": ["@smithy/middleware-content-length@4.3.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-lzOzJ4c0t3vkBut02CjdWNgduN3mUWjc1WK9TPr75KVV6OgVWico9wMDn9ZnQN97VJPYfweBW6Dm5CElvQl8BQ=="],
+    "@smithy/middleware-content-length": ["@smithy/middleware-content-length@4.4.9", "", { "dependencies": { "@smithy/core": "^3.29.4", "tslib": "^2.6.2" } }, "sha512-xh2Pzcqo/FxrjQwXiB7CfPHw5mXu+7X/5RvlO4PBgW7761Cgv3tq4SA4R8TeVDypqSJU4VaR2WK50XaYBcVcVQ=="],
 
-    "@smithy/middleware-endpoint": ["@smithy/middleware-endpoint@4.5.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-8DnkSoUMQAcuT/DHdigsFPti8M/Dm6TPCAsrIQ/bUDGxRkrgGuI++3dXRr8CoUyc9r0kGSCcZHjJje407ydgBQ=="],
+    "@smithy/middleware-endpoint": ["@smithy/middleware-endpoint@4.6.9", "", { "dependencies": { "@smithy/core": "^3.29.4", "tslib": "^2.6.2" } }, "sha512-XHmOEMv6WFn7Q0Zpf+EuBvAgWLj7AbTxcut/R43EUYrfS0ErwLolUohAtMAgAmlmbXxFma9KAJPX2gwACKBdbg=="],
 
-    "@smithy/middleware-retry": ["@smithy/middleware-retry@4.6.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-fumMIfh5xOFjirylbSzmBX9bgQtrWFtQrosPfkjsJSBzqXVbQMNDGIC8oJBz4V3bokIm2F0CL3bziLtbXR7cbA=="],
+    "@smithy/middleware-retry": ["@smithy/middleware-retry@4.7.9", "", { "dependencies": { "@smithy/core": "^3.29.4", "tslib": "^2.6.2" } }, "sha512-gVM/o0Mttd4j1N1PSw2qv6fbPevCBP1iJ2Wfeee6yoAoiCIgYAMlcj2OMFCRpCPowWkTPHIyIsKFwhf/o6OziA=="],
 
-    "@smithy/middleware-serde": ["@smithy/middleware-serde@4.3.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-+7glfRrb7byruZCPAM53TvmK8cx/ghzAThB4EvPzHynAYobtISl0g+DzzSVEC0NQob5BunP9gC9GP+Fcz6H9yw=="],
+    "@smithy/middleware-serde": ["@smithy/middleware-serde@4.4.9", "", { "dependencies": { "@smithy/core": "^3.29.4", "tslib": "^2.6.2" } }, "sha512-ENGPrAvYE2EV31pRtdrQWEZB7Y+MPJwyTBmAwduB99yLjobnjse6+kMWbGt2NG0Mkl1+86VyESDy4HdaEKNaTQ=="],
 
-    "@smithy/middleware-stack": ["@smithy/middleware-stack@4.3.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-Yj4wjBQZXHePRIy9cBIKfCOn/kPjRlgDPGlr7DjIhwrnz8kWu7Ux7UwPr51P/wcug5oq4nWdBXSY4TV5afBdew=="],
+    "@smithy/middleware-stack": ["@smithy/middleware-stack@4.4.9", "", { "dependencies": { "@smithy/core": "^3.29.4", "tslib": "^2.6.2" } }, "sha512-ZaCOlOGnTxZVqemJ0BtCY/EYKadTlxMvkH/uUk++64bRqt+ZHE99tS2BJlPduu0vi8GCffiJHjgkXueM5+77Rg=="],
 
-    "@smithy/node-config-provider": ["@smithy/node-config-provider@4.4.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-c2G9QJ4xVZLwAkAf+WQESSSCkKbtt33ytje1klGvTcBn6cKuqV28E+62wbRPHwuTikkB3LQ7CBnNrayCoJur5A=="],
+    "@smithy/node-config-provider": ["@smithy/node-config-provider@4.5.9", "", { "dependencies": { "@smithy/core": "^3.29.4", "tslib": "^2.6.2" } }, "sha512-8+sIiArnV0qdA62FN7dnXoRq5L3vxnWY66HdPmCC+uZAd2i/qCdjxL/gRBGQXtVuEptPehRsJz8Mxf5t/GRrCg=="],
 
-    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3dA9TQ+ybRSZ/m0wnbZhiBy4Dezjgq1Ib/ZZrYTpJDBgpoLLU/SDzZc/g0x0MNAdOJe1wPcM+x2PBRmoOur+Sw=="],
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.6", "", { "dependencies": { "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-odd+HYx3OLcXRSEz0ZeF3JQdSYdK8QnRgA2N87cPW7coWIbKfRk7a9VQjfeWQLqnzrDLk23KMEn46p8N7M/JFg=="],
 
-    "@smithy/protocol-http": ["@smithy/protocol-http@5.4.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-jOD+4WNWQLntiLJn3r82C7BLheEbRCKTbU5U5bskZmT7nwRiGkh0IghuHwHRZ1ZEFXpHltQxxp9/koOPsdluJg=="],
+    "@smithy/protocol-http": ["@smithy/protocol-http@5.5.9", "", { "dependencies": { "@smithy/core": "^3.29.4", "tslib": "^2.6.2" } }, "sha512-2tHlXQPzkTi0vXTyy2iWU1Lw60mIhUrS3heDO0bHJ4EvUH+RQlBuxiSqUWc34mRBpq3OgRPla89nNgqcTrX/vg=="],
 
-    "@smithy/signature-v4": ["@smithy/signature-v4@5.4.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-QBJKWGqIknH0dc9LWpfH1mkdokAx6iXYN3UcQ3eY6uIEyScuoQAhfl94ge7ozUy9WgFUdE8xsvwBjaYBbWmPNA=="],
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.6.5", "", { "dependencies": { "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-MO5VEhwVl0BN7xVoVeNrZfiUFoQtqxUbgl6/RwOTlMMxCSjblG8twSrVTwz3J4w9WZxd2rBfBAUXjH77agspBg=="],
 
-    "@smithy/smithy-client": ["@smithy/smithy-client@4.13.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-pg9QRQESz3m/5HgAW/z9lA3ln8MSsCWNWc82MX40Djlxpcj/+7DZQ0yIk7tGWYJCVZog/9LBdNl1uEVRAhqm5Q=="],
+    "@smithy/smithy-client": ["@smithy/smithy-client@4.14.9", "", { "dependencies": { "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-qXDg5ioWU4b5xhEyKFJ863Yr/1i40pxaSLKNEI0YFnAgtGdyIqG6eiAnojiV0r/pNNioBvKBtUEzyoxapN2R+w=="],
 
-    "@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+    "@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
 
-    "@smithy/url-parser": ["@smithy/url-parser@4.3.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-f7kUYrRdLiAHz10WXQXiUkuBFaL2c2ZBD2kSwZyQBh73lWFTvXwdpS9l5irQ/uldk8YMJpm66BozmqCg/3uZvA=="],
+    "@smithy/url-parser": ["@smithy/url-parser@4.4.9", "", { "dependencies": { "@smithy/core": "^3.29.4", "tslib": "^2.6.2" } }, "sha512-WFNfVQ5A8WcJNp/tIiuymhbiiCmZipjLJ6Iiq1jAnWjdl7efKri6koJkqh5+hQwiQXQHk2DGKmQvD3dOGFq8pQ=="],
 
-    "@smithy/util-base64": ["@smithy/util-base64@4.4.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-2J8l+DoX3IIiP75X5SYkJ3mIgOkxW29MxOs7oPjbXLuInQ7UL6zLw2IJHbQ44+eKDBBhTjvt+GgwsTTNBGt8zA=="],
+    "@smithy/util-base64": ["@smithy/util-base64@4.5.9", "", { "dependencies": { "@smithy/core": "^3.29.4", "tslib": "^2.6.2" } }, "sha512-4q8h+aztxE85KYzuLH3b9P/OTKDoEwG4UKKphmrh5k65p4d5S/REwUgGcTTigFpWLYWGKt3h1aABO3mhUZEAKw=="],
 
-    "@smithy/util-body-length-browser": ["@smithy/util-body-length-browser@4.3.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-nQtYwXg4spM6uc0Luq3yck+WXZ1VPfrYkC2SqkQ+YOGks0qR2bKKlSCjidSqfpq+VAY/RJe1O5V+CtBmnT63KQ=="],
+    "@smithy/util-body-length-browser": ["@smithy/util-body-length-browser@4.4.9", "", { "dependencies": { "@smithy/core": "^3.29.4", "tslib": "^2.6.2" } }, "sha512-jbg4TVopmTEYZ4AL8PVfDZXXhY1SdTXspy4Myoi000RV2xErNXWmY8Qz5NMzcTlzE19ARjmtbhNg+opEdtjEiA=="],
 
-    "@smithy/util-body-length-node": ["@smithy/util-body-length-node@4.3.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-BAsAed9yWExECwNIi61Le6D8ZTY71MFEFrf3d4L2+uzcbTjFAWxOtymkA1vCV8bNZQN9TGgZo4c68JDsnjNShA=="],
+    "@smithy/util-body-length-node": ["@smithy/util-body-length-node@4.4.9", "", { "dependencies": { "@smithy/core": "^3.29.4", "tslib": "^2.6.2" } }, "sha512-+w6SNxGyl5w01dggIE8pnYspDDgscLSqQlBF59OkUoOEVQaNymMWFxGThFWhgJXE1E2i4sG3ZjlP9I1RvxmSAw=="],
 
     "@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
-    "@smithy/util-defaults-mode-browser": ["@smithy/util-defaults-mode-browser@4.4.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-LbE6AGHhQOunqIN5UyWDMgpPwmUHUzrV2NtUOQ+lt6Stpipzo6S7uDyeGtO0GGgUD1balEPCNu8Xfl1AQNiruQ=="],
+    "@smithy/util-defaults-mode-browser": ["@smithy/util-defaults-mode-browser@4.5.9", "", { "dependencies": { "@smithy/core": "^3.29.4", "tslib": "^2.6.2" } }, "sha512-IsNRWbkmLyV6QusLspvsGQxHL9GuDWbOnbpFJrzyU/YG5EmKE3ZOnmmyDOPGuCnzVi9AsGLTa6XWm87UlDvs9w=="],
 
-    "@smithy/util-defaults-mode-node": ["@smithy/util-defaults-mode-node@4.3.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-72gNpNDQ2iIGbaNmeaF9I58shWsEuD5tNI7my5uXlm1CSPH5i8IKI/nzU50qqB8y+kgw/qTLGgsf0We5qeM/aA=="],
+    "@smithy/util-defaults-mode-node": ["@smithy/util-defaults-mode-node@4.4.9", "", { "dependencies": { "@smithy/core": "^3.29.4", "tslib": "^2.6.2" } }, "sha512-9g8QNUIk5SeZPOTxdQcbe8EqwwTczTdka+fEiNoZi9OYcSv0Iz/9prZMWjuahI4LHOFJ5Gsb+V3A1sbL8NpoVw=="],
 
-    "@smithy/util-endpoints": ["@smithy/util-endpoints@3.5.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-NJhe8KmNjeZ7V+gJsQR5xw0IN47N8pBKosed40xfhelDuYkg8VQ5CVGDcHTEuJq3e3zQb21vnoOOReQothejhA=="],
+    "@smithy/util-endpoints": ["@smithy/util-endpoints@3.6.9", "", { "dependencies": { "@smithy/core": "^3.29.4", "tslib": "^2.6.2" } }, "sha512-wvNKq7FvzEUjxZWMYU0ShHRCzCHcl8//jb2mB9b1qCVczN7oQwLB/lTnlfJP+nLQA1kpbFOOvUZgfNd5XRlCFA=="],
 
-    "@smithy/util-middleware": ["@smithy/util-middleware@4.3.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-N1IR4bMHIDbqO3GxkJHgqNGsnrd7MNrj+EVqhFqKeRqSBV5I3KCjNllKfnbF9KV0YteGhfLqcMR5CYsPLJqpqw=="],
+    "@smithy/util-middleware": ["@smithy/util-middleware@4.4.9", "", { "dependencies": { "@smithy/core": "^3.29.4", "tslib": "^2.6.2" } }, "sha512-r1xxiqE6mV/e7sMCb4N7KLd6BJzqUb9gW7S7UdquVz4woGGLfiq3HweiWWRIq7FePoNA+0f88VvqAtu/8gn9lA=="],
 
-    "@smithy/util-retry": ["@smithy/util-retry@4.4.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-W9Ovy9i02yGqtLlpqZNQuXNxXc5OPfXujnembxN/FxyBtGjJd8vKY0PQYEJ8FNybTOcXG+ZxsSsX23HOb3zQzg=="],
+    "@smithy/util-retry": ["@smithy/util-retry@4.5.9", "", { "dependencies": { "@smithy/core": "^3.29.4", "tslib": "^2.6.2" } }, "sha512-h0iI/SuUOe8cnwNZ6DQtX5uRywGi2RsXQntP2XSe2rEA3oPy4rDCPULRoUtKYpi1Fj5T8TP13QJRPb/R0BT+lQ=="],
 
-    "@smithy/util-utf8": ["@smithy/util-utf8@4.3.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "tslib": "^2.6.2" } }, "sha512-l1d7I7YP2LjXjAZDC7eXqkzuEB75KfCANwhNj/knmT6+0a9XG3QasvI8kEn8WAI3tx/q8PdmSuuXcM+MTkk/7Q=="],
+    "@smithy/util-utf8": ["@smithy/util-utf8@4.4.9", "", { "dependencies": { "@smithy/core": "^3.29.4", "tslib": "^2.6.2" } }, "sha512-uHhshFHe243cUkI6FFpjhjMwak3NoD988da8cS4DV4I0FugzvVJ1RNRzaR4f1sgXNlEASeKv/EthmmRMudUI3w=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
-    "@types/node": ["@types/node@20.19.30", "https://registry.npmmirror.com/@types/node/-/node-20.19.30.tgz", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g=="],
+    "@types/node": ["@types/node@25.9.5", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg=="],
 
-    "@types/proper-lockfile": ["@types/proper-lockfile@4.1.4", "https://registry.npmmirror.com/@types/proper-lockfile/-/proper-lockfile-4.1.4.tgz", { "dependencies": { "@types/retry": "*" } }, "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ=="],
+    "@types/proper-lockfile": ["@types/proper-lockfile@4.1.4", "", { "dependencies": { "@types/retry": "*" } }, "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ=="],
 
-    "@types/retry": ["@types/retry@0.12.5", "https://registry.npmmirror.com/@types/retry/-/retry-0.12.5.tgz", {}, "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw=="],
+    "@types/retry": ["@types/retry@0.12.5", "", {}, "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw=="],
 
-    "ansi-escapes": ["ansi-escapes@7.2.0", "https://registry.npmmirror.com/ansi-escapes/-/ansi-escapes-7.2.0.tgz", { "dependencies": { "environment": "^1.0.0" } }, "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw=="],
+    "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
 
-    "ansi-regex": ["ansi-regex@6.2.2", "https://registry.npmmirror.com/ansi-regex/-/ansi-regex-6.2.2.tgz", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
-    "ansi-styles": ["ansi-styles@6.2.3", "https://registry.npmmirror.com/ansi-styles/-/ansi-styles-6.2.3.tgz", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "babel-plugin-jsx-dom-expressions": ["babel-plugin-jsx-dom-expressions@0.40.7", "", { "dependencies": { "@babel/helper-module-imports": "7.18.6", "@babel/plugin-syntax-jsx": "^7.18.6", "@babel/types": "^7.20.7", "html-entities": "2.3.3", "parse5": "^7.1.2" }, "peerDependencies": { "@babel/core": "^7.20.12" } }, "sha512-/O6JWUmjv03OI9lL2ry9bUjpD5S3PclM55RRJEyCdcFZ5W2SEA/59d+l2hNsk3gI6kiWRdRPdOtqZmsQzFN1pQ=="],
+
+    "babel-plugin-module-resolver": ["babel-plugin-module-resolver@5.0.2", "", { "dependencies": { "find-babel-config": "^2.1.1", "glob": "^9.3.3", "pkg-up": "^3.1.0", "reselect": "^4.1.7", "resolve": "^1.22.8" } }, "sha512-9KtaCazHee2xc0ibfqsDeamwDps6FZNo5S0Q81dUqEuFzVwPhcT4J5jOqIVvgCA3Q/wO9hKYxN/Ds3tIsp5ygg=="],
+
+    "babel-preset-solid": ["babel-preset-solid@1.9.12", "", { "dependencies": { "babel-plugin-jsx-dom-expressions": "^0.40.6" }, "peerDependencies": { "@babel/core": "^7.0.0", "solid-js": "^1.9.12" }, "optionalPeers": ["solid-js"] }, "sha512-LLqnuKVDlKpyBlMPcH6qEvs/wmS9a+NczppxJ3ryS/c0O5IiSFOIBQi9GzyiGDSbcJpx4Gr87jyFTos1MyEuWg=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.43", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ=="],
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
-    "braces": ["braces@3.0.3", "https://registry.npmmirror.com/braces/-/braces-3.0.3.tgz", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+    "brace-expansion": ["brace-expansion@2.1.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA=="],
 
-    "bun-types": ["bun-types@1.3.6", "https://registry.npmmirror.com/bun-types/-/bun-types-1.3.6.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
+    "browserslist": ["browserslist@4.28.6", "", { "dependencies": { "baseline-browser-mapping": "^2.10.42", "caniuse-lite": "^1.0.30001803", "electron-to-chromium": "^1.5.389", "node-releases": "^2.0.51", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw=="],
 
-    "cli-cursor": ["cli-cursor@5.0.0", "https://registry.npmmirror.com/cli-cursor/-/cli-cursor-5.0.0.tgz", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
+    "bun-ffi-structs": ["bun-ffi-structs@0.2.2", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-N/ZWtyN0piZlrXQT7TO0V+q952orYqkfhXRXM1Hcbb+R3QSiBH4vLnib187Mrs1H7pWIYECAmPeapGYDOMCl+w=="],
 
-    "cli-truncate": ["cli-truncate@5.1.1", "https://registry.npmmirror.com/cli-truncate/-/cli-truncate-5.1.1.tgz", { "dependencies": { "slice-ansi": "^7.1.0", "string-width": "^8.0.0" } }, "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A=="],
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
-    "colorette": ["colorette@2.0.20", "https://registry.npmmirror.com/colorette/-/colorette-2.0.20.tgz", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
+    "caniuse-lite": ["caniuse-lite@1.0.30001805", "", {}, "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA=="],
 
-    "commander": ["commander@14.0.2", "https://registry.npmmirror.com/commander/-/commander-14.0.2.tgz", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+    "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
+
+    "cli-truncate": ["cli-truncate@5.2.0", "", { "dependencies": { "slice-ansi": "^8.0.0", "string-width": "^8.2.0" } }, "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
     "detect-libc": ["detect-libc@2.0.2", "", {}, "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw=="],
+
+    "diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
 
     "effect": ["effect@4.0.0-beta.66", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-4arEr62cziFa8BBVDUwJCJJmaVepXf/kRg7KtC0h8+bufngscrHbwWFhr9c+HonwOF+31U3iD3xUJmw9KzX7Dw=="],
 
-    "emoji-regex": ["emoji-regex@10.6.0", "https://registry.npmmirror.com/emoji-regex/-/emoji-regex-10.6.0.tgz", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+    "electron-to-chromium": ["electron-to-chromium@1.5.391", "", {}, "sha512-YmCu4856jkgKT1Nh6fwRdeVrM6Ydf/fBnq51tpmSfX+jOcUMTxh31yH6hjKScRenhB2oDSvA9oooxcpjogPeig=="],
 
-    "environment": ["environment@1.1.0", "https://registry.npmmirror.com/environment/-/environment-1.1.0.tgz", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
+    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
-    "eventemitter3": ["eventemitter3@5.0.4", "https://registry.npmmirror.com/eventemitter3/-/eventemitter3-5.0.4.tgz", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
-    "fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
+    "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 
-    "fast-xml-builder": ["fast-xml-builder@1.2.0", "", { "dependencies": { "path-expression-matcher": "^1.5.0", "xml-naming": "^0.1.0" } }, "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q=="],
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
-    "fast-xml-parser": ["fast-xml-parser@5.7.3", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.7", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg=="],
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
-    "fill-range": ["fill-range@7.1.1", "https://registry.npmmirror.com/fill-range/-/fill-range-7.1.1.tgz", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
+    "fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
+
+    "find-babel-config": ["find-babel-config@2.1.2", "", { "dependencies": { "json5": "^2.2.3" } }, "sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg=="],
 
     "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
 
-    "get-east-asian-width": ["get-east-asian-width@1.4.0", "https://registry.npmmirror.com/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
+    "find-up": ["find-up@3.0.0", "", { "dependencies": { "locate-path": "^3.0.0" } }, "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg=="],
 
-    "graceful-fs": ["graceful-fs@4.2.11", "https://registry.npmmirror.com/graceful-fs/-/graceful-fs-4.2.11.tgz", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+    "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
-    "husky": ["husky@9.1.7", "https://registry.npmmirror.com/husky/-/husky-9.1.7.tgz", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
+
+    "glob": ["glob@9.3.5", "", { "dependencies": { "fs.realpath": "^1.0.0", "minimatch": "^8.0.2", "minipass": "^4.2.4", "path-scurry": "^1.6.1" } }, "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
+
+    "html-entities": ["html-entities@2.3.3", "", {}, "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="],
+
+    "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
     "ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
 
-    "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "https://registry.npmmirror.com/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
+    "is-core-module": ["is-core-module@2.16.2", "", { "dependencies": { "hasown": "^2.0.3" } }, "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA=="],
 
-    "is-number": ["is-number@7.0.0", "https://registry.npmmirror.com/is-number/-/is-number-7.0.0.tgz", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "kubernetes-types": ["kubernetes-types@1.30.0", "", {}, "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q=="],
 
     "libsql": ["libsql@0.5.29", "", { "dependencies": { "@neon-rs/load": "^0.0.4", "detect-libc": "2.0.2" }, "optionalDependencies": { "@libsql/darwin-arm64": "0.5.29", "@libsql/darwin-x64": "0.5.29", "@libsql/linux-arm-gnueabihf": "0.5.29", "@libsql/linux-arm-musleabihf": "0.5.29", "@libsql/linux-arm64-gnu": "0.5.29", "@libsql/linux-arm64-musl": "0.5.29", "@libsql/linux-x64-gnu": "0.5.29", "@libsql/linux-x64-musl": "0.5.29", "@libsql/win32-x64-msvc": "0.5.29" }, "os": [ "linux", "win32", "darwin", ], "cpu": [ "arm", "x64", "arm64", ] }, "sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg=="],
 
-    "lint-staged": ["lint-staged@16.2.7", "https://registry.npmmirror.com/lint-staged/-/lint-staged-16.2.7.tgz", { "dependencies": { "commander": "^14.0.2", "listr2": "^9.0.5", "micromatch": "^4.0.8", "nano-spawn": "^2.0.0", "pidtree": "^0.6.0", "string-argv": "^0.3.2", "yaml": "^2.8.1" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-lDIj4RnYmK7/kXMya+qJsmkRFkGolciXjrsZ6PC25GdTfWOAWetR0ZbsNXRAj1EHHImRSalc+whZFg56F5DVow=="],
+    "lint-staged": ["lint-staged@17.0.8", "", { "dependencies": { "listr2": "^10.2.1", "picomatch": "^4.0.4", "string-argv": "^0.3.2", "tinyexec": "^1.2.4" }, "optionalDependencies": { "yaml": "^2.9.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-B2P/d+jVW0UXOQ0MVMLrB/9ydA1P+zz6jYfdrbbEd9ur3S2rcbduFWKiUCC02Sm5hbC8nrm7y24WuYMG54HfxA=="],
 
-    "listr2": ["listr2@9.0.5", "https://registry.npmmirror.com/listr2/-/listr2-9.0.5.tgz", { "dependencies": { "cli-truncate": "^5.0.0", "colorette": "^2.0.20", "eventemitter3": "^5.0.1", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^9.0.0" } }, "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g=="],
+    "listr2": ["listr2@10.2.2", "", { "dependencies": { "cli-truncate": "^5.2.0", "eventemitter3": "^5.0.4", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^10.0.0" } }, "sha512-JtNtbZj8q5BnDMR7trpwvwk3RIrANtIVzEUm8w7amp6xelLgyuq+4WZoTH913XaQAoH/cNdYhaNzBPA2U3xbDw=="],
 
-    "log-update": ["log-update@6.1.0", "https://registry.npmmirror.com/log-update/-/log-update-6.1.0.tgz", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
+    "locate-path": ["locate-path@3.0.0", "", { "dependencies": { "p-locate": "^3.0.0", "path-exists": "^3.0.0" } }, "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A=="],
 
-    "micromatch": ["micromatch@4.0.8", "https://registry.npmmirror.com/micromatch/-/micromatch-4.0.8.tgz", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+    "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
 
-    "mimic-function": ["mimic-function@5.0.1", "https://registry.npmmirror.com/mimic-function/-/mimic-function-5.0.1.tgz", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
-    "msgpackr": ["msgpackr@1.11.12", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg=="],
+    "marked": ["marked@17.0.1", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="],
+
+    "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
+
+    "minimatch": ["minimatch@8.0.7", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg=="],
+
+    "minipass": ["minipass@4.2.8", "", {}, "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "msgpackr": ["msgpackr@1.12.1", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ=="],
 
     "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
 
-    "multipasta": ["multipasta@0.2.7", "", {}, "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA=="],
-
-    "nano-spawn": ["nano-spawn@2.0.0", "https://registry.npmmirror.com/nano-spawn/-/nano-spawn-2.0.0.tgz", {}, "sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw=="],
+    "multipasta": ["multipasta@0.2.8", "", {}, "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q=="],
 
     "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
-    "onetime": ["onetime@7.0.0", "https://registry.npmmirror.com/onetime/-/onetime-7.0.0.tgz", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
+    "node-releases": ["node-releases@2.0.51", "", {}, "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ=="],
 
-    "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
+    "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
+
+    "p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
+
+    "p-locate": ["p-locate@3.0.0", "", { "dependencies": { "p-limit": "^2.0.0" } }, "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ=="],
+
+    "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
+
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "path-exists": ["path-exists@3.0.0", "", {}, "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
-    "picomatch": ["picomatch@2.3.1", "https://registry.npmmirror.com/picomatch/-/picomatch-2.3.1.tgz", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+    "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
-    "pidtree": ["pidtree@0.6.0", "https://registry.npmmirror.com/pidtree/-/pidtree-0.6.0.tgz", { "bin": { "pidtree": "bin/pidtree.js" } }, "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g=="],
+    "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
-    "prettier": ["prettier@3.8.0", "https://registry.npmmirror.com/prettier/-/prettier-3.8.0.tgz", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA=="],
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "prettier-plugin-organize-imports": ["prettier-plugin-organize-imports@4.3.0", "https://registry.npmmirror.com/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-4.3.0.tgz", { "peerDependencies": { "prettier": ">=2.0", "typescript": ">=2.9", "vue-tsc": "^2.1.0 || 3" }, "optionalPeers": ["vue-tsc"] }, "sha512-FxFz0qFhyBsGdIsb697f/EkvHzi5SZOhWAjxcx2dLt+Q532bAlhswcXGYB1yzjZ69kW8UoadFBw7TyNwlq96Iw=="],
+    "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
-    "proper-lockfile": ["proper-lockfile@4.1.2", "https://registry.npmmirror.com/proper-lockfile/-/proper-lockfile-4.1.2.tgz", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
+    "pkg-up": ["pkg-up@3.1.0", "", { "dependencies": { "find-up": "^3.0.0" } }, "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA=="],
 
-    "pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
+    "prettier": ["prettier@3.9.5", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg=="],
 
-    "restore-cursor": ["restore-cursor@5.1.0", "https://registry.npmmirror.com/restore-cursor/-/restore-cursor-5.1.0.tgz", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
+    "prettier-plugin-organize-imports": ["prettier-plugin-organize-imports@4.3.0", "", { "peerDependencies": { "prettier": ">=2.0", "typescript": ">=2.9", "vue-tsc": "^2.1.0 || 3" }, "optionalPeers": ["vue-tsc"] }, "sha512-FxFz0qFhyBsGdIsb697f/EkvHzi5SZOhWAjxcx2dLt+Q532bAlhswcXGYB1yzjZ69kW8UoadFBw7TyNwlq96Iw=="],
 
-    "retry": ["retry@0.12.0", "https://registry.npmmirror.com/retry/-/retry-0.12.0.tgz", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
+    "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
 
-    "rfdc": ["rfdc@1.4.1", "https://registry.npmmirror.com/rfdc/-/rfdc-1.4.1.tgz", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
+    "pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
+
+    "reselect": ["reselect@4.1.8", "", {}, "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="],
+
+    "resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
+
+    "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
+
+    "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
+
+    "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
+
+    "s-js": ["s-js@0.4.9", "", {}, "sha512-RtpOm+cM6O0sHg6IA70wH+UC3FZcND+rccBZpBAHzlUgNO2Bm5BN+FnM8+OBxzXdwpKWFwX11JGF0MFRkhSoIQ=="],
+
+    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "seroval": ["seroval@1.5.5", "", {}, "sha512-bSjOuPcwPKLSJNhr9+bZxA20nQxVle5J5MNsYRVE6cIg7KpRLXGupymePavu0jrxlPiPsr4xGZSB8yUY2sH2sw=="],
+
+    "seroval-plugins": ["seroval-plugins@1.5.5", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-+BDhqYM6CEn3x09v44dpa9p6974FuUB2dxk+Ctn04k0cO1Zt6QODTXfmEZK0eBaTe/fJBvP4NMGuNJ+R8T+QMg=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "signal-exit": ["signal-exit@3.0.7", "https://registry.npmmirror.com/signal-exit/-/signal-exit-3.0.7.tgz", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
-    "slice-ansi": ["slice-ansi@7.1.2", "https://registry.npmmirror.com/slice-ansi/-/slice-ansi-7.1.2.tgz", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
+    "slice-ansi": ["slice-ansi@8.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg=="],
 
-    "string-argv": ["string-argv@0.3.2", "https://registry.npmmirror.com/string-argv/-/string-argv-0.3.2.tgz", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
+    "solid-js": ["solid-js@1.9.12", "", { "dependencies": { "csstype": "^3.1.0", "seroval": "~1.5.0", "seroval-plugins": "~1.5.0" } }, "sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw=="],
 
-    "string-width": ["string-width@8.1.0", "https://registry.npmmirror.com/string-width/-/string-width-8.1.0.tgz", { "dependencies": { "get-east-asian-width": "^1.3.0", "strip-ansi": "^7.1.0" } }, "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg=="],
+    "string-argv": ["string-argv@0.3.2", "", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
 
-    "strip-ansi": ["strip-ansi@7.1.2", "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-7.1.2.tgz", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
-    "strnum": ["strnum@2.3.0", "", {}, "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q=="],
+    "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
-    "to-regex-range": ["to-regex-range@5.0.1", "https://registry.npmmirror.com/to-regex-range/-/to-regex-range-5.0.1.tgz", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+    "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
-    "toml": ["toml@4.1.1", "", {}, "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw=="],
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
+
+    "toml": ["toml@4.3.0", "", {}, "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "typescript": ["typescript@5.9.3", "https://registry.npmmirror.com/typescript/-/typescript-5.9.3.tgz", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
-    "undici-types": ["undici-types@6.21.0", "https://registry.npmmirror.com/undici-types/-/undici-types-6.21.0.tgz", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
     "uuid": ["uuid@13.0.2", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw=="],
 
+    "web-tree-sitter": ["web-tree-sitter@0.25.10", "", { "peerDependencies": { "@types/emscripten": "^1.40.0" }, "optionalPeers": ["@types/emscripten"] }, "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
-    "wrap-ansi": ["wrap-ansi@9.0.2", "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-9.0.2.tgz", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+    "wrap-ansi": ["wrap-ansi@10.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "string-width": "^8.2.0", "strip-ansi": "^7.1.2" } }, "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ=="],
 
-    "xml-naming": ["xml-naming@0.1.0", "", {}, "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw=="],
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
-    "yaml": ["yaml@2.8.2", "https://registry.npmmirror.com/yaml/-/yaml-2.8.2.tgz", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
-    "zod": ["zod@3.25.76", "https://registry.npmmirror.com/zod/-/zod-3.25.76.tgz", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
     "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
-    "@opencode-ai/plugin/zod": ["zod@4.1.8", "https://registry.npmmirror.com/zod/-/zod-4.1.8.tgz", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
+    "@opencode-ai/plugin/zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
 
-    "effect/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+    "babel-plugin-jsx-dom-expressions/@babel/helper-module-imports": ["@babel/helper-module-imports@7.18.6", "", { "dependencies": { "@babel/types": "^7.18.6" } }, "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA=="],
 
-    "node-gyp-build-optional-packages/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+    "cli-truncate/string-width": ["string-width@8.2.2", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg=="],
 
-    "restore-cursor/signal-exit": ["signal-exit@4.1.0", "https://registry.npmmirror.com/signal-exit/-/signal-exit-4.1.0.tgz", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+    "log-update/slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
 
-    "wrap-ansi/string-width": ["string-width@7.2.0", "https://registry.npmmirror.com/string-width/-/string-width-7.2.0.tgz", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+    "log-update/wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "path-scurry/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "restore-cursor/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "wrap-ansi/string-width": ["string-width@8.2.2", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg=="],
   }
 }

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,5 @@
-export { KiroOAuthPlugin, createKiroPlugin } from './src/plugin';
-export { authorizeKiroIDC } from './src/kiro/oauth-idc';
-export type { KiroAuthDetails, KiroAuthMethod, KiroRegion, ManagedAccount } from './src/plugin/types';
-export type { KiroConfig } from './src/plugin/config';
+// Repo-root entrypoint kept in sync with the published API in src/index.ts.
+// The npm package ships dist/index.js (built from src/index.ts); this file is a
+// convenience re-export for source consumers and must not diverge.
+export * from './src/index'
+export { default } from './src/index'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,29 +1,48 @@
 {
   "name": "@zhafron/opencode-kiro-auth",
-  "version": "1.11.2",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zhafron/opencode-kiro-auth",
-      "version": "1.11.2",
+      "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
-        "@aws/codewhisperer-streaming-client": "^1.0.34",
-        "@opencode-ai/plugin": "^1.15.11",
-        "libsql": "^0.5.29",
+        "@aws/codewhisperer-streaming-client": "^1.0.45",
+        "@opencode-ai/plugin": "1.15.11",
+        "@opentui/solid": "0.2.15",
+        "libsql": "0.5.29",
         "proper-lockfile": "^4.1.2",
-        "zod": "^3.24.0"
+        "solid-js": "1.9.12",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
-        "@types/node": "^20.0.0",
+        "@types/node": "^25.9.1",
         "@types/proper-lockfile": "^4.1.4",
-        "bun-types": "^1.3.6",
+        "bun-types": "^1.3.14",
         "husky": "^9.1.7",
-        "lint-staged": "^16.2.7",
-        "prettier": "^3.4.2",
-        "prettier-plugin-organize-imports": "^4.1.0",
-        "typescript": "^5.7.3"
+        "lint-staged": "^17.0.5",
+        "prettier": "^3.8.3",
+        "prettier-plugin-organize-imports": "^4.3.0",
+        "typescript": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=20.17",
+        "opencode": ">=1.15.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -486,51 +505,51 @@
       }
     },
     "node_modules/@aws/codewhisperer-streaming-client": {
-      "version": "1.0.39",
-      "resolved": "https://registry.npmjs.org/@aws/codewhisperer-streaming-client/-/codewhisperer-streaming-client-1.0.39.tgz",
-      "integrity": "sha512-JFBMMQEqb23I5U2gmJIqXZabccmmGjUDZaQavYpI+TbIULOFO4QkAAR5l4LsHjbS/C/FMhksPM0LS7V8u/hY7w==",
+      "version": "1.0.45",
+      "resolved": "https://registry.npmjs.org/@aws/codewhisperer-streaming-client/-/codewhisperer-streaming-client-1.0.45.tgz",
+      "integrity": "sha512-XvqUjgrA+hS8bK/dU9tUhooxlYWLbIYNYg461gMcD2QQHAd+fXwqrImgcJ/pvU6LedguvTal1Vdd9Pf4I0O0Jg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/middleware-host-header": "^3.972.9",
-        "@aws-sdk/middleware-logger": "^3.972.9",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.10",
-        "@aws-sdk/middleware-user-agent": "^3.972.29",
-        "@aws-sdk/region-config-resolver": "^3.972.11",
-        "@aws-sdk/token-providers": "^3.1027.0",
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/util-endpoints": "^3.996.6",
-        "@aws-sdk/util-user-agent-browser": "^3.972.9",
-        "@aws-sdk/util-user-agent-node": "^3.973.15",
-        "@smithy/config-resolver": "^4.4.14",
-        "@smithy/core": "^3.23.14",
-        "@smithy/eventstream-serde-browser": "^4.2.13",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.13",
-        "@smithy/eventstream-serde-node": "^4.2.13",
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/hash-node": "^4.2.13",
-        "@smithy/invalid-dependency": "^4.2.13",
-        "@smithy/middleware-content-length": "^4.2.13",
-        "@smithy/middleware-endpoint": "^4.4.29",
-        "@smithy/middleware-retry": "^4.5.0",
-        "@smithy/middleware-serde": "^4.2.17",
-        "@smithy/middleware-stack": "^4.2.13",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/node-http-handler": "^4.5.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
+        "@aws-sdk/core": "^3.974.7",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.37",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/token-providers": "^3.1040.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.23",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/eventstream-serde-browser": "^4.2.14",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.14",
+        "@smithy/eventstream-serde-node": "^4.2.14",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.45",
-        "@smithy/util-defaults-mode-node": "^4.2.49",
-        "@smithy/util-endpoints": "^3.3.4",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-retry": "^4.3.0",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -547,6 +566,446 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
+      "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.0",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.27.3",
+        "@babel/helpers": "^7.27.6",
+        "@babel/parser": "^7.28.0",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.0",
+        "@babel/types": "^7.28.0",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.3.tgz",
+      "integrity": "sha512-RpLYy2sb51oNLjuu1iD3bwBqCBWUzjO0ocp+iaCP/lJtb2CPLcnC2Fftw+4sAzaMELGeWTgExSKADbdo0GFVzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-member-expression-to-functions": "^7.28.5",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/helper-replace-supers": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/traverse": "^7.29.0",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
+      "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.5",
+        "@babel/types": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
+      "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
+      "integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.28.5",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
+      "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz",
+      "integrity": "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.6.tgz",
+      "integrity": "sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz",
+      "integrity": "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@libsql/darwin-arm64": {
       "version": "0.5.29",
       "resolved": "https://registry.npmjs.org/@libsql/darwin-arm64/-/darwin-arm64-0.5.29.tgz",
@@ -554,6 +1013,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -566,6 +1026,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -578,6 +1039,7 @@
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -590,6 +1052,7 @@
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -602,6 +1065,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -614,6 +1078,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -626,6 +1091,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -638,6 +1104,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -650,6 +1117,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -736,7 +1204,8 @@
     "node_modules/@neon-rs/load": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/@neon-rs/load/-/load-0.0.4.tgz",
-      "integrity": "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw=="
+      "integrity": "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==",
+      "license": "MIT"
     },
     "node_modules/@nodable/entities": {
       "version": "2.1.0",
@@ -793,6 +1262,182 @@
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
+      }
+    },
+    "node_modules/@opentui/core": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@opentui/core/-/core-0.2.15.tgz",
+      "integrity": "sha512-YGHttdZWScMcSvtYgZkLR6VhUO1OoUiQzwYjZgIusf5eCkPLD8PapH+PTMVqAiX16CHO6JxfMlkHv5qDiHAccQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bun-ffi-structs": "0.2.2",
+        "diff": "9.0.0",
+        "marked": "17.0.1",
+        "string-width": "7.2.0",
+        "strip-ansi": "7.1.2",
+        "yoga-layout": "3.2.1"
+      },
+      "optionalDependencies": {
+        "@opentui/core-darwin-arm64": "0.2.15",
+        "@opentui/core-darwin-x64": "0.2.15",
+        "@opentui/core-linux-arm64": "0.2.15",
+        "@opentui/core-linux-x64": "0.2.15",
+        "@opentui/core-win32-arm64": "0.2.15",
+        "@opentui/core-win32-x64": "0.2.15"
+      },
+      "peerDependencies": {
+        "web-tree-sitter": "0.25.10"
+      }
+    },
+    "node_modules/@opentui/core-darwin-arm64": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@opentui/core-darwin-arm64/-/core-darwin-arm64-0.2.15.tgz",
+      "integrity": "sha512-s25f9GmZd6wxNM5ExRmwwnLT+NLCKxnTWuO9aObOlqsXfLMGHQZrb6YwgAn/PSTua98KmH7GJCVWdPgZ/P+0RQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@opentui/core-darwin-x64": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@opentui/core-darwin-x64/-/core-darwin-x64-0.2.15.tgz",
+      "integrity": "sha512-GyaipN+nOcEr8rcTO2mqKTGmOBk0C300I69fLtubD3BadHcMI1DVNlQrcf/J1mkQEuMYbmBTi/1hT1ybWGr2Mw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@opentui/core-linux-arm64": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@opentui/core-linux-arm64/-/core-linux-arm64-0.2.15.tgz",
+      "integrity": "sha512-h+uyufselGT4afKMP8Lg4yUl5Kp+DJBlhu3XpWXhphE5Pnq5+f0uGBr4P+34CNcWxMsDnvagSQLFRCS4rGrOWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@opentui/core-linux-x64": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@opentui/core-linux-x64/-/core-linux-x64-0.2.15.tgz",
+      "integrity": "sha512-jx+NImPq4wSp3Apfe7tlixiEJNnRyECTRJRWhGF6ZJz4PwFfgK2UHZKYR0DZHbV8nYawoDNQPJDXEWcoZShnMg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@opentui/core-win32-arm64": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@opentui/core-win32-arm64/-/core-win32-arm64-0.2.15.tgz",
+      "integrity": "sha512-2SQQLvf3sgmToxrNika9AdcccKrjPJEn5jW6sSv0oEixNBzUzW41vSZZG4LM/V3lL8eg0LoYDnRZeKLB4gwSqQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@opentui/core-win32-x64": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@opentui/core-win32-x64/-/core-win32-x64-0.2.15.tgz",
+      "integrity": "sha512-SVMVgnC7LVEm+yVZKdmmhRBj/xAT94PanT+UCcHxaCWK+OLmv/AX+ohHq2m0odup6iXcEqj+7mAltO9fgJLFIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@opentui/core/node_modules/bun-ffi-structs": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/bun-ffi-structs/-/bun-ffi-structs-0.2.2.tgz",
+      "integrity": "sha512-N/ZWtyN0piZlrXQT7TO0V+q952orYqkfhXRXM1Hcbb+R3QSiBH4vLnib187Mrs1H7pWIYECAmPeapGYDOMCl+w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "^5"
+      }
+    },
+    "node_modules/@opentui/core/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@opentui/core/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@opentui/core/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@opentui/solid": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@opentui/solid/-/solid-0.2.15.tgz",
+      "integrity": "sha512-CViepAjsCWXwrLndMt+qlLo7cooVX7DXwSJHNizw7mfrRJtOPzSYJZCIk1vF4IJTWffCHygoYMe3uSeKvzAcbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "7.28.0",
+        "@babel/preset-typescript": "7.27.1",
+        "@opentui/core": "0.2.15",
+        "babel-plugin-module-resolver": "5.0.2",
+        "babel-preset-solid": "1.9.12",
+        "entities": "7.0.1",
+        "s-js": "^0.4.9"
+      },
+      "peerDependencies": {
+        "solid-js": "1.9.12"
       }
     },
     "node_modules/@smithy/config-resolver": {
@@ -1440,13 +2085,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/proper-lockfile": {
@@ -1486,7 +2131,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1508,21 +2152,160 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/babel-plugin-jsx-dom-expressions": {
+      "version": "0.40.7",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.40.7.tgz",
+      "integrity": "sha512-/O6JWUmjv03OI9lL2ry9bUjpD5S3PclM55RRJEyCdcFZ5W2SEA/59d+l2hNsk3gI6kiWRdRPdOtqZmsQzFN1pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "7.18.6",
+        "@babel/plugin-syntax-jsx": "^7.18.6",
+        "@babel/types": "^7.20.7",
+        "html-entities": "2.3.3",
+        "parse5": "^7.1.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.20.12"
+      }
+    },
+    "node_modules/babel-plugin-jsx-dom-expressions/node_modules/@babel/helper-module-imports": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
+      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/babel-plugin-module-resolver": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-5.0.2.tgz",
+      "integrity": "sha512-9KtaCazHee2xc0ibfqsDeamwDps6FZNo5S0Q81dUqEuFzVwPhcT4J5jOqIVvgCA3Q/wO9hKYxN/Ds3tIsp5ygg==",
+      "license": "MIT",
+      "dependencies": {
+        "find-babel-config": "^2.1.1",
+        "glob": "^9.3.3",
+        "pkg-up": "^3.1.0",
+        "reselect": "^4.1.7",
+        "resolve": "^1.22.8"
+      }
+    },
+    "node_modules/babel-preset-solid": {
+      "version": "1.9.12",
+      "resolved": "https://registry.npmjs.org/babel-preset-solid/-/babel-preset-solid-1.9.12.tgz",
+      "integrity": "sha512-LLqnuKVDlKpyBlMPcH6qEvs/wmS9a+NczppxJ3ryS/c0O5IiSFOIBQi9GzyiGDSbcJpx4Gr87jyFTos1MyEuWg==",
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jsx-dom-expressions": "^0.40.6"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "solid-js": "^1.9.12"
+      },
+      "peerDependenciesMeta": {
+        "solid-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.32",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
+      "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/bowser": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "license": "MIT"
     },
+    "node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
     "node_modules/bun-types": {
-      "version": "1.3.11",
-      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.11.tgz",
-      "integrity": "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg==",
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.14.tgz",
+      "integrity": "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
@@ -1557,22 +2340,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/colorette": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "dev": true,
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
-    },
-    "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1588,6 +2360,29 @@
         "node": ">= 8"
       }
     },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1596,6 +2391,15 @@
       "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/effect": {
@@ -1616,12 +2420,29 @@
         "yaml": "^2.8.3"
       }
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.361",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.361.tgz",
+      "integrity": "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==",
+      "license": "ISC"
+    },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/environment": {
       "version": "1.1.0",
@@ -1634,6 +2455,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/eventemitter3": {
@@ -1701,17 +2540,61 @@
         "fxparser": "src/cli/cli.js"
       }
     },
+    "node_modules/find-babel-config": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-2.1.2.tgz",
+      "integrity": "sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg==",
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.3"
+      }
+    },
     "node_modules/find-my-way-ts": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
       "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
       "license": "MIT"
     },
+    "node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/get-east-asian-width": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
-      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
-      "dev": true,
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1720,11 +2603,48 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/glob": {
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "minimatch": "^8.0.2",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-entities": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
+      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==",
+      "license": "MIT"
     },
     "node_modules/husky": {
       "version": "9.1.7",
@@ -1751,6 +2671,21 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
@@ -1773,6 +2708,36 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/kubernetes-types": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
@@ -1789,6 +2754,7 @@
         "wasm32",
         "arm"
       ],
+      "license": "MIT",
       "os": [
         "darwin",
         "linux",
@@ -1814,50 +2780,64 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
       "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/lint-staged": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
-      "integrity": "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==",
+      "version": "17.0.5",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.5.tgz",
+      "integrity": "sha512-d12yC+/e8RhBjZtaxZn71FyrgU/P5e+uAPifhCLwdosQZP/zamSdKRWDC30ocVIbzDKiFG1McHc/LUgB92GIPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "commander": "^14.0.3",
-        "listr2": "^9.0.5",
-        "picomatch": "^4.0.3",
+        "listr2": "^10.2.1",
+        "picomatch": "^4.0.4",
         "string-argv": "^0.3.2",
-        "tinyexec": "^1.0.4",
-        "yaml": "^2.8.2"
+        "tinyexec": "^1.1.2"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
       },
       "engines": {
-        "node": ">=20.17"
+        "node": ">=22.22.1"
       },
       "funding": {
         "url": "https://opencollective.com/lint-staged"
+      },
+      "optionalDependencies": {
+        "yaml": "^2.8.4"
       }
     },
     "node_modules/listr2": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
-      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-10.2.1.tgz",
+      "integrity": "sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cli-truncate": "^5.0.0",
-        "colorette": "^2.0.20",
-        "eventemitter3": "^5.0.1",
+        "cli-truncate": "^5.2.0",
+        "eventemitter3": "^5.0.4",
         "log-update": "^6.1.0",
         "rfdc": "^1.4.1",
-        "wrap-ansi": "^9.0.0"
+        "wrap-ansi": "^10.0.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.13.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/log-update": {
@@ -1897,6 +2877,63 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/marked": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz",
+      "integrity": "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/mimic-function": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
@@ -1909,6 +2946,36 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/minimatch": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.7.tgz",
+      "integrity": "sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/msgpackr": {
       "version": "1.11.12",
@@ -1962,6 +3029,15 @@
         "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
+    "node_modules/node-releases": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
+      "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/onetime": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
@@ -1976,6 +3052,75 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/path-expression-matcher": {
@@ -2002,6 +3147,49 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/path-scurry/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
     "node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
@@ -2015,13 +3203,24 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pkg-up": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2076,6 +3275,33 @@
       ],
       "license": "MIT"
     },
+    "node_modules/reselect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
+      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==",
+      "license": "MIT"
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
@@ -2122,6 +3348,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/s-js": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/s-js/-/s-js-0.4.9.tgz",
+      "integrity": "sha512-RtpOm+cM6O0sHg6IA70wH+UC3FZcND+rccBZpBAHzlUgNO2Bm5BN+FnM8+OBxzXdwpKWFwX11JGF0MFRkhSoIQ==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/seroval": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.4.tgz",
+      "integrity": "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/seroval-plugins": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.4.tgz",
+      "integrity": "sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "seroval": "^1.0"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -2166,6 +3428,17 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/solid-js": {
+      "version": "1.9.12",
+      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.12.tgz",
+      "integrity": "sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.0",
+        "seroval": "~1.5.0",
+        "seroval-plugins": "~1.5.0"
+      }
+    },
     "node_modules/string-argv": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
@@ -2177,9 +3450,9 @@
       }
     },
     "node_modules/string-width": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
-      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2221,10 +3494,22 @@
       ],
       "license": "MIT"
     },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/tinyexec": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
-      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2247,12 +3532,11 @@
       "license": "0BSD"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2262,11 +3546,41 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
     },
     "node_modules/uuid": {
       "version": "13.0.2",
@@ -2279,6 +3593,21 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/web-tree-sitter": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.25.10.tgz",
+      "integrity": "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@types/emscripten": "^1.40.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/emscripten": {
+          "optional": true
+        }
       }
     },
     "node_modules/which": {
@@ -2297,40 +3626,28 @@
       }
     },
     "node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
+      "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
+        "ansi-styles": "^6.2.3",
+        "string-width": "^8.2.0",
+        "strip-ansi": "^7.1.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.8.4",
@@ -2347,10 +3664,16 @@
         "url": "https://github.com/sponsors/eemeli"
       }
     },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
+    },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -1,13 +1,26 @@
 {
   "name": "@zhafron/opencode-kiro-auth",
-  "version": "1.11.2",
+  "version": "1.12.0",
   "description": "OpenCode plugin for AWS Kiro (CodeWhisperer) providing access to Claude models",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./tui": {
+      "types": "./dist/tui.d.ts",
+      "import": "./dist/tui.js"
+    },
+    "./package.json": "./package.json"
+  },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json && node scripts/fix-esm-imports.mjs",
-    "format": "prettier --write 'src/**/*.ts'",
+    "clean": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
+    "build": "bun run clean && tsc -p tsconfig.build.json && node scripts/fix-esm-imports.mjs && bun scripts/build-tui.ts",
+    "check": "bun run typecheck && bun test && bun run build",
+    "format": "prettier --write 'src/**/*.{ts,tsx}' 'scripts/**/*.ts' 'README.md' 'package.json'",
     "test": "bun test",
     "typecheck": "tsc --noEmit",
     "prepare": "husky"
@@ -24,6 +37,10 @@
   ],
   "author": "tickernelz",
   "license": "MIT",
+  "engines": {
+    "node": ">=20.17",
+    "opencode": ">=1.15.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tickernelz/opencode-kiro-auth.git"
@@ -32,21 +49,23 @@
     "access": "public"
   },
   "dependencies": {
-    "@aws/codewhisperer-streaming-client": "^1.0.34",
-    "@opencode-ai/plugin": "^1.15.11",
-    "libsql": "^0.5.29",
+    "@aws/codewhisperer-streaming-client": "^1.0.45",
+    "@opencode-ai/plugin": "1.15.11",
+    "@opentui/solid": "0.2.15",
+    "libsql": "0.5.29",
     "proper-lockfile": "^4.1.2",
-    "zod": "^3.24.0"
+    "solid-js": "1.9.12",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@types/node": "^20.0.0",
+    "@types/node": "^25.9.1",
     "@types/proper-lockfile": "^4.1.4",
-    "bun-types": "^1.3.6",
+    "bun-types": "^1.3.14",
     "husky": "^9.1.7",
-    "lint-staged": "^16.2.7",
-    "prettier": "^3.4.2",
-    "prettier-plugin-organize-imports": "^4.1.0",
-    "typescript": "^5.7.3"
+    "lint-staged": "^17.0.5",
+    "prettier": "^3.8.3",
+    "prettier-plugin-organize-imports": "^4.3.0",
+    "typescript": "^6.0.3"
   },
   "opencode": {
     "type": "plugin",

--- a/scripts/build-tui.ts
+++ b/scripts/build-tui.ts
@@ -1,0 +1,33 @@
+#!/usr/bin/env bun
+
+import { createSolidTransformPlugin } from '@opentui/solid/bun-plugin'
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+const result = await Bun.build({
+  entrypoints: ['src/tui.tsx'],
+  target: 'bun',
+  format: 'esm',
+  outdir: 'dist',
+  plugins: [createSolidTransformPlugin()],
+  external: ['@opentui/solid', 'solid-js'],
+  sourcemap: 'none'
+})
+
+for (const log of result.logs) {
+  console.error(log)
+}
+
+if (!result.success) {
+  process.exit(1)
+}
+
+const output = await readFile(resolve('dist/tui.js'), 'utf8')
+
+if (output.includes('@opentui/solid/jsx-runtime')) {
+  throw new Error(
+    'TUI build still imports @opentui/solid/jsx-runtime, which is types-only at runtime.'
+  )
+}
+
+console.log('build-tui: wrote dist/tui.js with OpenTUI Solid transform')

--- a/src/__tests__/auth-bootstrap.test.ts
+++ b/src/__tests__/auth-bootstrap.test.ts
@@ -54,6 +54,16 @@ describe('bootstrapAuthIfNeeded', () => {
     rmSync(home, { recursive: true, force: true })
   })
 
+  test('does not rewrite non-object auth.json', () => {
+    const { home, authPath } = setupBootstrapFixture()
+    writeFileSync(authPath, 'null')
+
+    bootstrapAuthIfNeeded('kiro')
+
+    expect(readFileSync(authPath, 'utf-8')).toBe('null')
+    rmSync(home, { recursive: true, force: true })
+  })
+
   test('adds placeholder while preserving existing auth providers', () => {
     const { home, authPath } = setupBootstrapFixture()
     writeFileSync(authPath, JSON.stringify({ github: { type: 'api', key: 'existing' } }, null, 2))
@@ -71,6 +81,18 @@ describe('bootstrapAuthIfNeeded', () => {
     const { home, authPath } = setupBootstrapFixture()
     writeFileSync(authPath, JSON.stringify({ github: { type: 'api', key: 'existing' } }, null, 2))
     chmodSync(authPath, 0o600)
+
+    bootstrapAuthIfNeeded('kiro')
+
+    expect(statSync(authPath).mode & 0o777).toBe(0o600)
+    rmSync(home, { recursive: true, force: true })
+  })
+
+  test('repairs permissive auth.json permissions when rewriting', () => {
+    if (process.platform === 'win32') return
+    const { home, authPath } = setupBootstrapFixture()
+    writeFileSync(authPath, JSON.stringify({ github: { type: 'api', key: 'existing' } }, null, 2))
+    chmodSync(authPath, 0o644)
 
     bootstrapAuthIfNeeded('kiro')
 

--- a/src/__tests__/auth-network-hardening.test.ts
+++ b/src/__tests__/auth-network-hardening.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { getOidcEndpoint, parseCodeWhispererProfileArn } from '../constants.js'
+import { encodeRefreshToken } from '../kiro/auth.js'
+import { authorizeKiroIDC, pollKiroIDCToken } from '../kiro/oauth-idc.js'
+import { refreshAccessToken } from '../plugin/token.js'
+import type { KiroAuthDetails } from '../plugin/types.js'
+import { fetchUsageLimits } from '../plugin/usage.js'
+
+const originalFetch = globalThis.fetch
+const originalXdgConfigHome = process.env.XDG_CONFIG_HOME
+let tempConfigHome: string | undefined
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  if (originalXdgConfigHome === undefined) delete process.env.XDG_CONFIG_HOME
+  else process.env.XDG_CONFIG_HOME = originalXdgConfigHome
+  if (tempConfigHome) rmSync(tempConfigHome, { recursive: true, force: true })
+  tempConfigHome = undefined
+})
+
+describe('partition-aware authentication', () => {
+  test('parses commercial and GovCloud profile ARNs', () => {
+    expect(
+      parseCodeWhispererProfileArn(
+        'arn:aws:codewhisperer:eu-central-1:123456789012:profile/PROFILE_1'
+      )
+    ).toMatchObject({ partition: 'aws', service: 'codewhisperer', region: 'eu-central-1' })
+    expect(
+      parseCodeWhispererProfileArn(
+        'arn:aws-us-gov:qdeveloper:us-gov-west-1:123456789012:profile/PROFILE_2'
+      )
+    ).toMatchObject({ partition: 'aws-us-gov', service: 'qdeveloper', region: 'us-gov-west-1' })
+  })
+
+  test('rejects partition-region mismatches, unsupported China, and non-profile resources', () => {
+    expect(
+      parseCodeWhispererProfileArn(
+        'arn:aws:codewhisperer:us-gov-west-1:123456789012:profile/PROFILE'
+      )
+    ).toBeUndefined()
+    expect(
+      parseCodeWhispererProfileArn(
+        'arn:aws-cn:codewhisperer:cn-north-1:123456789012:profile/PROFILE'
+      )
+    ).toBeUndefined()
+    expect(
+      parseCodeWhispererProfileArn('arn:aws:codewhisperer:us-east-1:123456789012:workspace/PROFILE')
+    ).toBeUndefined()
+  })
+
+  test('selects the FIPS OIDC host for GovCloud and rejects China', () => {
+    expect(getOidcEndpoint('us-gov-west-1')).toBe('https://oidc-fips.us-gov-west-1.amazonaws.com')
+    expect(getOidcEndpoint('us-east-1')).toBe('https://oidc.us-east-1.amazonaws.com')
+    expect(() => getOidcEndpoint('cn-north-1')).toThrow('AWS China regions are not supported')
+  })
+
+  test('uses the GovCloud FIPS endpoint and timeouts for device authorization', async () => {
+    tempConfigHome = mkdtempSync(join(tmpdir(), 'kiro-oidc-test-'))
+    process.env.XDG_CONFIG_HOME = tempConfigHome
+    const calls: Array<{ input: string; init?: RequestInit }> = []
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      calls.push({ input: String(input), init })
+      if (calls.length === 1) {
+        return Response.json({
+          clientId: 'client-id',
+          clientSecret: 'client-secret',
+          clientSecretExpiresAt: Math.floor(Date.now() / 1000) + 86400 * 30
+        })
+      }
+      return Response.json({
+        verificationUri: 'https://device.sso.us-gov-west-1.amazonaws.com/',
+        verificationUriComplete: 'https://device.sso.us-gov-west-1.amazonaws.com/?user_code=CODE',
+        userCode: 'CODE',
+        deviceCode: 'device-code',
+        interval: 1,
+        expiresIn: 600
+      })
+    }) as typeof fetch
+
+    await authorizeKiroIDC('us-gov-west-1')
+
+    expect(calls.map((call) => call.input)).toEqual([
+      'https://oidc-fips.us-gov-west-1.amazonaws.com/client/register',
+      'https://oidc-fips.us-gov-west-1.amazonaws.com/device_authorization'
+    ])
+    expect(calls.every((call) => call.init?.signal instanceof AbortSignal)).toBe(true)
+  })
+
+  test('uses the GovCloud FIPS endpoint and timeout for device token polling', async () => {
+    let call: { input: string; init?: RequestInit } | undefined
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      call = { input: String(input), init }
+      return Response.json({
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        expiresIn: 3600
+      })
+    }) as typeof fetch
+
+    await pollKiroIDCToken('client-id', 'client-secret', 'device-code', 0.001, 2, 'us-gov-west-1')
+
+    expect(call?.input).toBe('https://oidc-fips.us-gov-west-1.amazonaws.com/token')
+    expect(call?.init?.signal).toBeInstanceOf(AbortSignal)
+  })
+
+  test('refresh uses the GovCloud FIPS endpoint, a timeout, and one transient retry', async () => {
+    const calls: Array<{ input: string; init?: RequestInit }> = []
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      calls.push({ input: String(input), init })
+      if (calls.length === 1) throw new TypeError('fetch failed')
+      return new Response(
+        JSON.stringify({ accessToken: 'new-access', refreshToken: 'new-refresh', expiresIn: 3600 }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    }) as typeof fetch
+    const auth: KiroAuthDetails = {
+      refresh: encodeRefreshToken({
+        refreshToken: 'old-refresh',
+        clientId: 'client-id',
+        clientSecret: 'client-secret',
+        authMethod: 'idc'
+      }),
+      access: 'old-access',
+      expires: 0,
+      authMethod: 'idc',
+      region: 'us-gov-west-1',
+      oidcRegion: 'us-gov-west-1'
+    }
+
+    const refreshed = await refreshAccessToken(auth)
+
+    expect(calls).toHaveLength(2)
+    expect(calls[0]?.input).toBe('https://oidc-fips.us-gov-west-1.amazonaws.com/token')
+    expect(calls.every((call) => call.init?.signal instanceof AbortSignal)).toBe(true)
+    expect(refreshed.access).toBe('new-access')
+  })
+
+  test('bounds usage requests with an abort signal', async () => {
+    let signal: AbortSignal | null | undefined
+    globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+      signal = init?.signal
+      return Response.json({ usageBreakdownList: [] })
+    }) as typeof fetch
+
+    await fetchUsageLimits({
+      refresh: 'refresh',
+      access: 'access',
+      expires: Date.now() + 3600000,
+      authMethod: 'idc',
+      region: 'us-east-1'
+    })
+
+    expect(signal).toBeInstanceOf(AbortSignal)
+  })
+
+  test('creates a fresh timeout signal for each usage fallback attempt', async () => {
+    const signals: AbortSignal[] = []
+    globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+      signals.push(init?.signal as AbortSignal)
+      if (signals.length === 1) {
+        return new Response('FEATURE_NOT_SUPPORTED', { status: 400 })
+      }
+      return Response.json({ usageBreakdownList: [] })
+    }) as typeof fetch
+
+    await fetchUsageLimits({
+      refresh: 'refresh',
+      access: 'access',
+      expires: Date.now() + 3600000,
+      authMethod: 'idc',
+      region: 'us-east-1'
+    })
+
+    expect(signals).toHaveLength(2)
+    expect(signals[0]).toBeInstanceOf(AbortSignal)
+    expect(signals[1]).toBeInstanceOf(AbortSignal)
+    expect(signals[0]).not.toBe(signals[1])
+  })
+})

--- a/src/__tests__/constants.test.ts
+++ b/src/__tests__/constants.test.ts
@@ -1,27 +1,134 @@
 import { describe, expect, test } from 'bun:test'
-import { isLongContextModel, normalizeRegion, SUPPORTED_MODELS } from '../constants.js'
+import {
+  DEFAULT_MODEL_IDS,
+  DEFAULT_PROVIDER_MODELS,
+  isLongContextModel,
+  normalizeRegion
+} from '../constants.js'
 
 describe('isLongContextModel', () => {
-  test('returns true for all 1m model variants', () => {
-    const expected1m = SUPPORTED_MODELS.filter((k) => k.includes('-1m'))
-    expect(expected1m.length).toBeGreaterThan(0)
-    for (const model of expected1m) {
-      expect(isLongContextModel(model)).toBe(true)
-    }
+  test('returns true for long-context models', () => {
+    expect(isLongContextModel('claude-opus-4.8')).toBe(true)
+    expect(isLongContextModel('claude-opus-4-8')).toBe(true)
+    expect(isLongContextModel('claude-opus-4.7')).toBe(true)
+    expect(isLongContextModel('claude-opus-4-7')).toBe(true)
+    expect(isLongContextModel('claude-opus-4.7-thinking')).toBe(true)
+    expect(isLongContextModel('claude-opus-4.6')).toBe(true)
+    expect(isLongContextModel('claude-sonnet-4.6')).toBe(true)
   })
 
   test('returns false for standard context models', () => {
-    const standard = SUPPORTED_MODELS.filter((k) => !k.includes('-1m'))
-    expect(standard.length).toBeGreaterThan(0)
-    for (const model of standard) {
-      expect(isLongContextModel(model)).toBe(false)
-    }
+    expect(isLongContextModel('claude-opus-4.5')).toBe(false)
+    expect(isLongContextModel('claude-sonnet-4.5')).toBe(false)
+    expect(isLongContextModel('claude-sonnet-4-5')).toBe(false)
+    expect(isLongContextModel('claude-haiku-4.5')).toBe(false)
+    expect(isLongContextModel('deepseek-3.2')).toBe(false)
   })
 
   test('returns false for unknown model strings', () => {
     expect(isLongContextModel('unknown-model')).toBe(false)
     expect(isLongContextModel('')).toBe(false)
-    expect(isLongContextModel('claude-sonnet-4-6')).toBe(false)
+  })
+})
+
+describe('DEFAULT_PROVIDER_MODELS', () => {
+  const variants = (model: string) => (DEFAULT_PROVIDER_MODELS[model] as any)?.variants
+
+  test('surfaces every default model in the OpenCode provider config', () => {
+    for (const model of DEFAULT_MODEL_IDS) {
+      expect(model in DEFAULT_PROVIDER_MODELS).toBe(true)
+    }
+  })
+
+  test('defines the exact Kiro effort variants for supported models', () => {
+    expect(variants('claude-opus-4.8')).toEqual({
+      low: { reasoningEffort: 'low' },
+      medium: { reasoningEffort: 'medium' },
+      high: { reasoningEffort: 'high' },
+      xhigh: { reasoningEffort: 'xhigh' },
+      max: { reasoningEffort: 'max' }
+    })
+    expect(variants('claude-opus-4.6')).toEqual({
+      low: { reasoningEffort: 'low' },
+      medium: { reasoningEffort: 'medium' },
+      high: { reasoningEffort: 'high' },
+      max: { reasoningEffort: 'max' }
+    })
+    expect(variants('claude-opus-4.5')).toEqual({
+      low: { disabled: true },
+      medium: { disabled: true },
+      high: { disabled: true }
+    })
+    expect(variants('claude-sonnet-5')).toEqual({
+      low: { disabled: true },
+      medium: { disabled: true },
+      high: { disabled: true }
+    })
+    for (const model of ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']) {
+      expect(variants(model)).toEqual({
+        low: { reasoningEffort: 'low' },
+        medium: { reasoningEffort: 'medium' },
+        high: { reasoningEffort: 'high' },
+        xhigh: { reasoningEffort: 'xhigh' },
+        max: { reasoningEffort: 'max' }
+      })
+    }
+  })
+
+  test('surfaces only the official Kiro CLI model slugs by default', () => {
+    expect(DEFAULT_MODEL_IDS).toEqual([
+      'auto',
+      'gpt-5.6-sol',
+      'gpt-5.6-terra',
+      'gpt-5.6-luna',
+      'claude-opus-4.8',
+      'claude-opus-4.7',
+      'claude-opus-4.6',
+      'claude-opus-4.5',
+      'claude-sonnet-4.6',
+      'claude-sonnet-5',
+      'claude-sonnet-4.5',
+      'claude-sonnet-4',
+      'claude-haiku-4.5',
+      'deepseek-3.2',
+      'minimax-m2.5',
+      'glm-5',
+      'minimax-m2.1',
+      'qwen3-coder-next'
+    ])
+  })
+
+  test('uses current Kiro context windows', () => {
+    expect(DEFAULT_PROVIDER_MODELS['gpt-5.6-sol']?.limit.context).toBe(272000)
+    expect(DEFAULT_PROVIDER_MODELS['gpt-5.6-terra']?.limit.context).toBe(272000)
+    expect(DEFAULT_PROVIDER_MODELS['gpt-5.6-luna']?.limit.context).toBe(272000)
+    expect(DEFAULT_PROVIDER_MODELS.auto?.limit.context).toBe(1000000)
+    expect(DEFAULT_PROVIDER_MODELS['claude-opus-4.8']?.limit.context).toBe(1000000)
+    expect(DEFAULT_PROVIDER_MODELS['claude-opus-4.8']?.limit.output).toBe(128000)
+    expect(DEFAULT_PROVIDER_MODELS['claude-opus-4.7']?.limit.context).toBe(1000000)
+    expect(DEFAULT_PROVIDER_MODELS['claude-opus-4.6']?.limit.context).toBe(1000000)
+    expect(DEFAULT_PROVIDER_MODELS['claude-sonnet-4.6']?.limit.context).toBe(1000000)
+    expect(DEFAULT_PROVIDER_MODELS['claude-opus-4.5']?.limit.context).toBe(200000)
+    expect(DEFAULT_PROVIDER_MODELS['claude-sonnet-4.5']?.limit.context).toBe(200000)
+    expect(DEFAULT_PROVIDER_MODELS['glm-5']?.limit.context).toBe(200000)
+    expect(DEFAULT_PROVIDER_MODELS['deepseek-3.2']?.limit.context).toBe(164000)
+    expect(DEFAULT_PROVIDER_MODELS['minimax-m2.5']?.limit.context).toBe(196000)
+    expect(DEFAULT_PROVIDER_MODELS['minimax-m2.1']?.limit.context).toBe(196000)
+  })
+
+  test('uses current Kiro model credit multipliers', () => {
+    expect(DEFAULT_PROVIDER_MODELS['gpt-5.6-sol']?.name).toContain('2.4x')
+    expect(DEFAULT_PROVIDER_MODELS['gpt-5.6-terra']?.name).toContain('1.2x')
+    expect(DEFAULT_PROVIDER_MODELS['gpt-5.6-luna']?.name).toContain('0.6x')
+    expect(DEFAULT_PROVIDER_MODELS['deepseek-3.2']?.name).toContain('0.25x')
+    expect(DEFAULT_PROVIDER_MODELS['glm-5']?.name).toContain('0.5x')
+    expect(DEFAULT_PROVIDER_MODELS['minimax-m2.5']?.name).toContain('0.25x')
+    expect(DEFAULT_PROVIDER_MODELS['qwen3-coder-next']?.name).toContain('0.05x')
+  })
+
+  test('uses models.dev display name for Sonnet 4 without adding a duplicate slug', () => {
+    expect(DEFAULT_PROVIDER_MODELS['claude-sonnet-4']?.name).toContain('Claude Sonnet 4')
+    expect(DEFAULT_MODEL_IDS).not.toContain('claude-sonnet-4.0')
   })
 })
 

--- a/src/__tests__/database-init-worker.ts
+++ b/src/__tests__/database-init-worker.ts
@@ -1,0 +1,8 @@
+import { dirname, join } from 'node:path'
+
+const path = process.argv[2]
+if (!path) throw new Error('Database path is required')
+
+process.env.XDG_CONFIG_HOME = join(dirname(path), `worker-${process.pid}`)
+const { createDatabase } = await import('../plugin/storage/sqlite.js')
+createDatabase(path).close()

--- a/src/__tests__/effort.test.ts
+++ b/src/__tests__/effort.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import {
   budgetToEffort,
   getEffectiveEffort,
+  getEffortSchemaPath,
   resolveEffort,
   supportsEffort,
   supportsXHighEffort
@@ -14,23 +15,42 @@ describe('effort module', () => {
       expect(supportsEffort('claude-opus-4.7')).toBe(true)
       expect(supportsEffort('claude-sonnet-4.6')).toBe(true)
       expect(supportsEffort('claude-sonnet-4.6-1m')).toBe(true)
+      expect(supportsEffort('gpt-5.6-sol')).toBe(true)
+      expect(supportsEffort('gpt-5.6-terra')).toBe(true)
+      expect(supportsEffort('gpt-5.6-luna')).toBe(true)
     })
 
     test('returns false for unsupported models', () => {
       expect(supportsEffort('claude-haiku-4.5')).toBe(false)
+      expect(supportsEffort('claude-opus-4.5')).toBe(false)
+      expect(supportsEffort('claude-sonnet-4.5')).toBe(false)
       expect(supportsEffort('unknown-model')).toBe(false)
     })
   })
 
   describe('supportsXHighEffort', () => {
-    test('returns true for opus 4.7 and 4.8', () => {
+    test('returns true for models with the five-level effort enum', () => {
       expect(supportsXHighEffort('claude-opus-4.8')).toBe(true)
       expect(supportsXHighEffort('claude-opus-4.7')).toBe(true)
+      expect(supportsXHighEffort('gpt-5.6-sol')).toBe(true)
+      expect(supportsXHighEffort('gpt-5.6-terra')).toBe(true)
+      expect(supportsXHighEffort('gpt-5.6-luna')).toBe(true)
     })
 
     test('returns false for other models', () => {
       expect(supportsXHighEffort('claude-opus-4.6')).toBe(false)
       expect(supportsXHighEffort('claude-sonnet-4.6')).toBe(false)
+    })
+  })
+
+  describe('getEffortSchemaPath', () => {
+    test('returns the request schema path advertised for each model family', () => {
+      expect(getEffortSchemaPath('gpt-5.6-sol')).toBe('reasoning')
+      expect(getEffortSchemaPath('gpt-5.6-terra')).toBe('reasoning')
+      expect(getEffortSchemaPath('gpt-5.6-luna')).toBe('reasoning')
+      expect(getEffortSchemaPath('claude-opus-4.8')).toBe('output_config')
+      expect(getEffortSchemaPath('claude-sonnet-4.6')).toBe('output_config')
+      expect(getEffortSchemaPath('claude-haiku-4.5')).toBeUndefined()
     })
   })
 
@@ -43,11 +63,14 @@ describe('effort module', () => {
       expect(resolveEffort('claude-opus-4.8', 'low')).toBe('low')
       expect(resolveEffort('claude-opus-4.8', 'max')).toBe('max')
       expect(resolveEffort('claude-opus-4.8', 'xhigh')).toBe('xhigh')
+      expect(resolveEffort('gpt-5.6-sol', 'xhigh')).toBe('xhigh')
+      expect(resolveEffort('gpt-5.6-terra', 'max')).toBe('max')
+      expect(resolveEffort('gpt-5.6-luna', 'low')).toBe('low')
     })
 
-    test('clamps xhigh to max for models without xhigh support', () => {
-      expect(resolveEffort('claude-sonnet-4.6', 'xhigh')).toBe('max')
-      expect(resolveEffort('claude-opus-4.6', 'xhigh')).toBe('max')
+    test('rejects xhigh for models without xhigh support', () => {
+      expect(resolveEffort('claude-sonnet-4.6', 'xhigh')).toBeUndefined()
+      expect(resolveEffort('claude-opus-4.6', 'xhigh')).toBeUndefined()
     })
   })
 
@@ -77,6 +100,13 @@ describe('effort module', () => {
     test('uses explicit config when provided', () => {
       expect(getEffectiveEffort('claude-opus-4.8', true, 20000, 'max')).toBe('max')
       expect(getEffectiveEffort('claude-opus-4.8', false, 20000, 'high')).toBe('high')
+    })
+
+    test('gives the selected OpenCode variant priority over static config', () => {
+      expect(getEffectiveEffort('claude-opus-4.8', true, 20000, 'low', false, 'max')).toBe('max')
+      expect(
+        getEffectiveEffort('claude-sonnet-4.6', true, 20000, undefined, false, 'xhigh')
+      ).toBeUndefined()
     })
 
     test('returns undefined when not thinking and no config', () => {

--- a/src/__tests__/kiro-cli-sync.test.ts
+++ b/src/__tests__/kiro-cli-sync.test.ts
@@ -88,6 +88,45 @@ describe('Kiro CLI account sync', () => {
         [synced, staleSameProfile, stalePreviouslySynced, manualOtherAccount],
         [synced]
       )
-    ).toEqual(['old-id', 'old-cli-synced-id'])
+    ).toEqual(['old-id'])
+  })
+
+  test('does not deactivate unrelated previously synced accounts with the same auth method', () => {
+    const synced = {
+      id: 'current-id',
+      email: 'current@example.com',
+      authMethod: 'idc' as const,
+      clientId: 'current-client',
+      profileArn: 'arn:aws:codewhisperer:us-east-1:123:profile/current'
+    }
+    const unrelated = {
+      id: 'other-id',
+      email: 'other@example.com',
+      auth_method: 'idc',
+      client_id: 'other-client',
+      profile_arn: 'arn:aws:codewhisperer:us-east-1:123:profile/other',
+      last_sync: Date.now() - 1000
+    }
+
+    expect(getStaleKiroCliAccountIds([synced, unrelated], [synced])).toEqual([])
+  })
+
+  test('does not treat a shared email as identity when stable identifiers differ', () => {
+    const synced = {
+      id: 'current-id',
+      email: 'shared@example.com',
+      authMethod: 'idc' as const,
+      clientId: 'current-client',
+      profileArn: 'profile-current'
+    }
+    const unrelated = {
+      id: 'other-id',
+      email: 'shared@example.com',
+      auth_method: 'idc',
+      client_id: 'other-client',
+      profile_arn: 'profile-other'
+    }
+
+    expect(getStaleKiroCliAccountIds([synced, unrelated], [synced])).toEqual([])
   })
 })

--- a/src/__tests__/kiro-cli-writeback.test.ts
+++ b/src/__tests__/kiro-cli-writeback.test.ts
@@ -1,0 +1,196 @@
+import { Database } from 'bun:sqlite'
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { writeToKiroCli } from '../plugin/sync/kiro-cli.js'
+
+const created: string[] = []
+
+type TokenRow = { key: string; value?: Record<string, unknown> }
+
+function makeCliDb(...rows: TokenRow[]): string {
+  const dir = mkdtempSync(join(tmpdir(), 'kirocli-test-'))
+  created.push(dir)
+  const dbPath = join(dir, 'data.sqlite3')
+  const db = new Database(dbPath)
+  db.run('CREATE TABLE auth_kv (key TEXT PRIMARY KEY, value TEXT)')
+  const insert = db.prepare('INSERT INTO auth_kv (key, value) VALUES (?, ?)')
+  for (const row of rows) {
+    insert.run(
+      row.key,
+      JSON.stringify({
+        access_token: 'OLD_ACCESS',
+        refresh_token: 'OLD_REFRESH',
+        expires_at: '2020-01-01T00:00:00.000Z',
+        ...row.value
+      })
+    )
+  }
+  db.close()
+  return dbPath
+}
+
+function readToken(dbPath: string, tokenKey: string): any {
+  const db = new Database(dbPath, { readonly: true })
+  const row = db.prepare('SELECT value FROM auth_kv WHERE key = ?').get(tokenKey) as any
+  db.close()
+  return JSON.parse(row.value)
+}
+
+afterEach(() => {
+  delete process.env.KIROCLI_DB_PATH
+  for (const dir of created.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('writeToKiroCli', () => {
+  test('writes refreshed IDC tokens back to the kirocli:oidc:token key', async () => {
+    const dbPath = makeCliDb({
+      key: 'kirocli:oidc:token',
+      value: { client_id: 'matching-client' }
+    })
+    process.env.KIROCLI_DB_PATH = dbPath
+
+    await writeToKiroCli({
+      authMethod: 'idc',
+      clientId: 'matching-client',
+      accessToken: 'NEW_ACCESS',
+      refreshToken: 'NEW_REFRESH',
+      expiresAt: Date.parse('2030-01-01T00:00:00.000Z')
+    })
+
+    const data = readToken(dbPath, 'kirocli:oidc:token')
+    expect(data.access_token).toBe('NEW_ACCESS')
+    expect(data.refresh_token).toBe('NEW_REFRESH')
+    expect(data.expires_at).toBe('2030-01-01T00:00:00.000Z')
+  })
+
+  test('writes refreshed IDC tokens back to the legacy kirocli:odic:token key', async () => {
+    const dbPath = makeCliDb({ key: 'kirocli:odic:token' })
+    process.env.KIROCLI_DB_PATH = dbPath
+
+    await writeToKiroCli(
+      {
+        authMethod: 'idc',
+        accessToken: 'NEW_ACCESS',
+        refreshToken: 'NEW_REFRESH',
+        expiresAt: Date.parse('2030-01-01T00:00:00.000Z')
+      },
+      'OLD_REFRESH'
+    )
+
+    const data = readToken(dbPath, 'kirocli:odic:token')
+    expect(data.access_token).toBe('NEW_ACCESS')
+    expect(data.refresh_token).toBe('NEW_REFRESH')
+  })
+
+  test('writes refreshed desktop tokens back to the kirocli:social:token key', async () => {
+    const dbPath = makeCliDb({ key: 'kirocli:social:token' })
+    process.env.KIROCLI_DB_PATH = dbPath
+
+    await writeToKiroCli(
+      {
+        authMethod: 'desktop',
+        accessToken: 'NEW_ACCESS',
+        refreshToken: 'NEW_REFRESH',
+        expiresAt: Date.parse('2030-01-01T00:00:00.000Z')
+      },
+      'OLD_REFRESH'
+    )
+
+    const data = readToken(dbPath, 'kirocli:social:token')
+    expect(data.access_token).toBe('NEW_ACCESS')
+    expect(data.refresh_token).toBe('NEW_REFRESH')
+  })
+
+  test('updates only the IDC row whose embedded identity matches', async () => {
+    const dbPath = makeCliDb(
+      {
+        key: 'kirocli:oidc:token',
+        value: { client_id: 'other-client', refresh_token: 'OTHER_REFRESH' }
+      },
+      {
+        key: 'workspace:kirocli:odic:token',
+        value: { client_id: 'matching-client', refresh_token: 'MATCHING_REFRESH' }
+      }
+    )
+    process.env.KIROCLI_DB_PATH = dbPath
+
+    await writeToKiroCli(
+      {
+        authMethod: 'idc',
+        clientId: 'matching-client',
+        accessToken: 'NEW_ACCESS',
+        refreshToken: 'NEW_REFRESH',
+        expiresAt: Date.parse('2030-01-01T00:00:00.000Z')
+      },
+      'MATCHING_REFRESH'
+    )
+
+    expect(readToken(dbPath, 'kirocli:oidc:token').access_token).toBe('OLD_ACCESS')
+    expect(readToken(dbPath, 'workspace:kirocli:odic:token').access_token).toBe('NEW_ACCESS')
+  })
+
+  test('skips writeback when multiple rows match the account identity', async () => {
+    const dbPath = makeCliDb(
+      { key: 'kirocli:oidc:token', value: { client_id: 'shared-client' } },
+      { key: 'workspace:kirocli:odic:token', value: { client_id: 'shared-client' } }
+    )
+    process.env.KIROCLI_DB_PATH = dbPath
+
+    await writeToKiroCli({
+      authMethod: 'idc',
+      clientId: 'shared-client',
+      accessToken: 'NEW_ACCESS',
+      refreshToken: 'NEW_REFRESH',
+      expiresAt: Date.parse('2030-01-01T00:00:00.000Z')
+    })
+
+    expect(readToken(dbPath, 'kirocli:oidc:token').access_token).toBe('OLD_ACCESS')
+    expect(readToken(dbPath, 'workspace:kirocli:odic:token').access_token).toBe('OLD_ACCESS')
+  })
+
+  test('does not prefer the canonical key when another row is the identity match', async () => {
+    const dbPath = makeCliDb(
+      { key: 'kirocli:oidc:token', value: { profile_arn: 'profile-other' } },
+      { key: 'workspace:kirocli:odic:token', value: { profile_arn: 'profile-match' } }
+    )
+    process.env.KIROCLI_DB_PATH = dbPath
+
+    await writeToKiroCli({
+      authMethod: 'idc',
+      profileArn: 'profile-match',
+      accessToken: 'NEW_ACCESS',
+      refreshToken: 'NEW_REFRESH',
+      expiresAt: Date.parse('2030-01-01T00:00:00.000Z')
+    })
+
+    expect(readToken(dbPath, 'kirocli:oidc:token').access_token).toBe('OLD_ACCESS')
+    expect(readToken(dbPath, 'workspace:kirocli:odic:token').access_token).toBe('NEW_ACCESS')
+  })
+
+  test('does not match a profile account only by a shared client ID', async () => {
+    const dbPath = makeCliDb({
+      key: 'kirocli:oidc:token',
+      value: { client_id: 'shared-client', refresh_token: 'OTHER_REFRESH' }
+    })
+    process.env.KIROCLI_DB_PATH = dbPath
+
+    await writeToKiroCli(
+      {
+        authMethod: 'idc',
+        clientId: 'shared-client',
+        profileArn: 'arn:aws:codewhisperer:us-east-1:123456789012:profile/ONE',
+        accessToken: 'NEW_ACCESS',
+        refreshToken: 'NEW_REFRESH',
+        expiresAt: Date.parse('2030-01-01T00:00:00.000Z')
+      },
+      'MATCHING_REFRESH'
+    )
+
+    expect(readToken(dbPath, 'kirocli:oidc:token').access_token).toBe('OLD_ACCESS')
+    expect(readToken(dbPath, 'kirocli:oidc:token').refresh_token).toBe('OTHER_REFRESH')
+  })
+})

--- a/src/__tests__/model-resolution.test.ts
+++ b/src/__tests__/model-resolution.test.ts
@@ -5,17 +5,45 @@ import { resolveKiroModel } from '../plugin/models.js'
 describe('resolveKiroModel', () => {
   test('resolves newly advertised model slugs', () => {
     expect(resolveKiroModel('auto')).toBe('auto')
+    expect(resolveKiroModel('gpt-5.6-sol')).toBe('gpt-5.6-sol')
+    expect(resolveKiroModel('gpt-5.6-terra')).toBe('gpt-5.6-terra')
+    expect(resolveKiroModel('gpt-5.6-luna')).toBe('gpt-5.6-luna')
+    expect(resolveKiroModel('claude-opus-4.8')).toBe('claude-opus-4.8')
+    expect(resolveKiroModel('claude-opus-4.7')).toBe('claude-opus-4.7')
+    expect(resolveKiroModel('claude-sonnet-5')).toBe('claude-sonnet-5')
+    expect(resolveKiroModel('claude-sonnet-4.6')).toBe('claude-sonnet-4.6')
     expect(resolveKiroModel('deepseek-3.2')).toBe('deepseek-3.2')
+    expect(resolveKiroModel('glm-5')).toBe('glm-5')
     expect(resolveKiroModel('minimax-m2.5')).toBe('minimax-m2.5')
     expect(resolveKiroModel('minimax-m2.1')).toBe('minimax-m2.1')
     expect(resolveKiroModel('qwen3-coder-next')).toBe('qwen3-coder-next')
   })
 
   test('keeps existing supported Claude slugs intact', () => {
-    expect(resolveKiroModel('claude-sonnet-4-5')).toBe('claude-sonnet-4.5')
+    expect(resolveKiroModel('claude-sonnet-4.5')).toBe('claude-sonnet-4.5')
     expect(resolveKiroModel('claude-sonnet-4')).toBe('claude-sonnet-4')
     expect(resolveKiroModel('claude-opus-4-8')).toBe('claude-opus-4.8')
     expect(resolveKiroModel('claude-opus-4-8-thinking')).toBe('claude-opus-4.8')
+  })
+
+  test('accepts legacy hyphenated and thinking aliases without listing them by default', () => {
+    expect(resolveKiroModel('claude-opus-4-8')).toBe('claude-opus-4.8')
+    expect(resolveKiroModel('claude-opus-4-8-thinking')).toBe('claude-opus-4.8')
+    expect(resolveKiroModel('claude-opus-4-7')).toBe('claude-opus-4.7')
+    expect(resolveKiroModel('claude-opus-4-7-thinking')).toBe('claude-opus-4.7')
+    expect(resolveKiroModel('claude-haiku-4.5')).toBe('claude-haiku-4.5')
+    expect(resolveKiroModel('claude-haiku-4.5-thinking')).toBe('claude-haiku-4.5')
+    expect(resolveKiroModel('claude-opus-4-5')).toBe('claude-opus-4.5')
+  })
+
+  test('maps legacy 1m aliases onto their current catalog model', () => {
+    expect(resolveKiroModel('claude-sonnet-4-5-1m')).toBe('claude-sonnet-4.5')
+    expect(resolveKiroModel('claude-sonnet-4-5-1m-thinking')).toBe('claude-sonnet-4.5')
+    expect(resolveKiroModel('claude-sonnet-4.5-1m')).toBe('claude-sonnet-4.5')
+    expect(resolveKiroModel('claude-sonnet-4-6-1m')).toBe('claude-sonnet-4.6')
+    expect(resolveKiroModel('claude-sonnet-4.6-1m')).toBe('claude-sonnet-4.6')
+    expect(resolveKiroModel('claude-opus-4-6-1m')).toBe('claude-opus-4.6')
+    expect(resolveKiroModel('claude-opus-4.6-1m')).toBe('claude-opus-4.6')
   })
 
   test('rejects removed qwen3-coder-480b slug', () => {
@@ -26,6 +54,22 @@ describe('resolveKiroModel', () => {
 
   test('supported model list excludes removed qwen3-coder-480b slug', () => {
     expect(SUPPORTED_MODELS).not.toContain('qwen3-coder-480b')
+  })
+
+  test('supported model list includes current Kiro documentation models', () => {
+    expect(SUPPORTED_MODELS).toContain('gpt-5.6-sol')
+    expect(SUPPORTED_MODELS).toContain('gpt-5.6-terra')
+    expect(SUPPORTED_MODELS).toContain('gpt-5.6-luna')
+    expect(SUPPORTED_MODELS).toContain('claude-opus-4.8')
+    expect(SUPPORTED_MODELS).toContain('claude-opus-4.7')
+    expect(SUPPORTED_MODELS).toContain('claude-sonnet-5')
+    expect(SUPPORTED_MODELS).toContain('glm-5')
+  })
+
+  test('rejects docs-only Sonnet 4.0 label as a model id', () => {
+    expect(() => resolveKiroModel('claude-sonnet-4.0')).toThrow(
+      'Unsupported model: claude-sonnet-4.0'
+    )
   })
 
   test('rejects unknown slugs', () => {

--- a/src/__tests__/oidc-client-cache.test.ts
+++ b/src/__tests__/oidc-client-cache.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { putCachedOidcClient } from '../kiro/oidc-client-cache.js'
+
+let configHome: string
+let previousConfigHome: string | undefined
+
+beforeEach(() => {
+  previousConfigHome = process.env.XDG_CONFIG_HOME
+  configHome = mkdtempSync(join(tmpdir(), 'kiro-oidc-cache-'))
+  process.env.XDG_CONFIG_HOME = configHome
+})
+
+afterEach(() => {
+  if (previousConfigHome === undefined) delete process.env.XDG_CONFIG_HOME
+  else process.env.XDG_CONFIG_HOME = previousConfigHome
+  rmSync(configHome, { recursive: true, force: true })
+})
+
+describe('OIDC client cache', () => {
+  test('preserves a malformed cache rather than replacing it', () => {
+    const cacheDir = join(configHome, 'opencode')
+    const cachePath = join(cacheDir, 'kiro-oidc-clients.json')
+    mkdirSync(cacheDir, { recursive: true })
+    writeFileSync(cachePath, '{"existing":')
+
+    putCachedOidcClient('us-east-1', 'https://example.com', ['scope'], {
+      clientId: 'client',
+      clientSecret: 'secret'
+    })
+
+    expect(readFileSync(cachePath, 'utf-8')).toBe('{"existing":')
+  })
+
+  test('atomically preserves entries during concurrent process updates', async () => {
+    const cachePath = join(configHome, 'opencode', 'kiro-oidc-clients.json')
+    putCachedOidcClient('us-east-1', 'https://existing.example.com', ['scope'], {
+      clientId: 'existing-client',
+      clientSecret: 'existing-secret'
+    })
+
+    const moduleUrl = pathToFileURL(
+      join(import.meta.dir, '..', 'kiro', 'oidc-client-cache.ts')
+    ).href
+    const workers = Array.from({ length: 12 }, (_, index) => {
+      const script = `
+        import { putCachedOidcClient } from ${JSON.stringify(moduleUrl)};
+        putCachedOidcClient('us-east-1', 'https://client-${index}.example.com', ['scope'], {
+          clientId: 'client-${index}', clientSecret: 'secret-${index}'
+        });
+      `
+      return Bun.spawn([process.execPath, '-e', script], {
+        env: { ...process.env, XDG_CONFIG_HOME: configHome },
+        stdout: 'ignore',
+        stderr: 'pipe'
+      })
+    })
+
+    const results = await Promise.all(
+      workers.map(async (worker) => ({
+        exitCode: await worker.exited,
+        stderr: await new Response(worker.stderr).text()
+      }))
+    )
+    expect(results.filter((result) => result.exitCode !== 0)).toEqual([])
+
+    const cache = JSON.parse(readFileSync(cachePath, 'utf-8'))
+    expect(Object.keys(cache)).toHaveLength(13)
+    expect(Object.values(cache)).toContainEqual({
+      clientId: 'existing-client',
+      clientSecret: 'existing-secret'
+    })
+    for (let index = 0; index < 12; index++) {
+      expect(Object.values(cache)).toContainEqual({
+        clientId: `client-${index}`,
+        clientSecret: `secret-${index}`
+      })
+    }
+    if (process.platform !== 'win32') expect(statSync(cachePath).mode & 0o777).toBe(0o600)
+    expect(results.map((result) => result.stderr)).toEqual(Array(12).fill(''))
+  })
+})

--- a/src/__tests__/opencode-auth.test.ts
+++ b/src/__tests__/opencode-auth.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import {
+  atomicWritePrivateJsonFile,
+  ensureOpenCodeAuthPlaceholder,
+  getOpenCodeAuthPath
+} from '../plugin/opencode-auth.js'
+
+const PLACEHOLDER_KEY = 'opencode-kiro-auth-placeholder'
+
+let dataHome: string
+let prevXdg: string | undefined
+const created: string[] = []
+
+beforeEach(() => {
+  prevXdg = process.env.XDG_DATA_HOME
+  dataHome = mkdtempSync(join(tmpdir(), 'octest-'))
+  created.push(dataHome)
+  process.env.XDG_DATA_HOME = dataHome
+})
+
+afterEach(() => {
+  if (prevXdg === undefined) delete process.env.XDG_DATA_HOME
+  else process.env.XDG_DATA_HOME = prevXdg
+  for (const dir of created.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('ensureOpenCodeAuthPlaceholder', () => {
+  test('leaves a malformed auth.json untouched and does not drop other providers', () => {
+    const authPath = getOpenCodeAuthPath()
+    mkdirSync(join(authPath, '..'), { recursive: true })
+    const corrupt = '{ "anthropic": { "type": "api", "key": "SECRET_ANT'
+    writeFileSync(authPath, corrupt)
+
+    ensureOpenCodeAuthPlaceholder()
+
+    expect(readFileSync(authPath, 'utf-8')).toBe(corrupt)
+  })
+
+  test('leaves non-object auth.json content untouched', () => {
+    const authPath = getOpenCodeAuthPath()
+    mkdirSync(join(authPath, '..'), { recursive: true })
+    writeFileSync(authPath, '[{"provider":"github"}]')
+
+    ensureOpenCodeAuthPlaceholder()
+
+    expect(readFileSync(authPath, 'utf-8')).toBe('[{"provider":"github"}]')
+  })
+
+  test('creates a fresh placeholder file when auth.json is missing', () => {
+    const authPath = getOpenCodeAuthPath()
+    expect(existsSync(authPath)).toBe(false)
+
+    ensureOpenCodeAuthPlaceholder()
+
+    const data = JSON.parse(readFileSync(authPath, 'utf-8'))
+    expect(data.kiro).toEqual({ type: 'api', key: PLACEHOLDER_KEY })
+    if (process.platform !== 'win32') expect(statSync(authPath).mode & 0o777).toBe(0o600)
+    expect(readdirSync(join(authPath, '..')).filter((name) => name.endsWith('.tmp'))).toEqual([])
+  })
+
+  test('keeps existing providers and adds the placeholder for valid auth.json', () => {
+    const authPath = getOpenCodeAuthPath()
+    mkdirSync(join(authPath, '..'), { recursive: true })
+    writeFileSync(authPath, JSON.stringify({ anthropic: { type: 'api', key: 'SECRET' } }, null, 2))
+
+    ensureOpenCodeAuthPlaceholder()
+
+    const data = JSON.parse(readFileSync(authPath, 'utf-8'))
+    expect(data.anthropic).toEqual({ type: 'api', key: 'SECRET' })
+    expect(data.kiro).toEqual({ type: 'api', key: PLACEHOLDER_KEY })
+  })
+
+  test('preserves all providers during concurrent process updates', async () => {
+    const authPath = getOpenCodeAuthPath()
+    mkdirSync(join(authPath, '..'), { recursive: true })
+    writeFileSync(authPath, JSON.stringify({ github: { type: 'api', key: 'existing' } }))
+    const moduleUrl = pathToFileURL(join(import.meta.dir, '..', 'plugin', 'opencode-auth.ts')).href
+    const workers = Array.from({ length: 8 }, (_, index) =>
+      Bun.spawn(
+        [
+          process.execPath,
+          '-e',
+          `import { ensureOpenCodeAuthPlaceholder } from ${JSON.stringify(moduleUrl)};
+           ensureOpenCodeAuthPlaceholder('provider-${index}');`
+        ],
+        {
+          env: { ...process.env, XDG_DATA_HOME: dataHome },
+          stdout: 'ignore',
+          stderr: 'pipe'
+        }
+      )
+    )
+
+    const results = await Promise.all(
+      workers.map(async (worker) => ({
+        exitCode: await worker.exited,
+        stderr: await new Response(worker.stderr).text()
+      }))
+    )
+    expect(results.filter((result) => result.exitCode !== 0)).toEqual([])
+
+    const data = JSON.parse(readFileSync(authPath, 'utf-8'))
+    expect(data.github).toEqual({ type: 'api', key: 'existing' })
+    for (let index = 0; index < 8; index++) {
+      expect(data[`provider-${index}`]).toEqual({ type: 'api', key: PLACEHOLDER_KEY })
+    }
+    expect(results.map((result) => result.stderr)).toEqual(Array(8).fill(''))
+  })
+
+  test('cleans up the private temp file when atomic replacement fails', () => {
+    const target = join(dataHome, 'target-directory')
+    mkdirSync(target)
+
+    expect(() => atomicWritePrivateJsonFile(target, { secret: true })).toThrow()
+
+    expect(readdirSync(dataHome)).toEqual(['target-directory'])
+  })
+
+  test('does not rewrite when the placeholder already exists', () => {
+    const authPath = getOpenCodeAuthPath()
+    mkdirSync(join(authPath, '..'), { recursive: true })
+    const existing = JSON.stringify({ kiro: { type: 'api', key: PLACEHOLDER_KEY } }, null, 2)
+    writeFileSync(authPath, existing)
+
+    ensureOpenCodeAuthPlaceholder()
+
+    expect(readFileSync(authPath, 'utf-8')).toBe(existing)
+  })
+
+  test('repairs permissive permissions without rewriting existing auth', () => {
+    if (process.platform === 'win32') return
+    const authPath = getOpenCodeAuthPath()
+    mkdirSync(join(authPath, '..'), { recursive: true })
+    writeFileSync(authPath, JSON.stringify({ kiro: { type: 'api', key: PLACEHOLDER_KEY } }))
+    chmodSync(authPath, 0o644)
+
+    ensureOpenCodeAuthPlaceholder()
+
+    expect(statSync(authPath).mode & 0o777).toBe(0o600)
+  })
+})

--- a/src/__tests__/package-manifest.test.ts
+++ b/src/__tests__/package-manifest.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const pkg = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf8'))
+
+describe('package manifest', () => {
+  test('exposes separate server and TUI plugin entrypoints', () => {
+    expect(pkg.exports['.'].import).toBe('./dist/index.js')
+    expect(pkg.exports['./tui'].import).toBe('./dist/tui.js')
+    expect(pkg.exports['./tui'].types).toBe('./dist/tui.d.ts')
+  })
+
+  test('keeps Solid pinned to the @opentui/solid peer version', () => {
+    expect(pkg.dependencies['@opentui/solid']).toBe('0.2.15')
+    expect(pkg.dependencies['solid-js']).toBe('1.9.12')
+  })
+})

--- a/src/__tests__/request-handler-thinking.test.ts
+++ b/src/__tests__/request-handler-thinking.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, test } from 'bun:test'
+import { THINKING_BUDGET_BY_EFFORT } from '../constants.js'
+import { RequestHandler } from '../core/request/request-handler.js'
+
+const account = {
+  id: 'account-1',
+  email: 'user@example.com',
+  authMethod: 'idc',
+  region: 'us-east-1',
+  refreshToken: 'refresh-token',
+  accessToken: 'access-token',
+  expiresAt: Date.now() + 60_000,
+  rateLimitResetTime: 0,
+  isHealthy: true,
+  failCount: 0
+}
+
+const auth = {
+  refresh: account.refreshToken,
+  access: account.accessToken,
+  expires: account.expiresAt,
+  authMethod: account.authMethod,
+  region: account.region,
+  email: account.email
+}
+
+async function captureThinkingOptions(body: Record<string, unknown>) {
+  const accountManager = {
+    getAccounts: () => [account],
+    toAuthDetails: () => auth
+  }
+  const repository = {}
+  const handler = new RequestHandler(
+    accountManager as any,
+    {
+      auto_sync_kiro_cli: false,
+      account_selection_strategy: 'sticky',
+      sdk_endpoint_mode: 'kiro-runtime',
+      enable_log_api_request: false,
+      auto_effort_mapping: false
+    } as any,
+    repository as any
+  ) as any
+
+  handler.accountSelector = { selectHealthyAccount: async () => account }
+  handler.tokenRefresher = {
+    refreshIfNeeded: async () => ({ account, shouldContinue: false, auth })
+  }
+  handler.usageTracker = { syncUsage: () => {} }
+  handler.responseHandler = { handleSdkSuccess: async () => new Response() }
+
+  let captured: { think: boolean; budget: number; effort?: string } | undefined
+  handler.prepareSdkRequest = (
+    _body: unknown,
+    model: string,
+    _auth: unknown,
+    think: boolean,
+    budget: number,
+    effort?: string
+  ) => {
+    captured = { think, budget, effort }
+    return {
+      conversationState: {},
+      streaming: true,
+      effectiveModel: model,
+      conversationId: 'conversation-1',
+      region: 'us-east-1'
+    }
+  }
+  handler.sendSdkRequestWithEndpointFallback = async () => ({
+    sdkResponse: {},
+    endpointMode: 'kiro-runtime'
+  })
+
+  await handler.handle(
+    'https://q.us-east-1.amazonaws.com/models/claude-opus-4.8/invoke',
+    { body: JSON.stringify({ messages: [{ role: 'user', content: 'hello' }], ...body }) },
+    () => {}
+  )
+
+  return captured
+}
+
+async function handleWithSdkError(error: Error & { $metadata?: { httpStatusCode: number } }) {
+  const accountManager = {
+    getAccounts: () => [account],
+    toAuthDetails: () => auth
+  }
+  const handler = new RequestHandler(
+    accountManager as any,
+    {
+      auto_sync_kiro_cli: false,
+      account_selection_strategy: 'sticky',
+      sdk_endpoint_mode: 'kiro-runtime',
+      enable_log_api_request: false,
+      auto_effort_mapping: false,
+      rate_limit_max_retries: 0,
+      rate_limit_retry_delay_ms: 0
+    } as any,
+    {} as any
+  ) as any
+
+  handler.accountSelector = { selectHealthyAccount: async () => account }
+  handler.tokenRefresher = {
+    refreshIfNeeded: async () => ({ account, shouldContinue: false, auth })
+  }
+  handler.prepareSdkRequest = () => ({
+    conversationState: {},
+    streaming: true,
+    effectiveModel: 'gpt-5.6-sol',
+    conversationId: 'conversation-1',
+    region: 'us-east-1'
+  })
+  handler.sendSdkRequestWithEndpointFallback = async () => ({
+    sdkResponse: {},
+    endpointMode: 'kiro-runtime'
+  })
+  handler.responseHandler = {
+    handleSdkSuccess: async () => {
+      throw error
+    }
+  }
+
+  return handler.handle(
+    'https://q.us-east-1.amazonaws.com/models/gpt-5.6-sol/invoke',
+    { body: JSON.stringify({ messages: [{ role: 'user', content: 'hello' }] }) },
+    () => {}
+  )
+}
+
+describe('request handler thinking config', () => {
+  test.each([
+    [{ thinkingConfig: { thinkingBudget: 8192 } }, 8192],
+    [{ thinkingConfig: { budget_tokens: 16384 } }, 16384],
+    [{ providerOptions: { thinkingConfig: { thinkingBudget: 24576 } } }, 24576],
+    [{ providerOptions: { thinkingConfig: { budget_tokens: 32768 } } }, 32768]
+  ])('extracts thinking budget from supported request shapes', async (body, budget) => {
+    expect(await captureThinkingOptions(body)).toEqual({ think: true, budget, effort: undefined })
+  })
+
+  test('gives explicit effort priority over thinking budget', async () => {
+    expect(
+      await captureThinkingOptions({
+        reasoning_effort: 'max',
+        thinkingConfig: { thinkingBudget: 8192 }
+      })
+    ).toEqual({
+      think: true,
+      budget: THINKING_BUDGET_BY_EFFORT.max,
+      effort: 'max'
+    })
+  })
+
+  test('preserves stream errors from successful SDK responses', async () => {
+    const error = Object.assign(new Error('event stream ended unexpectedly'), {
+      $metadata: { httpStatusCode: 200 }
+    })
+
+    expect(handleWithSdkError(error)).rejects.toThrow('event stream ended unexpectedly')
+  })
+
+  test('attributes a recovered request to the replacement account', async () => {
+    const replacement = { ...account, id: 'replacement-account' }
+    const accountManager = {
+      getAccounts: () => [account, replacement],
+      toAuthDetails: () => auth
+    }
+    const handler = new RequestHandler(
+      accountManager as any,
+      {
+        auto_sync_kiro_cli: false,
+        account_selection_strategy: 'sticky',
+        sdk_endpoint_mode: 'kiro-runtime',
+        enable_log_api_request: false,
+        auto_effort_mapping: false
+      } as any,
+      {} as any
+    ) as any
+    let usageAccount: typeof account | undefined
+
+    handler.accountSelector = { selectHealthyAccount: async () => account }
+    handler.tokenRefresher = {
+      refreshIfNeeded: async () => ({ account: replacement, shouldContinue: false, auth })
+    }
+    handler.prepareSdkRequest = () => ({
+      conversationState: {},
+      streaming: true,
+      effectiveModel: 'gpt-5.6-sol',
+      conversationId: 'conversation-1',
+      region: 'us-east-1'
+    })
+    handler.sendSdkRequestWithEndpointFallback = async () => ({
+      sdkResponse: {},
+      endpointMode: 'kiro-runtime'
+    })
+    handler.responseHandler = { handleSdkSuccess: async () => new Response() }
+    handler.usageTracker = {
+      syncUsage: (target: typeof account) => {
+        usageAccount = target
+      }
+    }
+
+    await handler.handle(
+      'https://q.us-east-1.amazonaws.com/models/gpt-5.6-sol/invoke',
+      { body: JSON.stringify({ messages: [{ role: 'user', content: 'hello' }] }) },
+      () => {}
+    )
+
+    expect(usageAccount).toBe(replacement)
+  })
+})

--- a/src/__tests__/request-history.test.ts
+++ b/src/__tests__/request-history.test.ts
@@ -64,7 +64,7 @@ describe('request history', () => {
     expect(JSON.stringify(state)).not.toContain('[system:')
   })
 
-  test('keeps history padding invisible and makes current continuation turns explicit', () => {
+  test('keeps history padding invisible and makes assistant-ended continuations explicit', () => {
     const state = transform([
       { role: 'user', content: 'First question.' },
       { role: 'assistant', content: '' },
@@ -91,7 +91,33 @@ describe('request history', () => {
     expect(assistantState.currentMessage.userInputMessage?.content).toBe(CONTINUE_TURN_CONTENT)
 
     const emptyState = transform([{ role: 'user', content: '' }])
-    expect(emptyState.currentMessage.userInputMessage?.content).toBe(CONTINUE_TURN_CONTENT)
+    expect(emptyState.currentMessage.userInputMessage?.content).toBe('')
+  })
+
+  test('keeps structured tool-result content empty like Kiro CLI', () => {
+    const state = transform([
+      { role: 'user', content: 'Read a file.' },
+      {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'tool-1', name: 'read', input: {} }]
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tool-1',
+            content: [{ type: 'text', text: 'file contents' }]
+          }
+        ]
+      }
+    ])
+
+    expect(state.currentMessage.userInputMessage?.content).toBe('')
+    expect(
+      state.currentMessage.userInputMessage?.userInputMessageContext?.toolResults?.[0]?.content?.[0]
+        ?.text
+    ).toBe('file contents')
   })
 
   test('unwraps system-reminder transport tags in tool results', () => {

--- a/src/__tests__/request-history.test.ts
+++ b/src/__tests__/request-history.test.ts
@@ -90,4 +90,45 @@ describe('request history', () => {
     const emptyState = transform([{ role: 'user', content: '' }])
     expect(emptyState.currentMessage.userInputMessage?.content).toBe(SYNTHETIC_TURN_CONTENT)
   })
+
+  test('unwraps system-reminder transport tags in tool results', () => {
+    const state = transform([
+      { role: 'user', content: 'Read the instructions.' },
+      {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'tool-1', name: 'read', input: {} }]
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tool-1',
+            content: [
+              {
+                type: 'text',
+                text: 'file output\n\n<system-reminder>\nPrivate instruction\n</system-reminder>'
+              }
+            ]
+          }
+        ]
+      }
+    ])
+
+    const toolResult =
+      state.currentMessage.userInputMessage?.userInputMessageContext?.toolResults?.[0]?.content?.[0]
+        ?.text
+    expect(toolResult).toBe('file output\n\nPrivate instruction')
+    expect(JSON.stringify(state)).not.toContain('system-reminder')
+  })
+
+  test('preserves system-reminder tags in ordinary user text', () => {
+    const state = transform([
+      { role: 'user', content: 'Explain `<system-reminder>literal</system-reminder>`.' }
+    ])
+
+    expect(state.currentMessage.userInputMessage?.content).toBe(
+      'Explain `<system-reminder>literal</system-reminder>`.'
+    )
+  })
 })

--- a/src/__tests__/request-history.test.ts
+++ b/src/__tests__/request-history.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from 'bun:test'
-import { SYNTHETIC_TURN_CONTENT } from '../infrastructure/transformers/message-transformer.js'
+import {
+  CONTINUE_TURN_CONTENT,
+  SYNTHETIC_TURN_CONTENT
+} from '../infrastructure/transformers/message-transformer.js'
 import { transformToSdkRequest } from '../plugin/request.js'
 import type { KiroAuthDetails } from '../plugin/types.js'
 
@@ -61,7 +64,7 @@ describe('request history', () => {
     expect(JSON.stringify(state)).not.toContain('[system:')
   })
 
-  test('uses invisible content for missing and current synthetic turns', () => {
+  test('keeps history padding invisible and makes current continuation turns explicit', () => {
     const state = transform([
       { role: 'user', content: 'First question.' },
       { role: 'assistant', content: '' },
@@ -85,10 +88,10 @@ describe('request history', () => {
         content: [{ type: 'tool_use', id: 'tool-1', name: 'read', input: {} }]
       }
     ])
-    expect(assistantState.currentMessage.userInputMessage?.content).toBe(SYNTHETIC_TURN_CONTENT)
+    expect(assistantState.currentMessage.userInputMessage?.content).toBe(CONTINUE_TURN_CONTENT)
 
     const emptyState = transform([{ role: 'user', content: '' }])
-    expect(emptyState.currentMessage.userInputMessage?.content).toBe(SYNTHETIC_TURN_CONTENT)
+    expect(emptyState.currentMessage.userInputMessage?.content).toBe(CONTINUE_TURN_CONTENT)
   })
 
   test('unwraps system-reminder transport tags in tool results', () => {

--- a/src/__tests__/request-history.test.ts
+++ b/src/__tests__/request-history.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'bun:test'
+import { SYNTHETIC_TURN_CONTENT } from '../infrastructure/transformers/message-transformer.js'
+import { transformToSdkRequest } from '../plugin/request.js'
+import type { KiroAuthDetails } from '../plugin/types.js'
+
+const auth: KiroAuthDetails = {
+  refresh: 'refresh-token',
+  access: 'access-token',
+  expires: Date.now() + 60_000,
+  authMethod: 'idc',
+  region: 'us-east-1'
+}
+
+function transform(messages: any[]) {
+  return transformToSdkRequest({ messages }, 'gpt-5.6-sol', auth).conversationState
+}
+
+describe('request history', () => {
+  test('uses invisible content when collapsing repeated tool-call preambles', () => {
+    const state = transform([
+      { role: 'user', content: 'Inspect the project.' },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'I will inspect it.' },
+          { type: 'tool_use', id: 'tool-1', name: 'read', input: { path: 'one' } }
+        ]
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tool-1',
+            content: [{ type: 'text', text: 'first result' }]
+          }
+        ]
+      },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'I will inspect another file.' },
+          { type: 'tool_use', id: 'tool-2', name: 'read', input: { path: 'two' } }
+        ]
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tool-2',
+            content: [{ type: 'text', text: 'second result' }]
+          }
+        ]
+      },
+      { role: 'assistant', content: 'Inspection complete.' },
+      { role: 'user', content: 'What did you find?' }
+    ])
+
+    expect(state.history?.[3]?.assistantResponseMessage?.content).toBe(SYNTHETIC_TURN_CONTENT)
+    expect(JSON.stringify(state)).not.toContain('[system:')
+  })
+
+  test('uses invisible content for missing and current synthetic turns', () => {
+    const state = transform([
+      { role: 'user', content: 'First question.' },
+      { role: 'assistant', content: '' },
+      { role: 'user', content: 'Second question.' },
+      { role: 'assistant', content: '' },
+      { role: 'user', content: 'Third question.' }
+    ])
+
+    expect(state.history).toEqual([
+      expect.objectContaining({ userInputMessage: expect.any(Object) }),
+      { assistantResponseMessage: { content: SYNTHETIC_TURN_CONTENT } },
+      expect.objectContaining({ userInputMessage: expect.any(Object) }),
+      { assistantResponseMessage: { content: SYNTHETIC_TURN_CONTENT } }
+    ])
+    expect(JSON.stringify(state)).not.toContain('[system:')
+
+    const assistantState = transform([
+      { role: 'user', content: 'Run a tool.' },
+      {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'tool-1', name: 'read', input: {} }]
+      }
+    ])
+    expect(assistantState.currentMessage.userInputMessage?.content).toBe(SYNTHETIC_TURN_CONTENT)
+
+    const emptyState = transform([{ role: 'user', content: '' }])
+    expect(emptyState.currentMessage.userInputMessage?.content).toBe(SYNTHETIC_TURN_CONTENT)
+  })
+})

--- a/src/__tests__/sdk-client.test.ts
+++ b/src/__tests__/sdk-client.test.ts
@@ -1,6 +1,11 @@
 import { GenerateAssistantResponseCommand } from '@aws/codewhisperer-streaming-client'
 import { describe, expect, test } from 'bun:test'
-import { clearSdkClientCache, createSdkClient, getSdkEndpoint } from '../plugin/sdk-client'
+import {
+  clearSdkClientCache,
+  createSdkClient,
+  getSdkEndpoint,
+  markRetryableKiroEventStreamError
+} from '../plugin/sdk-client'
 import type { KiroAuthDetails } from '../plugin/types'
 
 function auth(): KiroAuthDetails {
@@ -76,6 +81,105 @@ describe('SDK client', () => {
     expect(typeof retryMode === 'function' ? await retryMode() : retryMode).toBe('standard')
 
     clearSdkClientCache()
+  })
+
+  test('marks transient HTTP 200 event-stream startup failures as retryable', () => {
+    const error = {
+      message: 'Encountered an unexpected error when processing the request, please try again.',
+      $metadata: { httpStatusCode: 200 }
+    }
+
+    expect(markRetryableKiroEventStreamError(error)).toBe(true)
+    expect(error).toHaveProperty('$retryable', {})
+  })
+
+  test('classifies a hidden response without reading its body', () => {
+    const response = {
+      statusCode: 200,
+      get body(): never {
+        throw new Error('response body must not be read')
+      }
+    }
+    const error = Object.defineProperty(
+      { reason: 'MODEL_TEMPORARILY_UNAVAILABLE' } as Record<string, unknown>,
+      '$response',
+      { value: response, enumerable: false }
+    )
+
+    expect(markRetryableKiroEventStreamError(error)).toBe(true)
+    expect(error).toHaveProperty('$retryable', {})
+  })
+
+  test('retries a classified startup failure through the SDK middleware stack', async () => {
+    clearSdkClientCache()
+
+    const client = createSdkClient(auth(), 'us-east-1')
+    let attempts = 0
+    client.middlewareStack.addRelativeTo(
+      () => async () => {
+        attempts++
+        if (attempts === 1) {
+          throw Object.assign(
+            new Error(
+              'Encountered an unexpected error when processing the request, please try again.'
+            ),
+            { $metadata: { httpStatusCode: 200 } }
+          )
+        }
+        return {
+          response: { statusCode: 200, headers: {} },
+          output: { $metadata: {} }
+        }
+      },
+      {
+        relation: 'after',
+        toMiddleware: 'classifyKiroEventStreamError',
+        name: 'simulateKiroEventStreamStartup'
+      }
+    )
+
+    const command = new GenerateAssistantResponseCommand({
+      conversationState: {
+        chatTriggerType: 'MANUAL',
+        conversationId: 'test-conversation',
+        currentMessage: {
+          userInputMessage: {
+            content: 'hello',
+            modelId: 'gpt-5.6-sol',
+            origin: 'AI_EDITOR'
+          }
+        }
+      }
+    })
+
+    try {
+      const result = await client.send(command)
+      expect(attempts).toBe(2)
+      expect(result.$metadata.attempts).toBe(2)
+    } finally {
+      clearSdkClientCache()
+    }
+  })
+
+  test('does not retry unrelated stream or request errors', () => {
+    expect(
+      markRetryableKiroEventStreamError({
+        message: 'event stream ended unexpectedly',
+        $metadata: { httpStatusCode: 200 }
+      })
+    ).toBe(false)
+    expect(
+      markRetryableKiroEventStreamError({
+        message: 'Invalid request body',
+        $metadata: { httpStatusCode: 400 }
+      })
+    ).toBe(false)
+    expect(
+      markRetryableKiroEventStreamError({
+        name: 'InternalServerException',
+        $metadata: { httpStatusCode: 403 }
+      })
+    ).toBe(false)
   })
 
   test('injects output-config effort before content-length is computed', async () => {

--- a/src/__tests__/sdk-client.test.ts
+++ b/src/__tests__/sdk-client.test.ts
@@ -1,6 +1,6 @@
 import { GenerateAssistantResponseCommand } from '@aws/codewhisperer-streaming-client'
 import { describe, expect, test } from 'bun:test'
-import { clearSdkClientCache, createSdkClient } from '../plugin/sdk-client'
+import { clearSdkClientCache, createSdkClient, getSdkEndpoint } from '../plugin/sdk-client'
 import type { KiroAuthDetails } from '../plugin/types'
 
 function auth(): KiroAuthDetails {
@@ -15,22 +15,10 @@ function auth(): KiroAuthDetails {
 }
 
 describe('SDK client', () => {
-  test('uses Kiro CLI-style standard SDK retries for throttling', async () => {
+  async function captureEffortRequest(modelId: string, additionalModelRequestFields?: object) {
     clearSdkClientCache()
 
-    const client = createSdkClient(auth(), 'us-east-1')
-
-    expect(await client.config.maxAttempts()).toBe(3)
-    const retryMode = client.config.retryMode
-    expect(typeof retryMode === 'function' ? await retryMode() : retryMode).toBe('standard')
-
-    clearSdkClientCache()
-  })
-
-  test('injects effort before content-length is computed', async () => {
-    clearSdkClientCache()
-
-    const client = createSdkClient(auth(), 'us-east-1', 'max')
+    const client = createSdkClient(auth(), 'us-east-1', 'kiro-runtime', 'max')
     let capturedRequest: any
 
     client.middlewareStack.add(
@@ -48,11 +36,12 @@ describe('SDK client', () => {
         currentMessage: {
           userInputMessage: {
             content: 'hello',
-            modelId: 'claude-opus-4.7',
+            modelId,
             origin: 'AI_EDITOR'
           }
         }
-      }
+      },
+      additionalModelRequestFields: additionalModelRequestFields as any
     })
 
     await client.send(command).catch((error) => {
@@ -63,11 +52,56 @@ describe('SDK client', () => {
       typeof capturedRequest.body === 'string'
         ? capturedRequest.body
         : Buffer.from(capturedRequest.body).toString('utf8')
-    const body = JSON.parse(bodyText)
-
-    expect(body.additionalModelRequestFields.output_config.effort).toBe('max')
-    expect(Number(capturedRequest.headers['content-length'])).toBe(Buffer.byteLength(bodyText))
 
     clearSdkClientCache()
+    return { body: JSON.parse(bodyText), bodyText, capturedRequest }
+  }
+
+  test('uses documented FIPS endpoints for public GovCloud traffic', () => {
+    expect(getSdkEndpoint('us-gov-west-1', 'kiro-runtime')).toBe(
+      'https://q-fips.us-gov-west-1.amazonaws.com'
+    )
+    expect(getSdkEndpoint('us-gov-east-1', 'legacy-q')).toBe(
+      'https://q-fips.us-gov-east-1.amazonaws.com'
+    )
+  })
+
+  test('uses Kiro CLI-style standard SDK retries for throttling', async () => {
+    clearSdkClientCache()
+
+    const client = createSdkClient(auth(), 'us-east-1')
+
+    expect(await client.config.maxAttempts()).toBe(3)
+    const retryMode = client.config.retryMode
+    expect(typeof retryMode === 'function' ? await retryMode() : retryMode).toBe('standard')
+
+    clearSdkClientCache()
+  })
+
+  test('injects output-config effort before content-length is computed', async () => {
+    const { body, bodyText, capturedRequest } = await captureEffortRequest('claude-opus-4.7', {
+      existing: true,
+      output_config: { existingOutput: true }
+    })
+
+    expect(body.additionalModelRequestFields).toEqual({
+      existing: true,
+      thinking: { type: 'adaptive', display: 'summarized' },
+      output_config: { existingOutput: true, effort: 'max' }
+    })
+    expect(Number(capturedRequest.headers['content-length'])).toBe(Buffer.byteLength(bodyText))
+  })
+
+  test('injects reasoning effort for GPT-5.6 without Claude-only fields', async () => {
+    const { body, bodyText, capturedRequest } = await captureEffortRequest('gpt-5.6-sol', {
+      existing: true,
+      reasoning: { existingReasoning: true }
+    })
+
+    expect(body.additionalModelRequestFields).toEqual({
+      existing: true,
+      reasoning: { existingReasoning: true, effort: 'max' }
+    })
+    expect(Number(capturedRequest.headers['content-length'])).toBe(Buffer.byteLength(bodyText))
   })
 })

--- a/src/__tests__/sdk-endpoint-fallback.test.ts
+++ b/src/__tests__/sdk-endpoint-fallback.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  deduplicateSdkEndpointModes,
+  shouldFallbackSdkEndpointError
+} from '../core/request/sdk-endpoint-fallback.js'
+import { getUsageEndpointBases } from '../plugin/usage.js'
+
+describe('SDK endpoint fallback', () => {
+  test('falls back for Kiro runtime endpoint socket failures', () => {
+    expect(
+      shouldFallbackSdkEndpointError({
+        code: 'FailedToOpenSocket',
+        path: 'https://runtime.us-east-1.kiro.dev/generateAssistantResponse'
+      })
+    ).toBe(true)
+  })
+
+  test('does not fall back for quota throttling', () => {
+    expect(
+      shouldFallbackSdkEndpointError({
+        $metadata: { httpStatusCode: 429 },
+        message: 'Too Many Requests'
+      })
+    ).toBe(false)
+  })
+
+  test('does not fall back for generic authorization or request errors', () => {
+    expect(
+      shouldFallbackSdkEndpointError({
+        $metadata: { httpStatusCode: 400 },
+        message: 'Invalid request body'
+      })
+    ).toBe(false)
+    expect(
+      shouldFallbackSdkEndpointError({
+        $metadata: { httpStatusCode: 403 },
+        message: 'Access denied'
+      })
+    ).toBe(false)
+  })
+
+  test('falls back for a classified operation mismatch', () => {
+    expect(
+      shouldFallbackSdkEndpointError({
+        name: 'UnknownOperationException',
+        $metadata: { httpStatusCode: 400 }
+      })
+    ).toBe(true)
+  })
+
+  test('falls back when the endpoint or operation route is absent', () => {
+    expect(shouldFallbackSdkEndpointError({ $metadata: { httpStatusCode: 404 } })).toBe(true)
+    expect(shouldFallbackSdkEndpointError({ $metadata: { httpStatusCode: 405 } })).toBe(true)
+  })
+
+  test('does not synthesize unsupported Kiro management hosts in GovCloud', () => {
+    expect(getUsageEndpointBases('us-gov-west-1')).toEqual([
+      'https://q-fips.us-gov-west-1.amazonaws.com'
+    ])
+  })
+
+  test('deduplicates auto endpoints that resolve to the same GovCloud URL', () => {
+    expect(deduplicateSdkEndpointModes('us-gov-west-1', ['kiro-runtime', 'legacy-q'])).toEqual([
+      'kiro-runtime'
+    ])
+  })
+})

--- a/src/__tests__/storage-merge.test.ts
+++ b/src/__tests__/storage-merge.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, test } from 'bun:test'
+import Database from 'libsql'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { mergeAccounts } from '../plugin/storage/locked-operations.js'
+import { runMigrations } from '../plugin/storage/migrations.js'
+import type { ManagedAccount } from '../plugin/types.js'
+
+function account(overrides: Partial<ManagedAccount> = {}): ManagedAccount {
+  return {
+    id: 'account-1',
+    email: 'user@example.com',
+    authMethod: 'idc',
+    region: 'us-east-1',
+    refreshToken: 'refresh',
+    accessToken: 'access',
+    expiresAt: Date.now() + 3600000,
+    rateLimitResetTime: 0,
+    isHealthy: true,
+    failCount: 0,
+    usedCount: 210.05,
+    limitCount: 2000,
+    subscriptionPlan: 'KIRO PRO+',
+    lastSync: 1000,
+    ...overrides
+  }
+}
+
+describe('mergeAccounts', () => {
+  test('keeps existing quota when incoming snapshot is not newer', () => {
+    const [merged] = mergeAccounts(
+      [account()],
+      [
+        account({
+          usedCount: 211,
+          limitCount: 2000,
+          lastSync: 1000,
+          lastUsed: 2000
+        })
+      ]
+    )
+
+    expect(merged?.usedCount).toBe(210.05)
+    expect(merged?.limitCount).toBe(2000)
+    expect(merged?.lastUsed).toBe(2000)
+  })
+
+  test('accepts newer remote quota snapshots even when usage decreases', () => {
+    const [merged] = mergeAccounts(
+      [account({ usedCount: 211, lastSync: 1000 })],
+      [account({ usedCount: 210.05, lastSync: 2000 })]
+    )
+
+    expect(merged?.usedCount).toBe(210.05)
+    expect(merged?.lastSync).toBe(2000)
+  })
+
+  test('merges access freshness and refresh-token authority independently', () => {
+    const now = Date.now()
+    const [merged] = mergeAccounts(
+      [
+        account({
+          refreshToken: 'fresh-refresh',
+          refreshTokenUpdatedAt: 1000,
+          accessToken: 'fresh-access',
+          expiresAt: now + 7200000,
+          usedCount: 100,
+          limitCount: 2000,
+          subscriptionPlan: 'KIRO PRO',
+          lastSync: 1000,
+          isHealthy: true
+        })
+      ],
+      [
+        account({
+          refreshToken: 'rotated-refresh',
+          refreshTokenUpdatedAt: 2000,
+          accessToken: 'stale-access',
+          expiresAt: now + 3600000,
+          usedCount: 120,
+          limitCount: 2500,
+          subscriptionPlan: 'KIRO PRO+',
+          lastSync: 2000
+        })
+      ]
+    )
+
+    expect(merged?.refreshToken).toBe('rotated-refresh')
+    expect(merged?.accessToken).toBe('fresh-access')
+    expect(merged?.expiresAt).toBe(now + 7200000)
+    expect(merged?.usedCount).toBe(120)
+    expect(merged?.limitCount).toBe(2500)
+    expect(merged?.subscriptionPlan).toBe('KIRO PRO+')
+    expect(merged?.lastSync).toBe(2000)
+  })
+
+  test('keeps a refresh token from a newer local refresh despite earlier access expiry', () => {
+    const now = Date.now()
+    const [merged] = mergeAccounts(
+      [
+        account({
+          refreshToken: 'old-refresh',
+          refreshTokenUpdatedAt: 3000,
+          accessToken: 'longer-access',
+          expiresAt: now + 7200000,
+          lastUsed: 1000,
+          lastSync: 3000
+        })
+      ],
+      [
+        account({
+          refreshToken: 'rotated-refresh',
+          refreshTokenUpdatedAt: 4000,
+          accessToken: 'shorter-access',
+          expiresAt: now + 3600000,
+          lastUsed: 4000,
+          lastSync: 2000
+        })
+      ]
+    )
+
+    expect(merged?.refreshToken).toBe('rotated-refresh')
+    expect(merged?.accessToken).toBe('longer-access')
+    expect(merged?.expiresAt).toBe(now + 7200000)
+  })
+
+  test('keeps a locally rotated refresh token when stale CLI credentials are observed later', () => {
+    const now = Date.now()
+    const [merged] = mergeAccounts(
+      [
+        account({
+          refreshToken: 'local-refresh',
+          refreshTokenUpdatedAt: now,
+          accessToken: 'local-access',
+          expiresAt: now + 7200000
+        })
+      ],
+      [
+        account({
+          refreshToken: 'stale-cli-refresh',
+          refreshTokenUpdatedAt: now,
+          accessToken: 'stale-cli-access',
+          expiresAt: now + 3600000
+        })
+      ]
+    )
+
+    expect(merged?.refreshToken).toBe('local-refresh')
+    expect(merged?.accessToken).toBe('local-access')
+  })
+
+  test('does not let a failed usage fetch (newer 0/0 snapshot) clobber real quota', () => {
+    const [merged] = mergeAccounts(
+      [account({ usedCount: 120.5, limitCount: 2000, lastSync: 1000 })],
+      [account({ usedCount: 0, limitCount: 0, lastSync: 2000 })]
+    )
+
+    expect(merged?.usedCount).toBe(120.5)
+    expect(merged?.limitCount).toBe(2000)
+  })
+
+  test('fills empty existing quota from a newer real snapshot', () => {
+    const [merged] = mergeAccounts(
+      [account({ usedCount: 0, limitCount: 0, lastSync: 1000 })],
+      [account({ usedCount: 5, limitCount: 2000, lastSync: 2000 })]
+    )
+
+    expect(merged?.usedCount).toBe(5)
+    expect(merged?.limitCount).toBe(2000)
+  })
+})
+
+describe('account storage migrations', () => {
+  test('adds the refresh-token authority timestamp idempotently', () => {
+    const db = new Database(':memory:')
+    db.exec(`
+      CREATE TABLE accounts (
+        id TEXT PRIMARY KEY, email TEXT NOT NULL, auth_method TEXT NOT NULL,
+        region TEXT NOT NULL, oidc_region TEXT, client_id TEXT, client_secret TEXT,
+        profile_arn TEXT, start_url TEXT, refresh_token TEXT NOT NULL,
+        access_token TEXT NOT NULL, expires_at INTEGER NOT NULL,
+        rate_limit_reset INTEGER DEFAULT 0, is_healthy INTEGER DEFAULT 1,
+        unhealthy_reason TEXT, recovery_time INTEGER, fail_count INTEGER DEFAULT 0,
+        last_used INTEGER DEFAULT 0, used_count REAL DEFAULT 0,
+        limit_count REAL DEFAULT 0, subscription_plan TEXT, last_sync INTEGER DEFAULT 0
+      )
+    `)
+
+    runMigrations(db)
+    runMigrations(db)
+
+    const columns = db.prepare('PRAGMA table_info(accounts)').all() as Array<{ name: string }>
+    expect(columns.filter((column) => column.name === 'refresh_token_updated_at')).toHaveLength(1)
+    db.close()
+  })
+
+  test('serializes concurrent database initialization across processes', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'kiro-db-init-'))
+    const path = join(dir, 'kiro.db')
+    const worker = new URL('./database-init-worker.ts', import.meta.url).pathname
+
+    try {
+      const processes = Array.from({ length: 8 }, () =>
+        Bun.spawn([process.execPath, worker, path], { stdout: 'pipe', stderr: 'pipe' })
+      )
+      const exitCodes = await Promise.all(processes.map((process) => process.exited))
+
+      expect(exitCodes).toEqual(Array(8).fill(0))
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/__tests__/streaming-thinking.test.ts
+++ b/src/__tests__/streaming-thinking.test.ts
@@ -110,6 +110,47 @@ describe('thinking stream transform', () => {
     expect(textFrom(deltas)).toBe('pre <thinking>not reasoning</thinking> answer')
   })
 
+  test('removes orphan system-reminder closing tags split across SDK chunks', async () => {
+    const deltas = await collectDeltas(
+      ['Visible answer.\nPending internal work\n</system-rem', 'inder>\nContinue here.'],
+      false
+    )
+
+    expect(textFrom(deltas)).toBe('Visible answer.\nPending internal work\nContinue here.')
+  })
+
+  test('removes balanced standalone system-reminder delimiters but keeps their content', async () => {
+    const deltas = await collectDeltas(
+      ['Visible answer.\n<system-rem', 'inder>\nPrivate instruction\n</system-reminder>\nDone.'],
+      false
+    )
+
+    expect(textFrom(deltas)).toBe('Visible answer.\nPrivate instruction\nDone.')
+  })
+
+  test('removes an orphan system-reminder closing tag after a thinking block', async () => {
+    const deltas = await collectDeltas(
+      ['<thinking>Plan</thinking>Answer\nPrivate todo\n</system-reminder>'],
+      true
+    )
+
+    expect(reasoningFrom(deltas)).toBe('Plan')
+    expect(textFrom(deltas)).toBe('Answer\nPrivate todo\n')
+  })
+
+  test('preserves system-reminder tags in normal prose and fenced code', async () => {
+    const deltas = await collectDeltas(
+      [
+        'Use `<system-reminder>` inline.\n```text\n<system-reminder>\nliteral\n</system-reminder>\n```'
+      ],
+      false
+    )
+
+    expect(textFrom(deltas)).toBe(
+      'Use `<system-reminder>` inline.\n```text\n<system-reminder>\nliteral\n</system-reminder>\n```'
+    )
+  })
+
   test('does not close thinking on quoted or backticked literal end tags', async () => {
     const deltas = await collectDeltas(
       ['<thinking>quoted `</thinking>` still thinking</thinking>\n\nDone'],

--- a/src/__tests__/streaming-thinking.test.ts
+++ b/src/__tests__/streaming-thinking.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, test } from 'bun:test'
+import { transformSdkStream } from '../plugin/streaming/sdk-stream-transformer.js'
+import { createStreamState } from '../plugin/streaming/stream-state.js'
+import {
+  createContentDeltaEvents,
+  flushContentDeltaEvents
+} from '../plugin/streaming/thinking-parser.js'
+
+async function* sdkContentStream(chunks: string[]) {
+  for (const content of chunks) {
+    yield { assistantResponseEvent: { content } }
+  }
+}
+
+async function collectDeltas(chunks: string[], thinkingRequested: boolean) {
+  const response = {
+    generateAssistantResponseResponse: sdkContentStream(chunks)
+  }
+  const events: any[] = []
+
+  for await (const event of transformSdkStream(
+    response,
+    thinkingRequested ? 'claude-sonnet-4-5-thinking' : 'claude-sonnet-4-5',
+    'chatcmpl-test',
+    thinkingRequested
+  )) {
+    events.push(event)
+  }
+
+  return events
+    .flatMap((event) => event.choices ?? [])
+    .map((choice) => choice.delta)
+    .filter((delta) => delta?.content !== undefined || delta?.reasoning_content !== undefined)
+}
+
+function textFrom(deltas: any[]): string {
+  return deltas.map((delta) => delta.content ?? '').join('')
+}
+
+function reasoningFrom(deltas: any[]): string {
+  return deltas.map((delta) => delta.reasoning_content ?? '').join('')
+}
+
+function textFromStreamEvents(events: any[]): string {
+  return events.map((event) => event.delta?.text ?? '').join('')
+}
+
+describe('thinking stream transform', () => {
+  test('emits reasoning before answer text and drops pre-thinking fragments', async () => {
+    const deltas = await collectDeltas(
+      ['Sure, ', '<think', 'ing>\nI should reason', '</thinking>\n\nFinal answer'],
+      true
+    )
+
+    const firstContentIndex = deltas.findIndex((delta) => delta.content)
+    const firstReasoningIndex = deltas.findIndex((delta) => delta.reasoning_content)
+
+    expect(firstReasoningIndex).toBeGreaterThanOrEqual(0)
+    expect(firstContentIndex).toBeGreaterThan(firstReasoningIndex)
+    expect(reasoningFrom(deltas)).toBe('I should reason')
+    expect(textFrom(deltas)).toBe('Final answer')
+  })
+
+  test('handles thinking tags split across SDK chunks', async () => {
+    const deltas = await collectDeltas(['<thinking>\nPlan', '</think', 'ing>\n\nAnswer'], true)
+
+    expect(reasoningFrom(deltas)).toBe('Plan')
+    expect(textFrom(deltas)).toBe('Answer')
+  })
+
+  test('handles an opening thinking tag split at every boundary', async () => {
+    const tag = '<thinking>'
+
+    for (let split = 1; split < tag.length; split++) {
+      const deltas = await collectDeltas(
+        [tag.slice(0, split), `${tag.slice(split)}Plan</thinking>Answer`],
+        true
+      )
+
+      expect(reasoningFrom(deltas)).toBe('Plan')
+      expect(textFrom(deltas)).toBe('Answer')
+    }
+  })
+
+  test('closes thinking before immediate answer text', async () => {
+    const deltas = await collectDeltas(['<thinking>reason</thinking>Answer'], true)
+
+    expect(reasoningFrom(deltas)).toBe('reason')
+    expect(textFrom(deltas)).toBe('Answer')
+  })
+
+  test('handles split thinking end tag before immediate answer text', async () => {
+    const deltas = await collectDeltas(['<thinking>Plan', '</think', 'ing>Answer'], true)
+
+    expect(reasoningFrom(deltas)).toBe('Plan')
+    expect(textFrom(deltas)).toBe('Answer')
+  })
+
+  test('strips leading CRLF after a thinking block', async () => {
+    const deltas = await collectDeltas(['<thinking>Plan</thinking>\r\n\r\nAnswer'], true)
+
+    expect(reasoningFrom(deltas)).toBe('Plan')
+    expect(textFrom(deltas)).toBe('Answer')
+  })
+
+  test('keeps normal model text streaming without parsing thinking tags', async () => {
+    const deltas = await collectDeltas(['pre <thinking>not reasoning</thinking> answer'], false)
+
+    expect(reasoningFrom(deltas)).toBe('')
+    expect(textFrom(deltas)).toBe('pre <thinking>not reasoning</thinking> answer')
+  })
+
+  test('does not close thinking on quoted or backticked literal end tags', async () => {
+    const deltas = await collectDeltas(
+      ['<thinking>quoted `</thinking>` still thinking</thinking>\n\nDone'],
+      true
+    )
+
+    expect(reasoningFrom(deltas)).toBe('quoted `</thinking>` still thinking')
+    expect(textFrom(deltas)).toBe('Done')
+  })
+
+  test('keeps quoted literal end tag with surrounding spaces inside reasoning', async () => {
+    const deltas = await collectDeltas(
+      ['<thinking>quote "keep </thinking> inside" still thinking</thinking>Done'],
+      true
+    )
+
+    expect(reasoningFrom(deltas)).toBe('quote "keep </thinking> inside" still thinking')
+    expect(textFrom(deltas)).toBe('Done')
+  })
+
+  test('does not close thinking on code-fenced literal end tags', async () => {
+    const deltas = await collectDeltas(
+      ['<thinking>\n```text\n</thinking>\n```\nstill thinking</thinking>Done'],
+      true
+    )
+
+    expect(reasoningFrom(deltas)).toBe('```text\n</thinking>\n```\nstill thinking')
+    expect(textFrom(deltas)).toBe('Done')
+  })
+
+  test('keeps fenced literal end tag intact when the fence is split across chunks', async () => {
+    const deltas = await collectDeltas(
+      ['<thinking>```text\ninside code ', '</thinking>\n```\nstill thinking</thinking>Done'],
+      true
+    )
+
+    expect(reasoningFrom(deltas)).toBe('```text\ninside code </thinking>\n```\nstill thinking')
+    expect(textFrom(deltas)).toBe('Done')
+  })
+
+  test('keeps quoted literal end tag intact when the quote is split across chunks', async () => {
+    const deltas = await collectDeltas(
+      ['<thinking>quote "keep ', '</thinking> inside" still thinking</thinking>Done'],
+      true
+    )
+
+    expect(reasoningFrom(deltas)).toBe('quote "keep </thinking> inside" still thinking')
+    expect(textFrom(deltas)).toBe('Done')
+  })
+
+  test('does not treat apostrophes in normal reasoning text as quote delimiters', async () => {
+    const deltas = await collectDeltas(["<thinking>I don't need more</thinking>Done"], true)
+
+    expect(reasoningFrom(deltas)).toBe("I don't need more")
+    expect(textFrom(deltas)).toBe('Done')
+  })
+
+  test('does not close thinking on an escaped quote inside a quoted literal tag', async () => {
+    const deltas = await collectDeltas(
+      ['<thinking>quote "keep \\" </thinking> \\" inside" still thinking</thinking>Done'],
+      true
+    )
+
+    expect(reasoningFrom(deltas)).toBe('quote "keep \\" </thinking> \\" inside" still thinking')
+    expect(textFrom(deltas)).toBe('Done')
+  })
+
+  test('keeps single-quoted literal end tags inside reasoning', async () => {
+    const deltas = await collectDeltas(
+      ["<thinking>quote 'keep </thinking> inside' still thinking</thinking>Done"],
+      true
+    )
+
+    expect(reasoningFrom(deltas)).toBe("quote 'keep </thinking> inside' still thinking")
+    expect(textFrom(deltas)).toBe('Done')
+  })
+
+  test('treats an unterminated quote at stream end as literal reasoning', async () => {
+    const deltas = await collectDeltas(['<thinking>partial "unterminated quote at end'], true)
+
+    expect(reasoningFrom(deltas)).toBe('partial "unterminated quote at end')
+    expect(textFrom(deltas)).toBe('')
+  })
+
+  test('buffers plain text until flush if a thinking model never emits a thinking block', () => {
+    const state = createStreamState(true)
+    const answer = 'plain answer in thinking model '.repeat(20)
+    const earlyEvents = createContentDeltaEvents(answer, state)
+
+    expect(earlyEvents).toEqual([])
+    expect(textFromStreamEvents(flushContentDeltaEvents(state))).toBe(answer)
+  })
+
+  test('drops a long preamble before a later thinking block', async () => {
+    const deltas = await collectDeltas(
+      ['This is a long preamble before reasoning. ', '<thinking>private plan</thinking>Answer'],
+      true
+    )
+
+    expect(reasoningFrom(deltas)).toBe('private plan')
+    expect(textFrom(deltas)).toBe('Answer')
+  })
+
+  test('keeps a quoted opening tag literal across plain-text chunks', () => {
+    const state = createStreamState(true)
+    const events = [
+      ...createContentDeltaEvents('plain answer with "literal ', state),
+      ...createContentDeltaEvents('<thinking>" text', state),
+      ...flushContentDeltaEvents(state)
+    ]
+
+    expect(textFromStreamEvents(events)).toBe('plain answer with "literal <thinking>" text')
+    expect(events.some((event) => event.delta?.thinking !== undefined)).toBe(false)
+  })
+
+  test('keeps a fenced opening tag literal across plain-text chunks', () => {
+    const state = createStreamState(true)
+    const events = [
+      ...createContentDeltaEvents('plain answer\n```text\n', state),
+      ...createContentDeltaEvents('<thinking>\n```\ntext', state),
+      ...flushContentDeltaEvents(state)
+    ]
+
+    expect(textFromStreamEvents(events)).toBe('plain answer\n```text\n<thinking>\n```\ntext')
+    expect(events.some((event) => event.delta?.thinking !== undefined)).toBe(false)
+  })
+
+  test('closes a thinking block whose end tag lands at stream end', async () => {
+    const deltas = await collectDeltas(['<thinking>only thought</thinking>'], true)
+
+    expect(reasoningFrom(deltas)).toBe('only thought')
+    expect(textFrom(deltas)).toBe('')
+  })
+})

--- a/src/__tests__/token-refresher.test.ts
+++ b/src/__tests__/token-refresher.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from 'bun:test'
+import { TokenRefresher } from '../core/auth/token-refresher.js'
+import { KiroTokenRefreshError } from '../plugin/errors.js'
+import type { KiroAuthDetails, ManagedAccount } from '../plugin/types.js'
+
+function account(): ManagedAccount {
+  return {
+    id: 'account-1',
+    email: 'user@example.com',
+    authMethod: 'idc',
+    region: 'us-east-1',
+    refreshToken: 'old-refresh',
+    accessToken: 'old-access',
+    expiresAt: 0,
+    rateLimitResetTime: 0,
+    isHealthy: true,
+    failCount: 0
+  }
+}
+
+function auth(acc: ManagedAccount): KiroAuthDetails {
+  return {
+    refresh: acc.refreshToken,
+    access: acc.accessToken,
+    expires: acc.expiresAt,
+    authMethod: acc.authMethod,
+    region: acc.region,
+    email: acc.email
+  }
+}
+
+describe('TokenRefresher', () => {
+  test('returns refreshed auth and shares one refresh across concurrent requests', async () => {
+    const acc = account()
+    const accounts = [acc]
+    let refreshCalls = 0
+    let releaseRefresh!: () => void
+    const refreshGate = new Promise<void>((resolve) => {
+      releaseRefresh = resolve
+    })
+    const refreshed: KiroAuthDetails = {
+      ...auth(acc),
+      refresh: 'new-refresh',
+      access: 'new-access',
+      expires: Date.now() + 3600000
+    }
+    const manager = {
+      getAccounts: () => accounts,
+      updateFromAuth: (target: ManagedAccount, next: KiroAuthDetails) => {
+        target.refreshToken = next.refresh
+        target.accessToken = next.access
+        target.expiresAt = next.expires
+      },
+      toAuthDetails: auth,
+      markUnhealthy: () => {},
+      addAccount: () => {},
+      removeAccount: () => {}
+    }
+    const repository = {
+      batchSave: async () => {},
+      invalidateCache: () => {},
+      findAll: async () => accounts
+    }
+    const refresher = new TokenRefresher(
+      {
+        token_expiry_buffer_ms: 300000,
+        auto_sync_kiro_cli: false,
+        account_selection_strategy: 'sticky'
+      },
+      manager as any,
+      async () => {},
+      repository as any,
+      async () => {
+        refreshCalls++
+        await refreshGate
+        return refreshed
+      }
+    )
+
+    const first = refresher.refreshIfNeeded(acc, auth(acc), () => {})
+    const second = refresher.refreshIfNeeded(acc, auth(acc), () => {})
+    releaseRefresh()
+    const results = await Promise.all([first, second])
+
+    expect(refreshCalls).toBe(1)
+    expect(results.map((result) => result.auth.access)).toEqual(['new-access', 'new-access'])
+    expect(acc.accessToken).toBe('new-access')
+  })
+
+  test('installs and immediately uses synced credentials when the account ID changed', async () => {
+    const acc: ManagedAccount = {
+      ...account(),
+      profileArn: 'arn:aws:codewhisperer:us-east-1:123456789012:profile/ABC'
+    }
+    const replacement: ManagedAccount = {
+      ...acc,
+      id: 'replacement-id',
+      accessToken: 'recovered-access',
+      expiresAt: Date.now() + 3600000
+    }
+    const managed: ManagedAccount[] = [acc]
+    const manager = {
+      getAccounts: () => managed,
+      updateFromAuth: () => {},
+      toAuthDetails: auth,
+      markUnhealthy: () => {},
+      removeAccount: (target: ManagedAccount) => {
+        const index = managed.indexOf(target)
+        if (index >= 0) managed.splice(index, 1)
+      },
+      addAccount: (target: ManagedAccount) => managed.push(target)
+    }
+    const repository = {
+      batchSave: async () => {},
+      invalidateCache: () => {},
+      findAll: async () => [acc, replacement]
+    }
+    const refresher = new TokenRefresher(
+      {
+        token_expiry_buffer_ms: 300000,
+        auto_sync_kiro_cli: true,
+        account_selection_strategy: 'sticky'
+      },
+      manager as any,
+      async () => {},
+      repository as any,
+      async () => {
+        throw new Error('refresh failed')
+      }
+    )
+
+    const result = await refresher.refreshIfNeeded(acc, auth(acc), () => {})
+
+    expect(result.account).toBe(replacement)
+    expect(result.auth.access).toBe('recovered-access')
+    expect(result.shouldContinue).toBe(false)
+    expect(managed).toEqual([replacement])
+  })
+
+  test('does not recover a different profile that only shares the OIDC client', async () => {
+    const acc: ManagedAccount = {
+      ...account(),
+      clientId: 'shared-client',
+      profileArn: 'arn:aws:codewhisperer:us-east-1:123456789012:profile/ONE'
+    }
+    const otherProfile: ManagedAccount = {
+      ...acc,
+      id: 'other-profile',
+      profileArn: 'arn:aws:codewhisperer:us-east-1:123456789012:profile/TWO',
+      accessToken: 'other-access',
+      expiresAt: Date.now() + 3600000
+    }
+    let markedUnhealthy = false
+    const manager = {
+      getAccounts: () => [acc],
+      updateFromAuth: () => {},
+      toAuthDetails: auth,
+      markUnhealthy: () => {
+        markedUnhealthy = true
+      },
+      removeAccount: () => {},
+      addAccount: () => {}
+    }
+    const repository = {
+      batchSave: async () => {},
+      invalidateCache: () => {},
+      findAll: async () => [acc, otherProfile]
+    }
+    const refresher = new TokenRefresher(
+      {
+        token_expiry_buffer_ms: 300000,
+        auto_sync_kiro_cli: true,
+        account_selection_strategy: 'sticky'
+      },
+      manager as any,
+      async () => {},
+      repository as any,
+      async () => {
+        throw new KiroTokenRefreshError('Invalid refresh token provided', 'InvalidTokenException')
+      }
+    )
+
+    const result = await refresher.refreshIfNeeded(acc, auth(acc), () => {})
+
+    expect(result.account).toBe(acc)
+    expect(result.shouldContinue).toBe(true)
+    expect(markedUnhealthy).toBe(true)
+  })
+})

--- a/src/__tests__/tui-usage.test.ts
+++ b/src/__tests__/tui-usage.test.ts
@@ -1,0 +1,186 @@
+import { Database } from 'bun:sqlite'
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  formatRequestQuota,
+  getSessionProviderID,
+  readUsageSnapshot,
+  resolveTuiDisplayOptions,
+  shouldShowKiroUsage,
+  summarizeUsage
+} from '../tui-usage.js'
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function tempDbPath(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'kiro-usage-test-'))
+  tempDirs.push(dir)
+  return join(dir, 'kiro.db')
+}
+
+function createAccountsTable(db: Database, withSubscriptionPlan = true): void {
+  db.run(`
+    CREATE TABLE accounts (
+      id TEXT PRIMARY KEY,
+      email TEXT NOT NULL,
+      auth_method TEXT NOT NULL,
+      region TEXT NOT NULL,
+      used_count REAL,
+      limit_count REAL,
+      ${withSubscriptionPlan ? 'subscription_plan TEXT,' : ''}
+      is_healthy INTEGER,
+      last_sync INTEGER,
+      last_used INTEGER
+    )
+  `)
+}
+
+describe('TUI usage data', () => {
+  test('reads current quota and subscription plan from the Kiro database', () => {
+    const dbPath = tempDbPath()
+    const db = new Database(dbPath)
+    createAccountsTable(db)
+    db.run(
+      `INSERT INTO accounts
+       (id, email, auth_method, region, used_count, limit_count, subscription_plan, is_healthy, last_sync, last_used)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ['a', 'user@example.com', 'idc', 'us-east-1', 164.127, 2000, 'KIRO PRO+', 1, 1000, 2000]
+    )
+    db.close()
+
+    const snapshot = readUsageSnapshot(dbPath)
+    const summary = summarizeUsage(snapshot)
+
+    expect(snapshot.error).toBeUndefined()
+    expect(summary.account?.email).toBe('user@example.com')
+    expect(summary.plan).toBe('KIRO PRO+')
+    expect(summary.used).toBe(164.127)
+    expect(summary.limit).toBe(2000)
+    expect(formatRequestQuota(summary)).toBe('Credits: 164.13 / 2000')
+  })
+
+  test('keeps legacy databases without subscription_plan readable', () => {
+    const dbPath = tempDbPath()
+    const db = new Database(dbPath)
+    createAccountsTable(db, false)
+    db.run(
+      `INSERT INTO accounts
+       (id, email, auth_method, region, used_count, limit_count, is_healthy, last_sync, last_used)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ['a', 'legacy@example.com', 'idc', 'us-east-1', 10, 100, 1, 1000, 2000]
+    )
+    db.close()
+
+    const summary = summarizeUsage(readUsageSnapshot(dbPath))
+
+    expect(summary.account?.email).toBe('legacy@example.com')
+    expect(summary.plan).toBe('Q Developer')
+    expect(formatRequestQuota(summary)).toBe('Credits: 10.00 / 100')
+  })
+
+  test('uses the first healthy account for sidebar usage', () => {
+    const dbPath = tempDbPath()
+    const db = new Database(dbPath)
+    createAccountsTable(db)
+    const insert = db.prepare(
+      `INSERT INTO accounts
+       (id, email, auth_method, region, used_count, limit_count, subscription_plan, is_healthy, last_sync, last_used)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    insert.run(
+      'newer-unhealthy',
+      'bad@example.com',
+      'idc',
+      'us-east-1',
+      90,
+      100,
+      'PRO',
+      0,
+      1000,
+      3000
+    )
+    insert.run(
+      'older-healthy',
+      'good@example.com',
+      'idc',
+      'us-east-1',
+      20,
+      100,
+      'KIRO PRO+',
+      1,
+      1000,
+      2000
+    )
+    db.close()
+
+    const summary = summarizeUsage(readUsageSnapshot(dbPath))
+
+    expect(summary.account?.email).toBe('good@example.com')
+    expect(summary.plan).toBe('KIRO PRO+')
+    expect(formatRequestQuota(summary)).toBe('Credits: 20.00 / 100')
+  })
+
+  test('formats request quota without a limit', () => {
+    const summary = summarizeUsage({
+      accounts: [
+        {
+          email: 'usage@example.com',
+          authMethod: 'builder',
+          region: 'us-east-1',
+          usedCount: 42,
+          limitCount: 0,
+          subscriptionPlan: 'FREE',
+          isHealthy: true,
+          lastSync: 0,
+          lastUsed: 0
+        }
+      ]
+    })
+
+    expect(formatRequestQuota(summary)).toBe('Credits: 42.00')
+  })
+
+  test('detects whether the sidebar belongs to a Kiro session', () => {
+    expect(
+      shouldShowKiroUsage([{ providerID: 'anthropic' }, { providerID: 'kiro' }], 'anthropic/claude')
+    ).toBe(true)
+    expect(shouldShowKiroUsage([{ model: { providerID: 'anthropic' } }], 'kiro/claude')).toBe(false)
+    expect(shouldShowKiroUsage([], 'kiro/claude-sonnet-4-6')).toBe(true)
+    expect(shouldShowKiroUsage([], 'anthropic/claude-sonnet-4-6')).toBe(false)
+    expect(getSessionProviderID([{ info: { providerID: 'kiro' } }])).toBe('kiro')
+  })
+
+  test('returns an empty snapshot for missing databases', () => {
+    const snapshot = readUsageSnapshot(join(tempDbPath(), 'missing.db'))
+
+    expect(snapshot).toEqual({ accounts: [] })
+  })
+
+  test('resolves TUI display options with compact defaults', () => {
+    expect(resolveTuiDisplayOptions()).toEqual({
+      showAccountEmail: false,
+      showPlan: true,
+      showCredits: true
+    })
+
+    expect(
+      resolveTuiDisplayOptions({
+        show_account_email: true,
+        show_plan: false,
+        show_credits: false
+      })
+    ).toEqual({
+      showAccountEmail: true,
+      showPlan: false,
+      showCredits: false
+    })
+  })
+})

--- a/src/__tests__/usage-format.test.ts
+++ b/src/__tests__/usage-format.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test'
+import { formatUsageLimit, formatUsageRatio, formatUsageValue } from '../plugin/usage-format.js'
+import {
+  extractUsageTotals,
+  getUsageEndpointBases,
+  normalizeSubscriptionPlan
+} from '../plugin/usage.js'
+
+describe('usage formatting', () => {
+  test('formats used requests with two decimals and whole plan limits without grouping', () => {
+    expect(formatUsageValue(208.823)).toBe('208.82')
+    expect(formatUsageLimit(2000)).toBe('2000')
+    expect(formatUsageRatio(208.96, 2000)).toBe('208.96 / 2000')
+  })
+
+  test('preserves subscription titles returned by getUsageLimits', () => {
+    expect(
+      normalizeSubscriptionPlan({ subscriptionInfo: { subscriptionTitle: 'KIRO PRO+' } })
+    ).toBe('KIRO PRO+')
+    expect(normalizeSubscriptionPlan({ subscription: { title: 'PRO' } })).toBe('PRO')
+    expect(normalizeSubscriptionPlan({ tierId: 'FREE' })).toBe('FREE')
+  })
+
+  test('prefers backend precision fields for usage totals', () => {
+    expect(
+      extractUsageTotals({
+        usageBreakdownList: [
+          {
+            currentUsage: 209,
+            currentUsageWithPrecision: 209.64,
+            usageLimit: 2000,
+            usageLimitWithPrecision: 2000
+          }
+        ]
+      })
+    ).toEqual({ usedCount: 209.64, limitCount: 2000 })
+  })
+
+  test('tries Kiro management usage endpoint before legacy q endpoint', () => {
+    expect(getUsageEndpointBases('us-east-1')).toEqual([
+      'https://management.us-east-1.kiro.dev',
+      'https://q.us-east-1.amazonaws.com'
+    ])
+  })
+})

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,10 +1,11 @@
-import { RegionSchema } from './plugin/config/schema'
+import { RegionSchema, type Effort } from './plugin/config/schema'
 import type { KiroRegion } from './plugin/types'
 
-const VALID_REGIONS: readonly KiroRegion[] = RegionSchema.options
+export const KIRO_PROVIDER_ID = 'kiro'
+export const KIRO_LEGACY_PROVIDER_ID = 'kiro-auth'
 
 export function isValidRegion(region: string): region is KiroRegion {
-  return VALID_REGIONS.includes(region as KiroRegion)
+  return RegionSchema.safeParse(region).success
 }
 
 export function normalizeRegion(region: string | undefined): KiroRegion {
@@ -12,6 +13,65 @@ export function normalizeRegion(region: string | undefined): KiroRegion {
     return 'us-east-1'
   }
   return region
+}
+
+export type SupportedAwsPartition = 'aws' | 'aws-us-gov'
+
+export interface CodeWhispererProfileArn {
+  arn: string
+  partition: SupportedAwsPartition
+  service: 'codewhisperer' | 'qdeveloper'
+  region: KiroRegion
+  accountId: string
+  profileId: string
+}
+
+export function getAwsPartition(region: string): SupportedAwsPartition {
+  if (!isValidRegion(region)) throw new Error(`Invalid AWS region: ${region}`)
+  if (region.startsWith('us-gov-')) return 'aws-us-gov'
+  if (region.startsWith('cn-')) {
+    throw new Error('AWS China regions are not supported by the configured Kiro endpoints')
+  }
+  return 'aws'
+}
+
+export function getOidcEndpoint(region: string): string {
+  const partition = getAwsPartition(region)
+  const host = partition === 'aws-us-gov' ? 'oidc-fips' : 'oidc'
+  return `https://${host}.${region}.amazonaws.com`
+}
+
+export function parseCodeWhispererProfileArn(
+  arn: string | undefined
+): CodeWhispererProfileArn | undefined {
+  if (!arn) return undefined
+  const match =
+    /^arn:(aws|aws-us-gov|aws-cn):(codewhisperer|qdeveloper):([^:]+):(\d{12}):profile\/([^/:\s]+)$/.exec(
+      arn
+    )
+  if (!match) return undefined
+
+  const [, partition, service, region, accountId, profileId] = match
+  if (!partition || !service || !region || !accountId || !profileId || !isValidRegion(region)) {
+    return undefined
+  }
+
+  let expectedPartition: SupportedAwsPartition
+  try {
+    expectedPartition = getAwsPartition(region)
+  } catch {
+    return undefined
+  }
+  if (partition !== expectedPartition) return undefined
+
+  return {
+    arn,
+    partition: partition as SupportedAwsPartition,
+    service: service as CodeWhispererProfileArn['service'],
+    region,
+    accountId,
+    profileId
+  }
 }
 
 export function buildUrl(template: string, region: KiroRegion): string {
@@ -26,13 +86,7 @@ export function buildUrl(template: string, region: KiroRegion): string {
 }
 
 export function extractRegionFromArn(arn: string | undefined): KiroRegion | undefined {
-  if (!arn) return undefined
-  const parts = arn.split(':')
-  if (parts.length < 6) return undefined
-  if (parts[0] !== 'arn') return undefined
-  const region = parts[3]
-  if (typeof region !== 'string' || !region) return undefined
-  return isValidRegion(region) ? (region as KiroRegion) : undefined
+  return parseCodeWhispererProfileArn(arn)?.region
 }
 
 export const KIRO_CONSTANTS = {
@@ -49,40 +103,251 @@ export const KIRO_CONSTANTS = {
   ORIGIN_AI_EDITOR: 'AI_EDITOR'
 }
 
-export const MODEL_MAPPING: Record<string, string> = {
-  // Claude Haiku
-  'claude-haiku-4-5': 'claude-haiku-4.5',
-  'claude-haiku-4-5-thinking': 'claude-haiku-4.5',
-  // Claude Sonnet
-  'claude-sonnet-4': 'claude-sonnet-4',
-  'claude-sonnet-4-5': 'claude-sonnet-4.5',
-  'claude-sonnet-4-5-thinking': 'claude-sonnet-4.5',
-  'claude-sonnet-4-5-1m': 'claude-sonnet-4.5-1m',
-  'claude-sonnet-4-5-1m-thinking': 'claude-sonnet-4.5-1m',
-  'claude-sonnet-4-6': 'claude-sonnet-4.6',
-  'claude-sonnet-4-6-thinking': 'claude-sonnet-4.6',
-  'claude-sonnet-4-6-1m': 'claude-sonnet-4.6-1m',
-  'claude-sonnet-4-6-1m-thinking': 'claude-sonnet-4.6-1m',
-  // Claude Opus
-  'claude-opus-4-5': 'claude-opus-4.5',
-  'claude-opus-4-5-thinking': 'claude-opus-4.5',
-  'claude-opus-4-6': 'claude-opus-4.6',
-  'claude-opus-4-6-thinking': 'claude-opus-4.6',
-  'claude-opus-4-6-1m': 'claude-opus-4.6-1m',
-  'claude-opus-4-6-1m-thinking': 'claude-opus-4.6-1m',
-  'claude-opus-4-7': 'claude-opus-4.7',
-  'claude-opus-4-7-thinking': 'claude-opus-4.7',
-  'claude-opus-4-8': 'claude-opus-4.8',
-  'claude-opus-4-8-thinking': 'claude-opus-4.8',
-  // Auto
-  auto: 'auto',
-  // Open weight models
-  'deepseek-3.2': 'deepseek-3.2',
-  'glm-5': 'glm-5',
-  'minimax-m2.5': 'minimax-m2.5',
-  'minimax-m2.1': 'minimax-m2.1',
-  'qwen3-coder-next': 'qwen3-coder-next',
-  // Legacy / internal mappings kept for backwards compatibility
+const TEXT_ONLY = ['text'] as const
+const TEXT_IMAGE = ['text', 'image'] as const
+const TEXT_IMAGE_PDF = ['text', 'image', 'pdf'] as const
+const TEXT_OUTPUT = ['text'] as const
+
+const STANDARD_CONTEXT = 200000
+const LONG_CONTEXT = 1000000
+const DEFAULT_OUTPUT = 64000
+
+export const THINKING_BUDGET_BY_EFFORT = {
+  low: 8192,
+  medium: 16384,
+  high: 32768,
+  xhigh: 65536,
+  max: 128000
+} as const
+
+export interface KiroModelDefinition {
+  name: string
+  apiModelId: string
+  context: number
+  output: number
+  input: readonly string[]
+  outputModalities: readonly string[]
+  costMultiplier?: string
+  releaseDate?: string
+  reasoning?: boolean
+  effortLevels?: readonly Effort[]
+}
+
+function model(input: KiroModelDefinition): KiroModelDefinition {
+  return input
+}
+
+export const KIRO_MODEL_CATALOG = {
+  auto: model({
+    name: 'Auto (1.0x)',
+    apiModelId: 'auto',
+    context: LONG_CONTEXT,
+    output: DEFAULT_OUTPUT,
+    input: TEXT_IMAGE_PDF,
+    outputModalities: TEXT_OUTPUT
+  }),
+
+  'gpt-5.6-sol': model({
+    name: 'GPT-5.6 Sol (2.4x)',
+    apiModelId: 'gpt-5.6-sol',
+    context: 272000,
+    output: DEFAULT_OUTPUT,
+    input: TEXT_IMAGE,
+    outputModalities: TEXT_OUTPUT,
+    costMultiplier: '2.4x',
+    releaseDate: '2026-07-13',
+    reasoning: true,
+    effortLevels: ['low', 'medium', 'high', 'xhigh', 'max']
+  }),
+
+  'gpt-5.6-terra': model({
+    name: 'GPT-5.6 Terra (1.2x)',
+    apiModelId: 'gpt-5.6-terra',
+    context: 272000,
+    output: DEFAULT_OUTPUT,
+    input: TEXT_IMAGE,
+    outputModalities: TEXT_OUTPUT,
+    costMultiplier: '1.2x',
+    releaseDate: '2026-07-13',
+    reasoning: true,
+    effortLevels: ['low', 'medium', 'high', 'xhigh', 'max']
+  }),
+
+  'gpt-5.6-luna': model({
+    name: 'GPT-5.6 Luna (0.6x)',
+    apiModelId: 'gpt-5.6-luna',
+    context: 272000,
+    output: DEFAULT_OUTPUT,
+    input: TEXT_IMAGE,
+    outputModalities: TEXT_OUTPUT,
+    costMultiplier: '0.6x',
+    releaseDate: '2026-07-13',
+    reasoning: true,
+    effortLevels: ['low', 'medium', 'high', 'xhigh', 'max']
+  }),
+
+  'claude-opus-4.8': model({
+    name: 'Claude Opus 4.8 (2.2x)',
+    apiModelId: 'claude-opus-4.8',
+    context: LONG_CONTEXT,
+    output: 128000,
+    input: TEXT_IMAGE_PDF,
+    outputModalities: TEXT_OUTPUT,
+    costMultiplier: '2.2x',
+    releaseDate: '2026-05-28',
+    reasoning: true,
+    effortLevels: ['low', 'medium', 'high', 'xhigh', 'max']
+  }),
+
+  'claude-opus-4.7': model({
+    name: 'Claude Opus 4.7 (2.2x)',
+    apiModelId: 'claude-opus-4.7',
+    context: LONG_CONTEXT,
+    output: DEFAULT_OUTPUT,
+    input: TEXT_IMAGE_PDF,
+    outputModalities: TEXT_OUTPUT,
+    costMultiplier: '2.2x',
+    releaseDate: '2026-04-16',
+    reasoning: true,
+    effortLevels: ['low', 'medium', 'high', 'xhigh', 'max']
+  }),
+
+  'claude-opus-4.6': model({
+    name: 'Claude Opus 4.6 (2.2x)',
+    apiModelId: 'claude-opus-4.6',
+    context: LONG_CONTEXT,
+    output: DEFAULT_OUTPUT,
+    input: TEXT_IMAGE_PDF,
+    outputModalities: TEXT_OUTPUT,
+    costMultiplier: '2.2x',
+    releaseDate: '2026-02-05',
+    reasoning: true,
+    effortLevels: ['low', 'medium', 'high', 'max']
+  }),
+
+  'claude-opus-4.5': model({
+    name: 'Claude Opus 4.5 (2.2x)',
+    apiModelId: 'claude-opus-4.5',
+    context: STANDARD_CONTEXT,
+    output: DEFAULT_OUTPUT,
+    input: TEXT_IMAGE_PDF,
+    outputModalities: TEXT_OUTPUT,
+    costMultiplier: '2.2x',
+    reasoning: true
+  }),
+
+  'claude-sonnet-4.6': model({
+    name: 'Claude Sonnet 4.6 (1.3x)',
+    apiModelId: 'claude-sonnet-4.6',
+    context: LONG_CONTEXT,
+    output: DEFAULT_OUTPUT,
+    input: TEXT_IMAGE_PDF,
+    outputModalities: TEXT_OUTPUT,
+    costMultiplier: '1.3x',
+    releaseDate: '2026-02-17',
+    reasoning: true,
+    effortLevels: ['low', 'medium', 'high', 'max']
+  }),
+
+  'claude-sonnet-5': model({
+    name: 'Claude Sonnet 5 (1.3x)',
+    apiModelId: 'claude-sonnet-5',
+    context: LONG_CONTEXT,
+    output: DEFAULT_OUTPUT,
+    input: TEXT_IMAGE_PDF,
+    outputModalities: TEXT_OUTPUT,
+    costMultiplier: '1.3x',
+    releaseDate: '2026-06-30',
+    reasoning: true
+  }),
+
+  'claude-sonnet-4.5': model({
+    name: 'Claude Sonnet 4.5 (1.3x)',
+    apiModelId: 'claude-sonnet-4.5',
+    context: STANDARD_CONTEXT,
+    output: DEFAULT_OUTPUT,
+    input: TEXT_IMAGE_PDF,
+    outputModalities: TEXT_OUTPUT,
+    costMultiplier: '1.3x',
+    reasoning: true
+  }),
+
+  'claude-sonnet-4': model({
+    name: 'Claude Sonnet 4 (1.3x)',
+    apiModelId: 'claude-sonnet-4',
+    context: STANDARD_CONTEXT,
+    output: DEFAULT_OUTPUT,
+    input: TEXT_IMAGE_PDF,
+    outputModalities: TEXT_OUTPUT,
+    costMultiplier: '1.3x',
+    reasoning: true
+  }),
+
+  'claude-haiku-4.5': model({
+    name: 'Claude Haiku 4.5 (0.4x)',
+    apiModelId: 'claude-haiku-4.5',
+    context: STANDARD_CONTEXT,
+    output: DEFAULT_OUTPUT,
+    input: TEXT_IMAGE,
+    outputModalities: TEXT_OUTPUT,
+    costMultiplier: '0.4x',
+    reasoning: true
+  }),
+
+  'deepseek-3.2': model({
+    name: 'DeepSeek 3.2 (0.25x)',
+    apiModelId: 'deepseek-3.2',
+    context: 164000,
+    output: DEFAULT_OUTPUT,
+    input: TEXT_ONLY,
+    outputModalities: TEXT_OUTPUT,
+    costMultiplier: '0.25x',
+    releaseDate: '2026-02-10'
+  }),
+  'minimax-m2.5': model({
+    name: 'MiniMax M2.5 (0.25x)',
+    apiModelId: 'minimax-m2.5',
+    context: 196000,
+    output: DEFAULT_OUTPUT,
+    input: TEXT_ONLY,
+    outputModalities: TEXT_OUTPUT,
+    costMultiplier: '0.25x',
+    releaseDate: '2026-03-18'
+  }),
+  'glm-5': model({
+    name: 'GLM-5 (0.5x)',
+    apiModelId: 'glm-5',
+    context: STANDARD_CONTEXT,
+    output: DEFAULT_OUTPUT,
+    input: TEXT_ONLY,
+    outputModalities: TEXT_OUTPUT,
+    costMultiplier: '0.5x',
+    releaseDate: '2026-03-31',
+    reasoning: true
+  }),
+  'minimax-m2.1': model({
+    name: 'MiniMax M2.1 (0.15x)',
+    apiModelId: 'minimax-m2.1',
+    context: 196000,
+    output: DEFAULT_OUTPUT,
+    input: TEXT_ONLY,
+    outputModalities: TEXT_OUTPUT,
+    costMultiplier: '0.15x',
+    releaseDate: '2026-02-10'
+  }),
+  'qwen3-coder-next': model({
+    name: 'Qwen3 Coder Next (0.05x)',
+    apiModelId: 'qwen3-coder-next',
+    context: 256000,
+    output: DEFAULT_OUTPUT,
+    input: TEXT_ONLY,
+    outputModalities: TEXT_OUTPUT,
+    costMultiplier: '0.05x',
+    releaseDate: '2026-02-10'
+  })
+} as const satisfies Record<string, KiroModelDefinition>
+
+export const LEGACY_MODEL_MAPPING: Record<string, string> = {
   'claude-3-7-sonnet': 'CLAUDE_3_7_SONNET_20250219_V1_0',
   'nova-swe': 'AGI_NOVA_SWE_V1_5',
   'gpt-oss-120b': 'OPENAI_GPT_OSS_120B_1_0',
@@ -90,12 +355,106 @@ export const MODEL_MAPPING: Record<string, string> = {
   'kimi-k2-thinking': 'MOONSHOT_KIMI_K2_THINKING'
 }
 
-export const SUPPORTED_MODELS = Object.keys(MODEL_MAPPING)
+const HYPHENATED_CLAUDE_ALIASES = [
+  'claude-opus-4.8',
+  'claude-opus-4.7',
+  'claude-opus-4.6',
+  'claude-opus-4.5',
+  'claude-sonnet-4.6',
+  'claude-sonnet-5',
+  'claude-sonnet-4.5',
+  'claude-haiku-4.5'
+] as const
 
-const LONG_CONTEXT_MODELS = new Set(Object.keys(MODEL_MAPPING).filter((k) => k.includes('-1m')))
+export const MODEL_ALIASES = {
+  ...Object.fromEntries(HYPHENATED_CLAUDE_ALIASES.map((id) => [id.replace(/\./g, '-'), id])),
+  'claude-opus-4-6-1m': 'claude-opus-4.6',
+  'claude-opus-4.6-1m': 'claude-opus-4.6',
+  'claude-sonnet-4-6-1m': 'claude-sonnet-4.6',
+  'claude-sonnet-4.6-1m': 'claude-sonnet-4.6',
+  // Sonnet 4.5 no longer has a dedicated 1M-context catalog entry; older
+  // configs that requested the 1M variant fall back to the standard 4.5 model.
+  'claude-sonnet-4-5-1m': 'claude-sonnet-4.5',
+  'claude-sonnet-4.5-1m': 'claude-sonnet-4.5'
+} as Record<string, keyof typeof KIRO_MODEL_CATALOG>
+
+function stripThinkingSuffix(model: string): string {
+  return model.endsWith('-thinking') ? model.slice(0, -'-thinking'.length) : model
+}
+
+function getCanonicalModelID(model: string): keyof typeof KIRO_MODEL_CATALOG | undefined {
+  const base = stripThinkingSuffix(model)
+  const canonical = MODEL_ALIASES[base] ?? base
+  return canonical in KIRO_MODEL_CATALOG
+    ? (canonical as keyof typeof KIRO_MODEL_CATALOG)
+    : undefined
+}
+
+function getModelDefinition(model: string): KiroModelDefinition | undefined {
+  const canonical = getCanonicalModelID(model)
+  return canonical ? KIRO_MODEL_CATALOG[canonical] : undefined
+}
+
+export function getKiroApiModelId(model: string): string | undefined {
+  const canonical = getCanonicalModelID(model)
+  if (canonical) return KIRO_MODEL_CATALOG[canonical].apiModelId
+  return LEGACY_MODEL_MAPPING[model]
+}
+
+export const MODEL_MAPPING: Record<string, string> = {
+  ...Object.fromEntries(
+    Object.entries(KIRO_MODEL_CATALOG).map(([id, definition]) => [id, definition.apiModelId])
+  ),
+  ...Object.fromEntries(
+    Object.entries(MODEL_ALIASES).map(([alias, canonical]) => [
+      alias,
+      KIRO_MODEL_CATALOG[canonical].apiModelId
+    ])
+  ),
+  ...LEGACY_MODEL_MAPPING
+}
+
+export const DEFAULT_MODEL_IDS = Object.keys(KIRO_MODEL_CATALOG)
+export const SUPPORTED_MODELS = DEFAULT_MODEL_IDS
+
+export const DEFAULT_PROVIDER_MODELS = Object.fromEntries(
+  Object.entries(KIRO_MODEL_CATALOG).map(([id, definition]) => [
+    id,
+    {
+      id: definition.apiModelId,
+      name: definition.name,
+      release_date: definition.releaseDate,
+      reasoning: definition.reasoning,
+      tool_call: true,
+      limit: { context: definition.context, output: definition.output },
+      modalities: { input: [...definition.input], output: [...definition.outputModalities] },
+      ...(definition.effortLevels
+        ? {
+            variants: Object.fromEntries(
+              definition.effortLevels.map((effort) => [effort, { reasoningEffort: effort }])
+            )
+          }
+        : definition.reasoning
+          ? {
+              // OpenCode infers these for every OpenAI-compatible reasoning model.
+              // Disable them when Kiro does not document configurable effort.
+              variants: {
+                low: { disabled: true },
+                medium: { disabled: true },
+                high: { disabled: true }
+              }
+            }
+          : {})
+    }
+  ])
+)
 
 export function isLongContextModel(model: string): boolean {
-  return LONG_CONTEXT_MODELS.has(model)
+  return (getModelDefinition(model)?.context ?? 0) >= LONG_CONTEXT
+}
+
+export function getModelContextWindow(model: string): number {
+  return getModelDefinition(model)?.context || STANDARD_CONTEXT
 }
 
 export const KIRO_AUTH_SERVICE = {

--- a/src/core/account/account-selector.ts
+++ b/src/core/account/account-selector.ts
@@ -1,6 +1,7 @@
 import type { AccountRepository } from '../../infrastructure/database/account-repository'
 import type { AccountManager } from '../../plugin/accounts'
 import type { ManagedAccount } from '../../plugin/types'
+import { formatUsageRatio, formatUsageValue } from '../../plugin/usage-format.js'
 
 type ToastFunction = (message: string, variant: 'info' | 'warning' | 'success' | 'error') => void
 
@@ -74,9 +75,9 @@ export class AccountSelector {
   private formatUsageMessage(usedCount: number, limitCount: number, email: string): string {
     if (limitCount > 0) {
       const percentage = Math.round((usedCount / limitCount) * 100)
-      return `Usage (${email}): ${usedCount}/${limitCount} (${percentage}%)`
+      return `Usage (${email}): ${formatUsageRatio(usedCount, limitCount)} (${percentage}%)`
     }
-    return `Usage (${email}): ${usedCount}`
+    return `Usage (${email}): ${formatUsageValue(usedCount)}`
   }
 
   private checkCircuitBreaker(): void {

--- a/src/core/auth/auth-handler.ts
+++ b/src/core/auth/auth-handler.ts
@@ -1,13 +1,16 @@
 import type { AuthHook } from '@opencode-ai/plugin'
+import { getOidcEndpoint, parseCodeWhispererProfileArn } from '../../constants.js'
 import type { AccountRepository } from '../../infrastructure/database/account-repository.js'
 import { RegionSchema } from '../../plugin/config/schema.js'
 import * as logger from '../../plugin/logger.js'
+import { formatUsageRatio, formatUsageValue } from '../../plugin/usage-format.js'
 import { IdcAuthMethod } from './idc-auth-method.js'
 
 type ToastFunction = (message: string, variant: 'info' | 'warning' | 'success' | 'error') => void
 
 export class AuthHandler {
   private accountManager?: any
+  private initializePromise?: Promise<void>
 
   constructor(
     private config: any,
@@ -15,6 +18,15 @@ export class AuthHandler {
   ) {}
 
   async initialize(showToast?: ToastFunction): Promise<void> {
+    if (this.initializePromise) return this.initializePromise
+    this.initializePromise = this.doInitialize(showToast).catch((error) => {
+      this.initializePromise = undefined
+      throw error
+    })
+    return this.initializePromise
+  }
+
+  private async doInitialize(showToast?: ToastFunction): Promise<void> {
     const { syncFromKiroCli } = await import('../../plugin/sync/kiro-cli.js')
 
     logger.log('Auth init', { autoSyncKiroCli: !!this.config.auto_sync_kiro_cli })
@@ -33,6 +45,7 @@ export class AuthHandler {
   }
 
   private logUsageSummary(showToast?: ToastFunction): void {
+    void showToast
     if (!this.accountManager) return
     const accounts = this.accountManager.getAccounts()
     if (!accounts.length) return
@@ -42,16 +55,11 @@ export class AuthHandler {
       const limit = acc.limitCount ?? 0
       if (limit > 0) {
         const pct = Math.round((used / limit) * 100)
-        const msg = `Kiro usage (${acc.email}): ${used}/${limit} (${pct}%)`
+        const msg = `Kiro usage (${acc.email}): ${formatUsageRatio(used, limit)} (${pct}%)`
         logger.log(msg)
-        if (showToast) {
-          const variant = pct >= 90 ? 'warning' : 'info'
-          setTimeout(() => showToast(msg, variant), 3000)
-        }
       } else if (used > 0) {
-        const msg = `Kiro usage (${acc.email}): ${used} requests used`
+        const msg = `Kiro usage (${acc.email}): ${formatUsageValue(used)} credits used`
         logger.log(msg)
-        if (showToast) setTimeout(() => showToast(msg, 'info'), 3000)
       }
     }
   }
@@ -102,9 +110,14 @@ export class AuthHandler {
             placeholder: 'us-east-1',
             validate: (value: string) => {
               if (!value) return undefined
-              return RegionSchema.safeParse(value.trim()).success
-                ? undefined
-                : 'Please enter a valid AWS region'
+              const region = value.trim()
+              if (!RegionSchema.safeParse(region).success) return 'Please enter a valid AWS region'
+              try {
+                getOidcEndpoint(region)
+                return undefined
+              } catch (error) {
+                return error instanceof Error ? error.message : 'Unsupported AWS region'
+              }
             }
           }
         ],
@@ -141,9 +154,14 @@ export class AuthHandler {
             placeholder: 'us-east-1',
             validate: (value: string) => {
               if (!value) return undefined
-              return RegionSchema.safeParse(value.trim()).success
-                ? undefined
-                : 'Please enter a valid AWS region'
+              const region = value.trim()
+              if (!RegionSchema.safeParse(region).success) return 'Please enter a valid AWS region'
+              try {
+                getOidcEndpoint(region)
+                return undefined
+              } catch (error) {
+                return error instanceof Error ? error.message : 'Unsupported AWS region'
+              }
             }
           },
           {
@@ -156,10 +174,9 @@ export class AuthHandler {
             validate: (value: string) => {
               if (!value && this.config.idc_profile_arn) return undefined
               if (!value) return 'Profile ARN is required for this method'
-              return value.startsWith('arn:aws:codewhisperer:') ||
-                value.startsWith('arn:aws:qdeveloper:')
+              return parseCodeWhispererProfileArn(value.trim())
                 ? undefined
-                : 'Please enter a valid CodeWhisperer or Q Developer profile ARN'
+                : 'Please enter a supported CodeWhisperer or Q Developer profile ARN'
             }
           }
         ],

--- a/src/core/auth/idc-auth-method.ts
+++ b/src/core/auth/idc-auth-method.ts
@@ -1,5 +1,5 @@
 import type { AuthOuathResult } from '@opencode-ai/plugin'
-import { exec } from 'node:child_process'
+import { spawn } from 'node:child_process'
 import { extractRegionFromArn, normalizeRegion } from '../../constants.js'
 import type { AccountRepository } from '../../infrastructure/database/account-repository.js'
 import { authorizeKiroIDC, pollKiroIDCToken } from '../../kiro/oauth-idc.js'
@@ -11,17 +11,20 @@ import type { KiroRegion, ManagedAccount } from '../../plugin/types.js'
 import { fetchUsageLimits } from '../../plugin/usage.js'
 
 const openBrowser = (url: string) => {
-  const escapedUrl = url.replace(/"/g, '\\"')
+  if (new URL(url).protocol !== 'https:') {
+    logger.warn('Refusing to open a non-HTTPS authentication URL')
+    return
+  }
   const platform = process.platform
-  const cmd =
+  const [command, args] =
     platform === 'win32'
-      ? `cmd /c start "" "${escapedUrl}"`
+      ? ['cmd', ['/c', 'start', '', url]]
       : platform === 'darwin'
-        ? `open "${escapedUrl}"`
-        : `xdg-open "${escapedUrl}"`
-  exec(cmd, (error) => {
-    if (error) logger.warn(`Browser error: ${error.message}`)
-  })
+        ? ['open', [url]]
+        : ['xdg-open', [url]]
+  const child = spawn(command, args, { detached: true, shell: false, stdio: 'ignore' })
+  child.on('error', (error) => logger.warn(`Browser error: ${error.message}`))
+  child.unref()
 }
 
 function normalizeStartUrl(raw: string | undefined): string | undefined {
@@ -30,14 +33,28 @@ function normalizeStartUrl(raw: string | undefined): string | undefined {
   if (!trimmed) return undefined
 
   const url = new URL(trimmed)
+  if (url.protocol !== 'https:') {
+    throw new Error('IAM Identity Center Start URL must use HTTPS')
+  }
   url.hash = ''
   url.search = ''
 
-  // Normalize common portal URL shapes to end in `/start` (AWS Builder ID and IAM Identity Center)
+  // Normalize common AWS access portal URLs without breaking GovCloud directory URLs.
   if (url.pathname.endsWith('/start/')) url.pathname = url.pathname.replace(/\/start\/$/, '/start')
-  if (!url.pathname.endsWith('/start')) url.pathname = url.pathname.replace(/\/+$/, '') + '/start'
+  if ((url.pathname === '' || url.pathname === '/') && url.hostname.endsWith('.awsapps.com')) {
+    url.pathname = '/start'
+  }
 
   return url.toString()
+}
+
+function canBuildPortalDeviceUrl(startUrl: string): boolean {
+  try {
+    const url = new URL(startUrl)
+    return /\/start\/?$/.test(url.pathname)
+  } catch {
+    return false
+  }
 }
 
 function buildDeviceUrl(startUrl: string, userCode: string): string {
@@ -78,9 +95,10 @@ export class IdcAuthMethod {
     // If a custom Identity Center start URL is provided, prefer the portal device page.
     // This avoids the AWS Builder ID device page (which often prompts for an email)
     // and routes the user into their org's IAM Identity Center sign-in.
-    const verificationUrl = startUrl
-      ? buildDeviceUrl(startUrl, auth.userCode)
-      : auth.verificationUriComplete || auth.verificationUrl
+    const verificationUrl =
+      startUrl && canBuildPortalDeviceUrl(startUrl)
+        ? buildDeviceUrl(startUrl, auth.userCode)
+        : auth.verificationUriComplete || auth.verificationUrl
 
     // Open the *AWS* verification page directly (no local web server).
     openBrowser(verificationUrl)
@@ -122,7 +140,7 @@ export class IdcAuthMethod {
             })
             if (startUrl && !profileArn) {
               throw new Error(
-                `Missing profile ARN for IAM Identity Center. Set "idc_profile_arn" in ~/.config/opencode/kiro.json, or run "kiro-cli profile" once so it can be auto-detected. Original error: ${
+                `Missing profile ARN for IAM Identity Center. Set "idc_profile_arn" in ~/.config/opencode/kiro.json, or use "kiro-cli whoami --format json" to find the active profile. Original error: ${
                   e instanceof Error ? e.message : String(e)
                 }`
               )
@@ -139,7 +157,11 @@ export class IdcAuthMethod {
                 email: undefined
               }
             } else {
-              throw e
+              logger.warn('Usage is unavailable; continuing authentication without quota data', {
+                serviceRegion,
+                profileArn,
+                error: errMsg
+              })
             }
           }
 
@@ -167,13 +189,16 @@ export class IdcAuthMethod {
             profileArn,
             startUrl: startUrl || undefined,
             refreshToken: token.refreshToken,
+            refreshTokenUpdatedAt: Date.now(),
             accessToken: token.accessToken,
             expiresAt: token.expiresAt,
             rateLimitResetTime: 0,
             isHealthy: true,
             failCount: 0,
             usedCount: usage.usedCount,
-            limitCount: usage.limitCount
+            limitCount: usage.limitCount,
+            subscriptionPlan: usage.subscriptionPlan,
+            lastSync: Date.now()
           }
 
           await this.repository.save(acc)
@@ -184,7 +209,7 @@ export class IdcAuthMethod {
           const err = e instanceof Error ? e : new Error(String(e))
           logger.error('IDC auth callback failed', err)
           throw new Error(
-            `IDC authorization failed: ${err.message}. Check ~/.config/opencode/kiro-logs/plugin.log for details. If this is an Identity Center account, ensure you have selected an AWS Q Developer/CodeWhisperer profile (try: kiro-cli profile).`
+            `IDC authorization failed: ${err.message}. Check ~/.config/opencode/kiro-logs/plugin.log for details. If this is an Identity Center account, verify the active AWS Q Developer/CodeWhisperer profile with "kiro-cli whoami --format json".`
           )
         }
       }

--- a/src/core/auth/token-refresher.ts
+++ b/src/core/auth/token-refresher.ts
@@ -15,27 +15,34 @@ interface TokenRefresherConfig {
 }
 
 export class TokenRefresher {
+  private refreshInFlight = new Map<string, Promise<KiroAuthDetails>>()
+
   constructor(
     private config: TokenRefresherConfig,
     private accountManager: AccountManager,
     private syncFromKiroCli: () => Promise<void>,
-    private repository: AccountRepository
+    private repository: AccountRepository,
+    private refresh: (auth: KiroAuthDetails) => Promise<KiroAuthDetails> = refreshAccessToken
   ) {}
 
   async refreshIfNeeded(
     account: ManagedAccount,
     auth: KiroAuthDetails,
     showToast: ToastFunction
-  ): Promise<{ account: ManagedAccount; shouldContinue: boolean }> {
+  ): Promise<{ account: ManagedAccount; auth: KiroAuthDetails; shouldContinue: boolean }> {
     if (!accessTokenExpired(auth, this.config.token_expiry_buffer_ms)) {
-      return { account, shouldContinue: false }
+      return { account, auth, shouldContinue: false }
     }
 
     try {
-      const newAuth = await refreshAccessToken(auth)
-      this.accountManager.updateFromAuth(account, newAuth)
-      await this.repository.batchSave(this.accountManager.getAccounts())
-      return { account, shouldContinue: false }
+      let refresh = this.refreshInFlight.get(account.id)
+      if (!refresh) {
+        refresh = this.refreshAccount(account, auth)
+        this.refreshInFlight.set(account.id, refresh)
+        refresh.finally(() => this.refreshInFlight.delete(account.id)).catch(() => {})
+      }
+      const newAuth = await refresh
+      return { account, auth: newAuth, shouldContinue: false }
     } catch (e: any) {
       return await this.handleRefreshError(e, account, showToast)
     }
@@ -45,7 +52,7 @@ export class TokenRefresher {
     error: any,
     account: ManagedAccount,
     showToast: ToastFunction
-  ): Promise<{ account: ManagedAccount; shouldContinue: boolean }> {
+  ): Promise<{ account: ManagedAccount; auth: KiroAuthDetails; shouldContinue: boolean }> {
     logger.error('Token refresh failed', {
       email: account.email,
       code: error instanceof KiroTokenRefreshError ? error.code : undefined,
@@ -57,17 +64,42 @@ export class TokenRefresher {
 
     this.repository.invalidateCache()
     const accounts = await this.repository.findAll()
-    const stillAcc = accounts.find((a: ManagedAccount) => a.id === account.id)
-
-    if (
-      stillAcc &&
+    const hasUsableCredentials = (candidate: ManagedAccount) =>
       !accessTokenExpired(
-        this.accountManager.toAuthDetails(stillAcc),
+        this.accountManager.toAuthDetails(candidate),
         this.config.token_expiry_buffer_ms
       )
-    ) {
+    let stillAcc = accounts.find(
+      (candidate: ManagedAccount) => candidate.id === account.id && hasUsableCredentials(candidate)
+    )
+    if (!stillAcc && account.profileArn) {
+      stillAcc = accounts.find(
+        (candidate: ManagedAccount) =>
+          candidate.authMethod === account.authMethod &&
+          candidate.profileArn === account.profileArn &&
+          hasUsableCredentials(candidate)
+      )
+    }
+    if (!stillAcc && !account.profileArn && account.clientId) {
+      stillAcc = accounts.find(
+        (candidate: ManagedAccount) =>
+          candidate.authMethod === account.authMethod &&
+          !candidate.profileArn &&
+          candidate.clientId === account.clientId &&
+          hasUsableCredentials(candidate)
+      )
+    }
+
+    if (stillAcc) {
+      if (stillAcc.id !== account.id) this.accountManager.removeAccount(account)
+      this.accountManager.addAccount(stillAcc)
+      const recoveredAuth = this.accountManager.toAuthDetails(stillAcc)
       showToast('Credentials recovered from Kiro CLI sync.', 'info')
-      return { account: stillAcc, shouldContinue: true }
+      return {
+        account: stillAcc,
+        auth: recoveredAuth,
+        shouldContinue: false
+      }
     }
 
     if (
@@ -83,7 +115,7 @@ export class TokenRefresher {
     ) {
       this.accountManager.markUnhealthy(account, error.message)
       await this.repository.batchSave(this.accountManager.getAccounts())
-      return { account, shouldContinue: true }
+      return { account, auth: this.accountManager.toAuthDetails(account), shouldContinue: true }
     }
 
     logger.error('Token refresh unrecoverable', {
@@ -92,5 +124,15 @@ export class TokenRefresher {
       message: error instanceof Error ? error.message : String(error)
     })
     throw error
+  }
+
+  private async refreshAccount(
+    account: ManagedAccount,
+    auth: KiroAuthDetails
+  ): Promise<KiroAuthDetails> {
+    const newAuth = await this.refresh(auth)
+    this.accountManager.updateFromAuth(account, newAuth)
+    await this.repository.batchSave(this.accountManager.getAccounts())
+    return newAuth
   }
 }

--- a/src/core/request/request-handler.ts
+++ b/src/core/request/request-handler.ts
@@ -1,19 +1,34 @@
 import { GenerateAssistantResponseCommand } from '@aws/codewhisperer-streaming-client'
+import { KIRO_PROVIDER_ID, THINKING_BUDGET_BY_EFFORT } from '../../constants'
 import type { AccountRepository } from '../../infrastructure/database/account-repository'
 import type { AccountManager } from '../../plugin/accounts'
 import type { KiroConfig } from '../../plugin/config'
+import { EffortSchema } from '../../plugin/config/schema'
 import { isPermanentError } from '../../plugin/health'
 import * as logger from '../../plugin/logger'
 import { transformToSdkRequest } from '../../plugin/request'
-import { createSdkClient } from '../../plugin/sdk-client'
+import {
+  createSdkClient,
+  getSdkEndpoint,
+  type ResolvedSdkEndpointMode
+} from '../../plugin/sdk-client'
 import { syncFromKiroCli } from '../../plugin/sync/kiro-cli'
-import type { KiroAuthDetails, ManagedAccount, SdkPreparedRequest } from '../../plugin/types'
+import type {
+  Effort,
+  KiroAuthDetails,
+  ManagedAccount,
+  SdkPreparedRequest
+} from '../../plugin/types'
 import { AccountSelector } from '../account/account-selector'
 import { UsageTracker } from '../account/usage-tracker'
 import { TokenRefresher } from '../auth/token-refresher'
 import { ErrorHandler } from './error-handler'
 import { ResponseHandler } from './response-handler'
 import { RetryStrategy } from './retry-strategy'
+import {
+  deduplicateSdkEndpointModes,
+  shouldFallbackSdkEndpointError
+} from './sdk-endpoint-fallback'
 
 type ToastFunction = (message: string, variant: 'info' | 'warning' | 'success' | 'error') => void
 
@@ -29,7 +44,6 @@ export class RequestHandler {
   private retryStrategy: RetryStrategy
   private reauthInFlight: Promise<boolean> | null = null
   private lastFailedReauthAt = 0
-  private static kiroRequestQueue: Promise<void> = Promise.resolve()
 
   constructor(
     private accountManager: AccountManager,
@@ -52,24 +66,7 @@ export class RequestHandler {
       return fetch(input, init)
     }
 
-    return this.enqueueKiroRequest(() => this.handleKiroRequest(url, init, showToast))
-  }
-
-  private async enqueueKiroRequest<T>(run: () => Promise<T>): Promise<T> {
-    const previous = RequestHandler.kiroRequestQueue
-    let release!: () => void
-
-    RequestHandler.kiroRequestQueue = new Promise((resolve) => {
-      release = resolve
-    })
-
-    await previous.catch(() => {})
-
-    try {
-      return await run()
-    } finally {
-      release()
-    }
+    return this.handleKiroRequest(url, init, showToast)
   }
 
   private async handleKiroRequest(
@@ -79,13 +76,21 @@ export class RequestHandler {
   ): Promise<Response> {
     const body = init?.body ? JSON.parse(init.body) : {}
     const model = this.extractModel(url) || body.model || 'claude-sonnet-4-5'
+    const effort = this.extractReasoningEffort(body)
+    const explicitThinkingBudget =
+      body.providerOptions?.thinkingConfig?.thinkingBudget ??
+      body.providerOptions?.thinkingConfig?.budget_tokens ??
+      body.thinkingConfig?.thinkingBudget ??
+      body.thinkingConfig?.budget_tokens
     const think =
-      model.endsWith('-thinking') || !!body.providerOptions?.thinkingConfig || !!body.thinkingConfig
+      model.endsWith('-thinking') ||
+      !!body.providerOptions?.thinkingConfig ||
+      !!body.thinkingConfig ||
+      !!effort
     const budget =
-      body.providerOptions?.thinkingConfig?.thinkingBudget ||
-      body.thinkingConfig?.thinkingBudget ||
-      body.thinkingConfig?.budget_tokens ||
-      20000
+      (effort ? THINKING_BUDGET_BY_EFFORT[effort] : undefined) ??
+      explicitThinkingBudget ??
+      (model.endsWith('-thinking') ? THINKING_BUDGET_BY_EFFORT.high : 20000)
 
     let retry = 0
     let consecutiveNullAccounts = 0
@@ -122,29 +127,36 @@ export class RequestHandler {
       }
 
       consecutiveNullAccounts = 0
-      const auth = this.accountManager.toAuthDetails(acc)
+      let auth = this.accountManager.toAuthDetails(acc)
 
       const tokenResult = await this.tokenRefresher.refreshIfNeeded(acc, auth, showToast)
+      acc = tokenResult.account
       if (tokenResult.shouldContinue) {
-        acc = tokenResult.account
         await this.sleep(500)
         continue
       }
+      auth = tokenResult.auth
 
-      const sdkPrep = this.prepareSdkRequest(init?.body, model, auth, think, budget, showToast)
+      const sdkPrep = this.prepareSdkRequest(
+        init?.body,
+        model,
+        auth,
+        think,
+        budget,
+        effort,
+        showToast
+      )
 
+      let sdkEndpointMode = this.getSdkEndpointModes(sdkPrep.region)[0] || 'kiro-runtime'
       const apiTimestamp = this.config.enable_log_api_request ? logger.getTimestamp() : null
       if (apiTimestamp) {
-        this.logSdkRequest(sdkPrep, acc, apiTimestamp)
+        this.logSdkRequest(sdkPrep, acc, apiTimestamp, sdkEndpointMode)
       }
-      try {
-        const client = createSdkClient(auth, sdkPrep.region, sdkPrep.effort)
-        const command = new GenerateAssistantResponseCommand({
-          conversationState: sdkPrep.conversationState as any,
-          profileArn: sdkPrep.profileArn
-        })
 
-        const sdkResponse = await client.send(command)
+      try {
+        const sdkResult = await this.sendSdkRequestWithEndpointFallback(auth, sdkPrep)
+        sdkEndpointMode = sdkResult.endpointMode
+        const sdkResponse = sdkResult.sdkResponse
 
         if (apiTimestamp) {
           this.logSdkResponse(sdkPrep, apiTimestamp)
@@ -157,14 +169,15 @@ export class RequestHandler {
           sdkResponse,
           model,
           sdkPrep.conversationId,
-          sdkPrep.streaming
+          sdkPrep.streaming,
+          think
         )
       } catch (e: any) {
         const httpStatus = e?.$metadata?.httpStatusCode
 
-        if (httpStatus) {
+        if (httpStatus && httpStatus >= 400) {
           if (apiTimestamp) {
-            this.logSdkError(sdkPrep, e, acc, apiTimestamp)
+            this.logSdkError(sdkPrep, e, acc, apiTimestamp, e.__kiroEndpointMode || sdkEndpointMode)
           }
 
           const mockResponse = new Response(
@@ -197,6 +210,10 @@ export class RequestHandler {
           throw new Error(`Kiro Error: ${httpStatus}`)
         }
 
+        if (httpStatus) {
+          logger.error('Kiro response stream failed after a successful HTTP response', e)
+        }
+
         const networkResult = await this.errorHandler.handleNetworkError(e, { retry }, showToast)
 
         if (networkResult.shouldRetry) {
@@ -221,11 +238,13 @@ export class RequestHandler {
     auth: KiroAuthDetails,
     think: boolean,
     budget: number,
+    requestEffort?: Effort,
     showToast?: (message: string, variant: 'info' | 'warning' | 'success' | 'error') => void
   ): SdkPreparedRequest {
     return transformToSdkRequest(body, model, auth, think, budget, showToast, {
       effort: this.config.effort,
-      autoEffortMapping: this.config.auto_effort_mapping
+      autoEffortMapping: this.config.auto_effort_mapping,
+      requestEffort
     })
   }
 
@@ -241,10 +260,70 @@ export class RequestHandler {
     }
   }
 
-  private logSdkRequest(prep: SdkPreparedRequest, acc: ManagedAccount, timestamp: string): void {
+  private async sendSdkRequestWithEndpointFallback(
+    auth: KiroAuthDetails,
+    prep: SdkPreparedRequest
+  ): Promise<{ sdkResponse: any; endpointMode: ResolvedSdkEndpointMode }> {
+    const endpointModes = this.getSdkEndpointModes(prep.region)
+    let lastError: any
+
+    for (let i = 0; i < endpointModes.length; i++) {
+      const endpointMode = endpointModes[i] || 'kiro-runtime'
+      try {
+        const client = createSdkClient(auth, prep.region, endpointMode, prep.effort)
+        const command = new GenerateAssistantResponseCommand({
+          conversationState: prep.conversationState as any,
+          profileArn: prep.profileArn
+        })
+        const sdkResponse = await client.send(command)
+        return { sdkResponse, endpointMode }
+      } catch (e: any) {
+        e.__kiroEndpointMode = endpointMode
+        lastError = e
+
+        if (i < endpointModes.length - 1 && this.shouldFallbackSdkEndpoint(e)) {
+          logger.warn('SDK endpoint failed; trying fallback endpoint', {
+            endpointMode,
+            fallbackEndpointMode: endpointModes[i + 1],
+            status: e?.$metadata?.httpStatusCode,
+            name: e?.name,
+            message: e?.message
+          })
+          continue
+        }
+
+        throw e
+      }
+    }
+
+    throw lastError
+  }
+
+  private getSdkEndpointModes(region: string): ResolvedSdkEndpointMode[] {
+    if (this.config.sdk_endpoint_mode === 'kiro-runtime') return ['kiro-runtime']
+    if (this.config.sdk_endpoint_mode === 'legacy-q') return ['legacy-q']
+    // Kiro documents q.<region>.amazonaws.com as legacy but still required until
+    // deprecation completes: https://kiro.dev/docs/cli/privacy-and-security/firewalls/
+    return deduplicateSdkEndpointModes(region, ['kiro-runtime', 'legacy-q'])
+  }
+
+  private shouldFallbackSdkEndpoint(error: any): boolean {
+    return shouldFallbackSdkEndpointError(error)
+  }
+
+  private formatSdkEndpointUrl(region: string, endpointMode: ResolvedSdkEndpointMode): string {
+    return `${getSdkEndpoint(region, endpointMode)}/generateAssistantResponse`
+  }
+
+  private logSdkRequest(
+    prep: SdkPreparedRequest,
+    acc: ManagedAccount,
+    timestamp: string,
+    endpointMode: ResolvedSdkEndpointMode
+  ): void {
     logger.logApiRequest(
       {
-        url: `https://q.${prep.region}.amazonaws.com/generateAssistantResponse`,
+        url: this.formatSdkEndpointUrl(prep.region, endpointMode),
         method: 'POST',
         headers: { 'x-amzn-kiro-agent-mode': 'vibe' },
         body: {
@@ -281,7 +360,8 @@ export class RequestHandler {
     prep: SdkPreparedRequest,
     error: any,
     acc: ManagedAccount,
-    apiTimestamp: string
+    apiTimestamp: string,
+    endpointMode: ResolvedSdkEndpointMode
   ): void {
     const status = error?.$metadata?.httpStatusCode || 0
     const rData = {
@@ -295,7 +375,7 @@ export class RequestHandler {
     if (!this.config.enable_log_api_request) {
       logger.logApiError(
         {
-          url: `https://q.${prep.region}.amazonaws.com/generateAssistantResponse`,
+          url: this.formatSdkEndpointUrl(prep.region, endpointMode),
           method: 'POST',
           headers: {},
           body: null,
@@ -339,12 +419,12 @@ export class RequestHandler {
     try {
       showToast('Session expired. Re-authenticating...', 'warning')
       await this.client.provider.oauth.authorize({
-        path: { id: 'kiro' },
+        path: { id: KIRO_PROVIDER_ID },
         body: { method: 0 }
       })
 
       await this.client.provider.oauth.callback({
-        path: { id: 'kiro' },
+        path: { id: KIRO_PROVIDER_ID },
         body: { method: 0 }
       })
 
@@ -385,5 +465,18 @@ export class RequestHandler {
 
   private sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms))
+  }
+
+  private extractReasoningEffort(body: any): Effort | undefined {
+    const value =
+      body?.reasoning_effort ||
+      body?.reasoningEffort ||
+      body?.providerOptions?.openaiCompatible?.reasoningEffort ||
+      body?.providerOptions?.openaiCompatible?.reasoning_effort ||
+      body?.providerOptions?.reasoningEffort
+
+    if (typeof value !== 'string') return undefined
+    const parsed = EffortSchema.safeParse(value.toLowerCase())
+    return parsed.success ? parsed.data : undefined
   }
 }

--- a/src/core/request/response-handler.ts
+++ b/src/core/request/response-handler.ts
@@ -7,10 +7,11 @@ export class ResponseHandler {
     response: Response,
     model: string,
     conversationId: string,
-    streaming: boolean
+    streaming: boolean,
+    thinkingRequested = false
   ): Promise<Response> {
     if (streaming) {
-      return this.handleStreaming(response, model, conversationId)
+      return this.handleStreaming(response, model, conversationId, thinkingRequested)
     }
     return this.handleNonStreaming(response, model, conversationId)
   }
@@ -19,10 +20,11 @@ export class ResponseHandler {
     sdkResponse: any,
     model: string,
     conversationId: string,
-    streaming: boolean
+    streaming: boolean,
+    thinkingRequested = false
   ): Promise<Response> {
     if (streaming) {
-      return this.handleSdkStreaming(sdkResponse, model, conversationId)
+      return this.handleSdkStreaming(sdkResponse, model, conversationId, thinkingRequested)
     }
     return this.handleSdkNonStreaming(sdkResponse, model, conversationId)
   }
@@ -30,9 +32,10 @@ export class ResponseHandler {
   private async handleStreaming(
     response: Response,
     model: string,
-    conversationId: string
+    conversationId: string,
+    thinkingRequested: boolean
   ): Promise<Response> {
-    const s = transformKiroStream(response, model, conversationId)
+    const s = transformKiroStream(response, model, conversationId, thinkingRequested)
     return new Response(
       new ReadableStream({
         async start(c) {
@@ -53,9 +56,10 @@ export class ResponseHandler {
   private async handleSdkStreaming(
     sdkResponse: any,
     model: string,
-    conversationId: string
+    conversationId: string,
+    thinkingRequested: boolean
   ): Promise<Response> {
-    const s = transformSdkStream(sdkResponse, model, conversationId)
+    const s = transformSdkStream(sdkResponse, model, conversationId, thinkingRequested)
     return new Response(
       new ReadableStream({
         async start(c) {

--- a/src/core/request/sdk-endpoint-fallback.ts
+++ b/src/core/request/sdk-endpoint-fallback.ts
@@ -1,0 +1,43 @@
+import { getSdkEndpoint, type ResolvedSdkEndpointMode } from '../../plugin/sdk-client'
+
+export function shouldFallbackSdkEndpointError(error: any): boolean {
+  const status = error?.$metadata?.httpStatusCode
+  if (status === 429) return false
+  if (status === 404 || status === 405) return true
+
+  const text = `${error?.name || ''} ${error?.code || ''} ${error?.message || ''}`.toLowerCase()
+  const networkFailure =
+    text.includes('failedtoopensocket') ||
+    text.includes('failed to open socket') ||
+    text.includes('enotfound') ||
+    text.includes('econnrefused') ||
+    text.includes('econnreset') ||
+    text.includes('etimedout') ||
+    text.includes('eai_again') ||
+    text.includes('socket hang up') ||
+    text.includes('connect timeout')
+  if (networkFailure) return true
+
+  const operationFailure =
+    text.includes('unknownoperation') ||
+    text.includes('unknown operation') ||
+    text.includes('unsupported operation') ||
+    text.includes('operation not found') ||
+    text.includes('method not allowed')
+  return (
+    operationFailure && (status === undefined || status === 400 || status === 404 || status === 405)
+  )
+}
+
+export function deduplicateSdkEndpointModes(
+  region: string,
+  endpointModes: ResolvedSdkEndpointMode[]
+): ResolvedSdkEndpointMode[] {
+  const urls = new Set<string>()
+  return endpointModes.filter((mode) => {
+    const url = getSdkEndpoint(region, mode)
+    if (urls.has(url)) return false
+    urls.add(url)
+    return true
+  })
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
-export { KiroOAuthPlugin } from './plugin.js'
+import { KIRO_PROVIDER_ID } from './constants.js'
 
+export { KIRO_LEGACY_PROVIDER_ID, KIRO_PROVIDER_ID } from './constants.js'
+export { authorizeKiroIDC } from './kiro/oauth-idc.js'
+export { createKiroPlugin, KiroOAuthPlugin } from './plugin.js'
 export type { KiroConfig } from './plugin/config/index.js'
-export type { KiroAuthMethod, KiroRegion, ManagedAccount } from './plugin/types.js'
+export type { KiroAuthDetails, KiroAuthMethod, KiroRegion, ManagedAccount } from './plugin/types.js'
 
-export default { id: 'kiro', server: (await import('./plugin.js')).KiroOAuthPlugin }
+export default { id: KIRO_PROVIDER_ID, server: (await import('./plugin.js')).KiroOAuthPlugin }

--- a/src/infrastructure/database/account-repository.ts
+++ b/src/infrastructure/database/account-repository.ts
@@ -22,6 +22,7 @@ export class AccountRepository {
       profileArn: r.profile_arn,
       startUrl: r.start_url || undefined,
       refreshToken: r.refresh_token,
+      refreshTokenUpdatedAt: r.refresh_token_updated_at || 0,
       accessToken: r.access_token,
       expiresAt: r.expires_at,
       rateLimitResetTime: r.rate_limit_reset,
@@ -32,6 +33,7 @@ export class AccountRepository {
       lastUsed: r.last_used,
       usedCount: r.used_count,
       limitCount: r.limit_count,
+      subscriptionPlan: r.subscription_plan || undefined,
       lastSync: r.last_sync
     }))
 

--- a/src/infrastructure/transformers/history-builder.ts
+++ b/src/infrastructure/transformers/history-builder.ts
@@ -5,7 +5,7 @@ import {
   extractTextFromParts
 } from '../../plugin/image-handler.js'
 import type { CodeWhispererMessage } from '../../plugin/types'
-import { getContentText } from './message-transformer.js'
+import { SYNTHETIC_TURN_CONTENT, getContentText } from './message-transformer.js'
 import { deduplicateToolResults } from './tool-transformer.js'
 
 /**
@@ -56,7 +56,7 @@ export function collapseAgenticLoops(history: CodeWhispererMessage[]): CodeWhisp
           } else {
             result.push({
               assistantResponseMessage: {
-                content: '[system: tool calling continues]',
+                content: SYNTHETIC_TURN_CONTENT,
                 toolUses: asst!.assistantResponseMessage!.toolUses
               }
             })
@@ -116,7 +116,7 @@ export function buildHistory(msgs: any[], resolved: string): CodeWhispererMessag
       if (trs.length) uim.userInputMessageContext = { toolResults: deduplicateToolResults(trs) }
       const prev = history[history.length - 1]
       if (prev && prev.userInputMessage)
-        history.push({ assistantResponseMessage: { content: '[system: conversation continues]' } })
+        history.push({ assistantResponseMessage: { content: SYNTHETIC_TURN_CONTENT } })
       history.push({ userInputMessage: uim })
     } else if (m.role === 'tool') {
       const trs: any[] = []
@@ -136,7 +136,7 @@ export function buildHistory(msgs: any[], resolved: string): CodeWhispererMessag
       }
       const prev = history[history.length - 1]
       if (prev && prev.userInputMessage)
-        history.push({ assistantResponseMessage: { content: '[system: conversation continues]' } })
+        history.push({ assistantResponseMessage: { content: SYNTHETIC_TURN_CONTENT } })
       history.push({
         userInputMessage: {
           content: 'Tool results provided.',

--- a/src/infrastructure/transformers/history-builder.ts
+++ b/src/infrastructure/transformers/history-builder.ts
@@ -5,7 +5,7 @@ import {
   extractTextFromParts
 } from '../../plugin/image-handler.js'
 import type { CodeWhispererMessage } from '../../plugin/types'
-import { SYNTHETIC_TURN_CONTENT, getContentText } from './message-transformer.js'
+import { SYNTHETIC_TURN_CONTENT, getContentText, getToolResultText } from './message-transformer.js'
 import { deduplicateToolResults } from './tool-transformer.js'
 
 /**
@@ -94,7 +94,7 @@ export function buildHistory(msgs: any[], resolved: string): CodeWhispererMessag
         for (const p of m.content) {
           if (p.type === 'tool_result') {
             trs.push({
-              content: [{ text: getContentText(p.content || p) }],
+              content: [{ text: getToolResultText(p.content || p) }],
               status: 'success',
               toolUseId: p.tool_use_id
             })
@@ -123,13 +123,13 @@ export function buildHistory(msgs: any[], resolved: string): CodeWhispererMessag
       if (m.tool_results) {
         for (const tr of m.tool_results)
           trs.push({
-            content: [{ text: getContentText(tr) }],
+            content: [{ text: getToolResultText(tr) }],
             status: 'success',
             toolUseId: tr.tool_call_id
           })
       } else {
         trs.push({
-          content: [{ text: getContentText(m) }],
+          content: [{ text: getToolResultText(m) }],
           status: 'success',
           toolUseId: m.tool_call_id
         })

--- a/src/infrastructure/transformers/message-transformer.ts
+++ b/src/infrastructure/transformers/message-transformer.ts
@@ -4,6 +4,14 @@ import type { CodeWhispererMessage } from '../../plugin/types'
 // because visible filler can be learned and echoed as an assistant response.
 export const SYNTHETIC_TURN_CONTENT = '\u2063'
 
+export function getToolResultText(value: any): string {
+  return unwrapSystemReminders(getContentText(value))
+}
+
+function unwrapSystemReminders(text: string): string {
+  return text.replace(/<system-reminder>\s*([\s\S]*?)\s*<\/system-reminder>/g, '$1')
+}
+
 export function sanitizeHistory(history: CodeWhispererMessage[]): CodeWhispererMessage[] {
   const result: CodeWhispererMessage[] = []
   for (let i = 0; i < history.length; i++) {
@@ -85,6 +93,12 @@ export function mergeAdjacentMessages(msgs: any[]): any[] {
 export function getContentText(m: any): string {
   if (!m) return ''
   if (typeof m === 'string') return m
+  if (Array.isArray(m)) {
+    return m
+      .filter((part: any) => part?.type === 'text' || typeof part?.text === 'string')
+      .map((part: any) => part.text || '')
+      .join('')
+  }
   if (typeof m.content === 'string') return m.content
   if (Array.isArray(m.content))
     return m.content

--- a/src/infrastructure/transformers/message-transformer.ts
+++ b/src/infrastructure/transformers/message-transformer.ts
@@ -4,6 +4,9 @@ import type { CodeWhispererMessage } from '../../plugin/types'
 // because visible filler can be learned and echoed as an assistant response.
 export const SYNTHETIC_TURN_CONTENT = '\u2063'
 
+// Unlike history padding, the active user turn must give the model an actionable instruction.
+export const CONTINUE_TURN_CONTENT = 'Continue.'
+
 export function getToolResultText(value: any): string {
   return unwrapSystemReminders(getContentText(value))
 }

--- a/src/infrastructure/transformers/message-transformer.ts
+++ b/src/infrastructure/transformers/message-transformer.ts
@@ -1,5 +1,9 @@
 import type { CodeWhispererMessage } from '../../plugin/types'
 
+// Kiro requires synthetic turns in a few alternation gaps. Keep them nonempty but invisible
+// because visible filler can be learned and echoed as an assistant response.
+export const SYNTHETIC_TURN_CONTENT = '\u2063'
+
 export function sanitizeHistory(history: CodeWhispererMessage[]): CodeWhispererMessage[] {
   const result: CodeWhispererMessage[] = []
   for (let i = 0; i < history.length; i++) {

--- a/src/kiro/oauth-idc.ts
+++ b/src/kiro/oauth-idc.ts
@@ -1,5 +1,11 @@
-import { KIRO_AUTH_SERVICE, KIRO_CONSTANTS, buildUrl, normalizeRegion } from '../constants'
+import { KIRO_AUTH_SERVICE, KIRO_CONSTANTS, getOidcEndpoint, normalizeRegion } from '../constants'
 import type { KiroRegion } from '../plugin/types'
+import {
+  deleteCachedOidcClient,
+  getCachedOidcClient,
+  putCachedOidcClient,
+  type CachedOidcClient
+} from './oidc-client-cache'
 
 export interface KiroIDCAuthorization {
   verificationUrl: string
@@ -25,15 +31,17 @@ export interface KiroIDCTokenResult {
   authMethod: 'idc'
 }
 
+const OIDC_REQUEST_TIMEOUT_MS = 30000
+
 export async function authorizeKiroIDC(
   region?: KiroRegion,
   startUrl?: string
 ): Promise<KiroIDCAuthorization> {
   const effectiveRegion = normalizeRegion(region)
-  const ssoOIDCEndpoint = buildUrl(KIRO_AUTH_SERVICE.SSO_OIDC_ENDPOINT, effectiveRegion)
+  const ssoOIDCEndpoint = getOidcEndpoint(effectiveRegion)
   const effectiveStartUrl = startUrl || KIRO_AUTH_SERVICE.BUILDER_ID_START_URL
 
-  try {
+  const registerClient = async (): Promise<CachedOidcClient> => {
     const registerResponse = await fetch(`${ssoOIDCEndpoint}/client/register`, {
       method: 'POST',
       headers: {
@@ -45,7 +53,8 @@ export async function authorizeKiroIDC(
         clientType: 'public',
         scopes: KIRO_AUTH_SERVICE.SCOPES,
         grantTypes: ['urn:ietf:params:oauth:grant-type:device_code', 'refresh_token']
-      })
+      }),
+      signal: AbortSignal.timeout(OIDC_REQUEST_TIMEOUT_MS)
     })
 
     if (!registerResponse.ok) {
@@ -55,13 +64,19 @@ export async function authorizeKiroIDC(
     }
 
     const registerData = await registerResponse.json()
-    const { clientId, clientSecret } = registerData
+    const { clientId, clientSecret, clientSecretExpiresAt } = registerData
 
     if (!clientId || !clientSecret) {
       const error = new Error('Client registration response missing clientId or clientSecret')
       throw error
     }
 
+    const client = { clientId, clientSecret, clientSecretExpiresAt }
+    putCachedOidcClient(effectiveRegion, effectiveStartUrl, KIRO_AUTH_SERVICE.SCOPES, client)
+    return client
+  }
+
+  const startDeviceAuthorization = async (client: CachedOidcClient) => {
     const deviceAuthResponse = await fetch(`${ssoOIDCEndpoint}/device_authorization`, {
       method: 'POST',
       headers: {
@@ -69,10 +84,11 @@ export async function authorizeKiroIDC(
         'User-Agent': KIRO_CONSTANTS.USER_AGENT
       },
       body: JSON.stringify({
-        clientId,
-        clientSecret,
+        clientId: client.clientId,
+        clientSecret: client.clientSecret,
         startUrl: effectiveStartUrl
-      })
+      }),
+      signal: AbortSignal.timeout(OIDC_REQUEST_TIMEOUT_MS)
     })
 
     if (!deviceAuthResponse.ok) {
@@ -104,14 +120,28 @@ export async function authorizeKiroIDC(
       verificationUriComplete,
       userCode,
       deviceCode,
-      clientId,
-      clientSecret,
+      clientId: client.clientId,
+      clientSecret: client.clientSecret,
       interval,
       expiresIn,
       region: effectiveRegion,
       startUrl: effectiveStartUrl
     }
+  }
+
+  let client =
+    getCachedOidcClient(effectiveRegion, effectiveStartUrl, KIRO_AUTH_SERVICE.SCOPES) ||
+    (await registerClient())
+
+  try {
+    return await startDeviceAuthorization(client)
   } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    if (/invalid_client|expired/i.test(message)) {
+      deleteCachedOidcClient(effectiveRegion, effectiveStartUrl, KIRO_AUTH_SERVICE.SCOPES)
+      client = await registerClient()
+      return await startDeviceAuthorization(client)
+    }
     throw error
   }
 }
@@ -130,18 +160,31 @@ export async function pollKiroIDCToken(
   }
 
   const effectiveRegion = normalizeRegion(region)
-  const ssoOIDCEndpoint = buildUrl(KIRO_AUTH_SERVICE.SSO_OIDC_ENDPOINT, effectiveRegion)
+  const ssoOIDCEndpoint = getOidcEndpoint(effectiveRegion)
 
-  const maxAttempts = Math.floor(expiresIn / interval)
-  let currentInterval = interval * 1000
+  if (
+    !Number.isFinite(interval) ||
+    interval <= 0 ||
+    !Number.isFinite(expiresIn) ||
+    expiresIn <= 0
+  ) {
+    throw new Error('Token polling received an invalid interval or expiration')
+  }
+
+  const deadline = Date.now() + expiresIn * 1000
+  let currentInterval = Math.max(interval, 1) * 1000
   let attempts = 0
 
-  while (attempts < maxAttempts) {
+  while (Date.now() < deadline) {
     attempts++
 
-    await new Promise((resolve) => setTimeout(resolve, currentInterval))
+    const sleepMs = Math.min(currentInterval, deadline - Date.now())
+    if (sleepMs <= 0) break
+    await new Promise((resolve) => setTimeout(resolve, sleepMs))
+    if (Date.now() >= deadline) break
 
     try {
+      const remainingMs = Math.max(1, deadline - Date.now())
       const tokenResponse = await fetch(`${ssoOIDCEndpoint}/token`, {
         method: 'POST',
         headers: {
@@ -153,7 +196,8 @@ export async function pollKiroIDCToken(
           clientSecret,
           deviceCode,
           grantType: 'urn:ietf:params:oauth:grant-type:device_code'
-        })
+        }),
+        signal: AbortSignal.timeout(Math.min(30000, remainingMs))
       })
 
       const responseText = await tokenResponse.text().catch(() => '')
@@ -234,19 +278,18 @@ export async function pollKiroIDCToken(
     } catch (error) {
       if (
         error instanceof Error &&
-        (error.message.includes('expired') ||
-          error.message.includes('denied') ||
-          error.message.includes('failed'))
+        (error.message.includes('Device code has expired') ||
+          error.message.includes('Authorization was denied') ||
+          error.message.startsWith('Token polling failed:') ||
+          error.message.startsWith('Token request failed'))
       ) {
         throw error
       }
 
-      if (attempts >= maxAttempts) {
-        const finalError = new Error(
+      if (Date.now() >= deadline)
+        throw new Error(
           `Token polling failed after ${attempts} attempts: ${error instanceof Error ? error.message : 'Unknown error'}`
         )
-        throw finalError
-      }
     }
   }
 

--- a/src/kiro/oidc-client-cache.ts
+++ b/src/kiro/oidc-client-cache.ts
@@ -1,0 +1,93 @@
+import { createHash } from 'node:crypto'
+import { existsSync, readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { atomicWritePrivateJsonFile, withInterprocessFileLock } from '../plugin/opencode-auth.js'
+import type { KiroRegion } from '../plugin/types'
+
+const CACHE_FILENAME = 'kiro-oidc-clients.json'
+const EXPIRY_SAFETY_MS = 24 * 60 * 60 * 1000
+
+export interface CachedOidcClient {
+  clientId: string
+  clientSecret: string
+  clientSecretExpiresAt?: number
+}
+
+function getConfigDir(): string {
+  const platform = process.platform
+  if (platform === 'win32') {
+    return join(process.env.APPDATA || join(homedir(), 'AppData', 'Roaming'), 'opencode')
+  }
+  const xdgConfig = process.env.XDG_CONFIG_HOME || join(homedir(), '.config')
+  return join(xdgConfig, 'opencode')
+}
+
+function cachePath(): string {
+  return join(getConfigDir(), CACHE_FILENAME)
+}
+
+function cacheKey(region: KiroRegion, startUrl: string, scopes: readonly string[]): string {
+  return createHash('sha256')
+    .update(`${region}\0${startUrl}\0${scopes.join(' ')}`)
+    .digest('hex')
+}
+
+function readCache(): Record<string, CachedOidcClient> | null {
+  const path = cachePath()
+  if (!existsSync(path)) return {}
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8'))
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+function updateCache(update: (cache: Record<string, CachedOidcClient>) => void): void {
+  const path = cachePath()
+  withInterprocessFileLock(path, () => {
+    const cache = readCache()
+    if (!cache) return
+    update(cache)
+    atomicWritePrivateJsonFile(path, cache)
+  })
+}
+
+export function getCachedOidcClient(
+  region: KiroRegion,
+  startUrl: string,
+  scopes: readonly string[]
+): CachedOidcClient | undefined {
+  const cache = readCache()
+  const hit = cache?.[cacheKey(region, startUrl, scopes)]
+  if (!hit?.clientId || !hit.clientSecret) return undefined
+  if (
+    hit.clientSecretExpiresAt &&
+    hit.clientSecretExpiresAt * 1000 <= Date.now() + EXPIRY_SAFETY_MS
+  ) {
+    return undefined
+  }
+  return hit
+}
+
+export function putCachedOidcClient(
+  region: KiroRegion,
+  startUrl: string,
+  scopes: readonly string[],
+  client: CachedOidcClient
+): void {
+  updateCache((cache) => {
+    cache[cacheKey(region, startUrl, scopes)] = client
+  })
+}
+
+export function deleteCachedOidcClient(
+  region: KiroRegion,
+  startUrl: string,
+  scopes: readonly string[]
+): void {
+  updateCache((cache) => {
+    delete cache[cacheKey(region, startUrl, scopes)]
+  })
+}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,9 @@
-import { KIRO_CONSTANTS } from './constants.js'
+import {
+  DEFAULT_PROVIDER_MODELS,
+  KIRO_CONSTANTS,
+  KIRO_LEGACY_PROVIDER_ID,
+  KIRO_PROVIDER_ID
+} from './constants.js'
 import { AuthHandler } from './core/auth/auth-handler.js'
 import { RequestHandler } from './core/request/request-handler.js'
 import { AccountCache } from './infrastructure/database/account-cache.js'
@@ -6,10 +11,27 @@ import { AccountRepository } from './infrastructure/database/account-repository.
 import { AccountManager } from './plugin/accounts.js'
 import { bootstrapAuthIfNeeded } from './plugin/auth-bootstrap.js'
 import { loadConfig } from './plugin/config/index.js'
+import { ensureOpenCodeAuthPlaceholder } from './plugin/opencode-auth.js'
 
 type ToastFunction = (message: string, variant: string) => void
 
-const KIRO_PROVIDER_ID = 'kiro'
+function mergeProviderModels(existing: Record<string, any> | undefined): Record<string, any> {
+  const merged: Record<string, any> = { ...(existing || {}) }
+
+  for (const [modelID, defaults] of Object.entries(DEFAULT_PROVIDER_MODELS)) {
+    const current = merged[modelID] || {}
+    const variants = { ...(defaults as any).variants, ...current.variants }
+    merged[modelID] = {
+      ...defaults,
+      ...current,
+      limit: { ...(defaults as any).limit, ...current.limit },
+      modalities: { ...(defaults as any).modalities, ...current.modalities },
+      ...(Object.keys(variants).length > 0 ? { variants } : {})
+    }
+  }
+
+  return merged
+}
 
 export const createKiroPlugin =
   (id: string) =>
@@ -29,11 +51,15 @@ export const createKiroPlugin =
 
     const requestHandler = new RequestHandler(accountManager, config, repository, client)
 
-    // Compute the base URL once so both the config hook and auth loader use the same value
     const baseURL = KIRO_CONSTANTS.BASE_URL.replace('/generateAssistantResponse', '').replace(
       '{{region}}',
-      config.default_region || 'us-east-1'
+      config.default_region || KIRO_CONSTANTS.DEFAULT_REGION
     )
+
+    await authHandler.initialize(showToast as any)
+    if (accountManager.getAccountCount() > 0) {
+      ensureOpenCodeAuthPlaceholder(id)
+    }
 
     return {
       config: async (input: any) => {
@@ -42,104 +68,25 @@ export const createKiroPlugin =
         bootstrapAuthIfNeeded(id)
 
         if (!input.provider) input.provider = {}
+        if (
+          id === KIRO_PROVIDER_ID &&
+          input.provider[KIRO_LEGACY_PROVIDER_ID] &&
+          !input.provider[id]
+        ) {
+          input.provider[id] = input.provider[KIRO_LEGACY_PROVIDER_ID]
+        }
         if (!input.provider[id]) input.provider[id] = {}
-        // Always set npm and api — these must be present regardless of whether
-        // the user has already defined the provider in their opencode.json.
+        if (!input.provider[id].name) input.provider[id].name = 'Kiro'
         input.provider[id].npm = '@ai-sdk/openai-compatible'
-        // Set the base URL at the provider level. OpenCode reads provider.api as
-        // model.api.url, which resolveSDK() uses to construct the endpoint URL.
-        // Only set if not already overridden by the user.
         if (!input.provider[id].api) {
           input.provider[id].api = baseURL
         }
-        if (!input.provider[id].models) {
-          input.provider[id].models = {
-            auto: {
-              name: 'Auto (1.0x)',
-              limit: { context: 200000, output: 64000 },
-              modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
-            },
-            // Claude Sonnet
-            'claude-sonnet-4': {
-              name: 'Claude Sonnet 4.0 (1.3x)',
-              limit: { context: 200000, output: 64000 },
-              modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
-            },
-            'claude-sonnet-4-5': {
-              name: 'Claude Sonnet 4.5 (1.3x)',
-              limit: { context: 200000, output: 64000 },
-              modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
-            },
-            'claude-sonnet-4-6': {
-              name: 'Claude Sonnet 4.6 (1.3x)',
-              limit: { context: 1000000, output: 64000 },
-              modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
-            },
-            // Claude Haiku
-            'claude-haiku-4-5': {
-              name: 'Claude Haiku 4.5 (0.4x)',
-              limit: { context: 200000, output: 64000 },
-              modalities: { input: ['text', 'image'], output: ['text'] }
-            },
-            // Claude Opus
-            'claude-opus-4-5': {
-              name: 'Claude Opus 4.5 (2.2x)',
-              limit: { context: 200000, output: 64000 },
-              modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
-            },
-            'claude-opus-4-6': {
-              name: 'Claude Opus 4.6 (2.2x)',
-              limit: { context: 1000000, output: 64000 },
-              modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
-            },
-            'claude-opus-4-7': {
-              name: 'Claude Opus 4.7 (2.2x)',
-              limit: { context: 1000000, output: 64000 },
-              modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
-            },
-            'claude-opus-4-8': {
-              name: 'Claude Opus 4.8 (2.2x)',
-              limit: { context: 1000000, output: 64000 },
-              modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
-            },
-            'claude-opus-4-8-thinking': {
-              name: 'Claude Opus 4.8 Thinking (2.2x)',
-              limit: { context: 1000000, output: 64000 },
-              modalities: { input: ['text', 'image', 'pdf'], output: ['text'] }
-            },
-            // Open weight models
-            'deepseek-3.2': {
-              name: 'DeepSeek 3.2 (0.25x)',
-              limit: { context: 128000, output: 64000 },
-              modalities: { input: ['text'], output: ['text'] }
-            },
-            'glm-5': {
-              name: 'GLM-5 (0.5x)',
-              limit: { context: 200000, output: 64000 },
-              modalities: { input: ['text'], output: ['text'] }
-            },
-            'minimax-m2.5': {
-              name: 'MiniMax M2.5 (0.25x)',
-              limit: { context: 200000, output: 64000 },
-              modalities: { input: ['text'], output: ['text'] }
-            },
-            'minimax-m2.1': {
-              name: 'MiniMax M2.1 (0.15x)',
-              limit: { context: 200000, output: 64000 },
-              modalities: { input: ['text'], output: ['text'] }
-            },
-            'qwen3-coder-next': {
-              name: 'Qwen3 Coder Next (0.05x)',
-              limit: { context: 256000, output: 64000 },
-              modalities: { input: ['text'], output: ['text'] }
-            }
-          }
-        }
+        input.provider[id].models = mergeProviderModels(input.provider[id].models)
       },
       auth: {
         provider: id,
         loader: async (getAuth: any) => {
-          await getAuth()
+          await getAuth().catch(() => undefined)
           await authHandler.initialize(showToast as any)
 
           return {

--- a/src/plugin/accounts.ts
+++ b/src/plugin/accounts.ts
@@ -46,6 +46,7 @@ export class AccountManager {
       profileArn: r.profile_arn,
       startUrl: r.start_url || undefined,
       refreshToken: r.refresh_token,
+      refreshTokenUpdatedAt: r.refresh_token_updated_at || 0,
       accessToken: r.access_token,
       expiresAt: r.expires_at,
       rateLimitResetTime: r.rate_limit_reset,
@@ -55,7 +56,8 @@ export class AccountManager {
       failCount: r.fail_count || 0,
       lastUsed: r.last_used,
       usedCount: r.used_count,
-      limitCount: r.limit_count
+      limitCount: r.limit_count,
+      subscriptionPlan: r.subscription_plan || undefined
     }))
     return new AccountManager(accounts, strategy || 'sticky')
   }
@@ -125,18 +127,28 @@ export class AccountManager {
     }
     if (selected) {
       selected.lastUsed = now
-      selected.usedCount = (selected.usedCount || 0) + 1
       this.cursor = this.accounts.indexOf(selected)
       return selected
     }
     return null
   }
-  updateUsage(id: string, meta: { usedCount: number; limitCount: number; email?: string }): void {
+  updateUsage(
+    id: string,
+    meta: {
+      usedCount: number
+      limitCount: number
+      email?: string
+      subscriptionPlan?: string
+      lastSync?: number
+    }
+  ): void {
     const a = this.accounts.find((x) => x.id === id)
     if (a) {
       a.usedCount = meta.usedCount
       a.limitCount = meta.limitCount
+      if (meta.lastSync) a.lastSync = meta.lastSync
       if (meta.email) a.email = meta.email
+      if (meta.subscriptionPlan) a.subscriptionPlan = meta.subscriptionPlan
       if (!isPermanentError(a.unhealthyReason)) {
         a.failCount = 0
         a.isHealthy = true
@@ -182,12 +194,14 @@ export class AccountManager {
   updateFromAuth(a: ManagedAccount, auth: KiroAuthDetails): void {
     const acc = this.accounts.find((x) => x.id === a.id)
     if (acc) {
+      const previousRefreshToken = acc.refreshToken
       acc.accessToken = auth.access
       acc.expiresAt = auth.expires
       acc.lastUsed = Date.now()
       if (auth.email) acc.email = auth.email
       const p = decodeRefreshToken(auth.refresh)
       acc.refreshToken = p.refreshToken
+      acc.refreshTokenUpdatedAt = Date.now()
       if (p.profileArn) acc.profileArn = p.profileArn
       if (p.clientId) acc.clientId = p.clientId
       acc.failCount = 0
@@ -201,7 +215,7 @@ export class AccountManager {
           error: e instanceof Error ? e.message : String(e)
         })
       )
-      writeToKiroCli(acc).catch((e) =>
+      writeToKiroCli(acc, previousRefreshToken).catch((e) =>
         logger.warn('CLI write failed', {
           method: 'updateFromAuth',
           email: acc.email,

--- a/src/plugin/auth-bootstrap.ts
+++ b/src/plugin/auth-bootstrap.ts
@@ -1,52 +1,9 @@
-import {
-  chmodSync,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  renameSync,
-  statSync,
-  writeFileSync
-} from 'node:fs'
-import { homedir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { existsSync } from 'node:fs'
 import * as logger from './logger.js'
+import { updateOpenCodeAuthPlaceholder } from './opencode-auth.js'
 import { getCliDbPath } from './sync/kiro-cli-parser.js'
 
-function getOpenCodeAuthPath(): string {
-  const dataRoot =
-    process.platform === 'win32'
-      ? process.env.LOCALAPPDATA || join(homedir(), 'AppData', 'Local')
-      : process.env.XDG_DATA_HOME || join(homedir(), '.local', 'share')
-
-  return join(dataRoot, 'opencode', 'auth.json')
-}
-
-function readAuthFile(authPath: string): Record<string, any> | null {
-  if (!existsSync(authPath)) return {}
-
-  try {
-    const parsed = JSON.parse(readFileSync(authPath, 'utf-8'))
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      logger.warn('Bootstrap: auth.json is not an object, skipping placeholder auth setup')
-      return null
-    }
-    return parsed
-  } catch (e) {
-    logger.warn(
-      `Bootstrap: invalid auth.json, skipping placeholder auth setup: ${e instanceof Error ? e.message : String(e)}`
-    )
-    return null
-  }
-}
-
-function writeAuthFile(authPath: string, auth: Record<string, any>): void {
-  mkdirSync(dirname(authPath), { recursive: true })
-  const mode = existsSync(authPath) ? statSync(authPath).mode & 0o777 : 0o600
-  const tempPath = `${authPath}.${process.pid}.${Date.now()}.tmp`
-  writeFileSync(tempPath, JSON.stringify(auth, null, 2), { encoding: 'utf-8', mode })
-  chmodSync(tempPath, mode)
-  renameSync(tempPath, authPath)
-}
+const BOOTSTRAP_PLACEHOLDER_KEY = 'kiro-bootstrap-placeholder'
 
 /**
  * OpenCode only calls the auth loader when there is a stored auth entry for the
@@ -64,22 +21,13 @@ export function bootstrapAuthIfNeeded(providerId: string): void {
       return
     }
 
-    const authPath = getOpenCodeAuthPath()
-    const auth = readAuthFile(authPath)
-    if (!auth) return
-
-    if (auth[providerId]) {
-      return
+    const result = updateOpenCodeAuthPlaceholder(providerId, BOOTSTRAP_PLACEHOLDER_KEY)
+    if (result.status === 'unparseable') {
+      logger.warn(`Bootstrap: invalid auth.json, skipping placeholder auth setup: ${result.error}`)
+    } else if (result.status === 'updated') {
+      logger.log(`Bootstrap: wrote placeholder auth entry for provider "${providerId}"`)
+      logger.log('Bootstrap: auth.json updated - loader will run on next request')
     }
-
-    logger.log(`Bootstrap: writing placeholder auth entry for provider "${providerId}"`)
-    auth[providerId] = {
-      type: 'api',
-      key: 'kiro-bootstrap-placeholder'
-    }
-
-    writeAuthFile(authPath, auth)
-    logger.log('Bootstrap: auth.json updated — loader will run on next request')
   } catch (e) {
     logger.warn(`Bootstrap failed: ${e instanceof Error ? e.message : String(e)}`)
   }

--- a/src/plugin/config/index.ts
+++ b/src/plugin/config/index.ts
@@ -5,5 +5,5 @@ export {
   getUserConfigPath,
   loadConfig
 } from './loader'
-export { DEFAULT_CONFIG, KiroConfigSchema } from './schema'
-export type { KiroConfig } from './schema'
+export { DEFAULT_CONFIG, KiroConfigSchema, SdkEndpointModeSchema } from './schema'
+export type { KiroConfig, SdkEndpointMode } from './schema'

--- a/src/plugin/config/loader.ts
+++ b/src/plugin/config/loader.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_CONFIG,
   KiroConfigSchema,
   RegionSchema,
+  SdkEndpointModeSchema,
   type KiroConfig
 } from './schema'
 
@@ -102,7 +103,7 @@ function parseNumberEnv(value: string | undefined, fallback: number): number {
 function applyEnvOverrides(config: KiroConfig): KiroConfig {
   const env = process.env
 
-  return {
+  const overridden = {
     ...config,
 
     account_selection_strategy: env.KIRO_ACCOUNT_SELECTION_STRATEGY
@@ -114,6 +115,18 @@ function applyEnvOverrides(config: KiroConfig): KiroConfig {
     default_region: env.KIRO_DEFAULT_REGION
       ? RegionSchema.catch('us-east-1').parse(env.KIRO_DEFAULT_REGION)
       : config.default_region,
+
+    idc_start_url: env.KIRO_IDC_START_URL
+      ? String(env.KIRO_IDC_START_URL).trim()
+      : config.idc_start_url,
+
+    idc_region: env.KIRO_IDC_REGION
+      ? RegionSchema.catch(config.idc_region || config.default_region).parse(env.KIRO_IDC_REGION)
+      : config.idc_region,
+
+    idc_profile_arn: env.KIRO_IDC_PROFILE_ARN
+      ? String(env.KIRO_IDC_PROFILE_ARN).trim()
+      : config.idc_profile_arn,
 
     rate_limit_retry_delay_ms: parseNumberEnv(
       env.KIRO_RATE_LIMIT_RETRY_DELAY_MS,
@@ -157,11 +170,26 @@ function applyEnvOverrides(config: KiroConfig): KiroConfig {
       config.usage_tracking_enabled
     ),
 
+    auto_sync_kiro_cli: parseBooleanEnv(env.KIRO_AUTO_SYNC_KIRO_CLI, config.auto_sync_kiro_cli),
+
+    sdk_endpoint_mode: env.KIRO_SDK_ENDPOINT_MODE
+      ? SdkEndpointModeSchema.catch('auto').parse(env.KIRO_SDK_ENDPOINT_MODE)
+      : config.sdk_endpoint_mode,
+
     enable_log_api_request: parseBooleanEnv(
       env.KIRO_ENABLE_LOG_API_REQUEST,
       config.enable_log_api_request
-    )
+    ),
+
+    auto_effort_mapping: parseBooleanEnv(env.KIRO_AUTO_EFFORT_MAPPING, config.auto_effort_mapping)
   }
+
+  const result = KiroConfigSchema.safeParse(overridden)
+  if (result.success) return result.data
+
+  const issues = result.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join(', ')
+  logger.warn(`Environment config validation error: ${issues}`)
+  return config
 }
 
 export function loadConfig(directory: string): KiroConfig {

--- a/src/plugin/config/schema.ts
+++ b/src/plugin/config/schema.ts
@@ -3,61 +3,39 @@ import { z } from 'zod'
 export const AccountSelectionStrategySchema = z.enum(['sticky', 'round-robin', 'lowest-usage'])
 export type AccountSelectionStrategy = z.infer<typeof AccountSelectionStrategySchema>
 
-/**
- * Kiro effort levels control thinking/reasoning depth.
- * - low: minimal reasoning
- * - medium: balanced (default when thinking enabled)
- * - high: deeper reasoning
- * - xhigh: extended reasoning (opus-4.7, opus-4.8 only)
- * - max: maximum reasoning depth (128k thinking tokens on opus-4.7/4.8)
- */
+export const SdkEndpointModeSchema = z.enum(['auto', 'kiro-runtime', 'legacy-q'])
+export type SdkEndpointMode = z.infer<typeof SdkEndpointModeSchema>
+
 export const EffortSchema = z.enum(['low', 'medium', 'high', 'xhigh', 'max'])
 export type Effort = z.infer<typeof EffortSchema>
 
-export const RegionSchema = z.enum([
-  'us-east-1',
-  'us-east-2',
-  'us-west-1',
-  'us-west-2',
-  'af-south-1',
-  'ap-east-1',
-  'ap-south-2',
-  'ap-southeast-3',
-  'ap-southeast-5',
-  'ap-southeast-4',
-  'ap-south-1',
-  'ap-southeast-6',
-  'ap-northeast-3',
-  'ap-northeast-2',
-  'ap-southeast-1',
-  'ap-southeast-2',
-  'ap-east-2',
-  'ap-southeast-7',
-  'ap-northeast-1',
-  'ca-central-1',
-  'ca-west-1',
-  'eu-central-1',
-  'eu-west-1',
-  'eu-west-2',
-  'eu-south-1',
-  'eu-west-3',
-  'eu-south-2',
-  'eu-north-1',
-  'eu-central-2',
-  'il-central-1',
-  'mx-central-1',
-  'me-south-1',
-  'me-central-1',
-  'sa-east-1'
-])
+const RegionStringSchema = z
+  .string()
+  .trim()
+  .regex(
+    /^(us|us-gov|af|ap|ca|cn|eu|il|me|mx|sa)-[a-z0-9-]+-\d+$/,
+    'Please enter a valid AWS region'
+  )
+
+export const RegionSchema = RegionStringSchema
 export type Region = z.infer<typeof RegionSchema>
+
+const OptionalTrimmedUrlSchema = z.preprocess(
+  (value) => (typeof value === 'string' && value.trim() ? value.trim() : undefined),
+  z.string().url().optional()
+)
+
+const OptionalTrimmedStringSchema = z.preprocess(
+  (value) => (typeof value === 'string' && value.trim() ? value.trim() : undefined),
+  z.string().optional()
+)
 
 export const KiroConfigSchema = z.object({
   $schema: z.string().optional(),
 
-  idc_start_url: z.string().url().optional(),
+  idc_start_url: OptionalTrimmedUrlSchema,
   idc_region: RegionSchema.optional(),
-  idc_profile_arn: z.string().optional(),
+  idc_profile_arn: OptionalTrimmedStringSchema,
 
   account_selection_strategy: AccountSelectionStrategySchema.default('lowest-usage'),
 
@@ -81,21 +59,10 @@ export const KiroConfigSchema = z.object({
 
   usage_tracking_enabled: z.boolean().default(true),
   auto_sync_kiro_cli: z.boolean().default(true),
+  sdk_endpoint_mode: SdkEndpointModeSchema.default('auto'),
   enable_log_api_request: z.boolean().default(false),
-
-  /**
-   * Default effort level for thinking models. Controls reasoning depth.
-   * When set, this overrides the automatic budget-based mapping.
-   * Values: 'low', 'medium', 'high', 'xhigh' (opus-4.7/4.8 only), 'max'
-   */
   effort: EffortSchema.optional(),
-
-  /**
-   * Enable automatic effort mapping from OpenCode's thinking budget.
-   * When true (default), maps budget ranges to effort levels.
-   * When false, only uses explicit effort config or falls back to 'medium'.
-   */
-  auto_effort_mapping: z.boolean().default(true)
+  auto_effort_mapping: z.boolean().default(false)
 })
 
 export type KiroConfig = z.infer<typeof KiroConfigSchema>
@@ -113,6 +80,7 @@ export const DEFAULT_CONFIG: KiroConfig = {
   auth_server_port_range: 10,
   usage_tracking_enabled: true,
   auto_sync_kiro_cli: true,
+  sdk_endpoint_mode: 'auto',
   enable_log_api_request: false,
-  auto_effort_mapping: true
+  auto_effort_mapping: false
 }

--- a/src/plugin/effort.ts
+++ b/src/plugin/effort.ts
@@ -5,22 +5,27 @@ import type { Effort } from './config/schema'
  */
 export const EFFORT_LEVELS: readonly Effort[] = ['low', 'medium', 'high', 'xhigh', 'max'] as const
 
+export type EffortSchemaPath = 'output_config' | 'reasoning'
+
+const REASONING_EFFORT_MODELS = new Set(['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'])
+
 /**
  * Models that support the 5-value effort enum (including xhigh).
- * These models support up to 128k thinking tokens with max effort.
  */
-const XHIGH_CAPABLE_MODELS = new Set(['claude-opus-4.7', 'claude-opus-4.8'])
+const XHIGH_CAPABLE_MODELS = new Set([
+  'gpt-5.6-sol',
+  'gpt-5.6-terra',
+  'gpt-5.6-luna',
+  'claude-opus-4.7',
+  'claude-opus-4.8'
+])
 
 /**
  * Models that support the 4-value effort enum (no xhigh).
- * xhigh requests on these models are clamped to max.
  */
 const EFFORT_CAPABLE_MODELS = new Set([
-  'claude-opus-4.5',
   'claude-opus-4.6',
   'claude-opus-4.6-1m',
-  'claude-sonnet-4.5',
-  'claude-sonnet-4.5-1m',
   'claude-sonnet-4.6',
   'claude-sonnet-4.6-1m',
   ...XHIGH_CAPABLE_MODELS
@@ -40,19 +45,23 @@ export function supportsXHighEffort(kiroModel: string): boolean {
   return XHIGH_CAPABLE_MODELS.has(kiroModel)
 }
 
+export function getEffortSchemaPath(kiroModel: string): EffortSchemaPath | undefined {
+  if (!supportsEffort(kiroModel)) return undefined
+  return REASONING_EFFORT_MODELS.has(kiroModel) ? 'reasoning' : 'output_config'
+}
+
 /**
  * Resolve effort level for a given model.
  * - Returns undefined if model doesn't support effort
- * - Clamps xhigh to max for models that don't support it
+ * - Returns undefined when the requested level is unsupported by the model
  */
 export function resolveEffort(kiroModel: string, requested: Effort): Effort | undefined {
   if (!supportsEffort(kiroModel)) {
     return undefined
   }
 
-  // xhigh is only supported on opus-4.7 and opus-4.8
   if (requested === 'xhigh' && !supportsXHighEffort(kiroModel)) {
-    return 'max'
+    return undefined
   }
 
   return requested
@@ -107,13 +116,19 @@ export function getEffectiveEffort(
   thinking: boolean,
   budget: number,
   configEffort?: Effort,
-  autoEffortMapping = true
+  autoEffortMapping = false,
+  requestEffort?: Effort
 ): Effort | undefined {
   if (!supportsEffort(kiroModel)) {
     return undefined
   }
 
-  // Explicit config takes precedence - always applied even without thinking
+  // A selected OpenCode model variant is specific to this request.
+  if (requestEffort) {
+    return resolveEffort(kiroModel, requestEffort)
+  }
+
+  // Explicit config applies even without thinking.
   if (configEffort) {
     return resolveEffort(kiroModel, configEffort)
   }

--- a/src/plugin/models.ts
+++ b/src/plugin/models.ts
@@ -1,7 +1,7 @@
-import { MODEL_MAPPING, SUPPORTED_MODELS, isLongContextModel } from '../constants'
+import { SUPPORTED_MODELS, getKiroApiModelId, getModelContextWindow } from '../constants'
 
 export function resolveKiroModel(model: string): string {
-  const resolved = MODEL_MAPPING[model]
+  const resolved = getKiroApiModelId(model)
   if (!resolved) {
     throw new Error(`Unsupported model: ${model}. Supported models: ${SUPPORTED_MODELS.join(', ')}`)
   }
@@ -9,5 +9,5 @@ export function resolveKiroModel(model: string): string {
 }
 
 export function getContextWindowSize(model: string): number {
-  return isLongContextModel(model) ? 1000000 : 200000
+  return getModelContextWindow(model)
 }

--- a/src/plugin/opencode-auth.ts
+++ b/src/plugin/opencode-auth.ts
@@ -1,0 +1,152 @@
+import { randomUUID } from 'node:crypto'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+import lockfile from 'proper-lockfile'
+import { KIRO_LEGACY_PROVIDER_ID, KIRO_PROVIDER_ID } from '../constants'
+import * as logger from './logger'
+
+const PLACEHOLDER_KEY = 'opencode-kiro-auth-placeholder'
+const LOCK_RETRY_MS = 25
+const LOCK_TIMEOUT_MS = 5000
+const lockWaitBuffer = new Int32Array(new SharedArrayBuffer(4))
+
+function getDataDir(): string {
+  const dataRoot =
+    process.platform === 'win32'
+      ? process.env.LOCALAPPDATA || join(homedir(), 'AppData', 'Local')
+      : process.env.XDG_DATA_HOME || join(homedir(), '.local', 'share')
+  return join(dataRoot, 'opencode')
+}
+
+export function getOpenCodeAuthPath(): string {
+  return join(getDataDir(), 'auth.json')
+}
+
+type ReadAuthResult =
+  | { status: 'ok'; data: Record<string, any> }
+  | { status: 'missing' }
+  | { status: 'unparseable'; error?: string }
+
+function readAuthFile(path: string): ReadAuthResult {
+  if (!existsSync(path)) return { status: 'missing' }
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8'))
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return { status: 'ok', data: parsed }
+    }
+    // Valid JSON but not an object (e.g. an array or scalar). Treat it as
+    // unparseable so we never clobber an unexpected file shape.
+    return { status: 'unparseable', error: 'auth.json is not an object' }
+  } catch (error) {
+    return {
+      status: 'unparseable',
+      error: error instanceof Error ? error.message : String(error)
+    }
+  }
+}
+
+export function withInterprocessFileLock<T>(path: string, operation: () => T): T {
+  mkdirSync(dirname(path), { recursive: true })
+  const deadline = Date.now() + LOCK_TIMEOUT_MS
+  let release: (() => void) | undefined
+
+  while (!release) {
+    try {
+      release = lockfile.lockSync(path, { realpath: false, stale: 10000 })
+    } catch (error) {
+      if (
+        !(error && typeof error === 'object' && 'code' in error && error.code === 'ELOCKED') ||
+        Date.now() >= deadline
+      ) {
+        throw error
+      }
+      Atomics.wait(lockWaitBuffer, 0, 0, LOCK_RETRY_MS)
+    }
+  }
+
+  try {
+    return operation()
+  } finally {
+    release()
+  }
+}
+
+export function atomicWritePrivateJsonFile(path: string, data: unknown): void {
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 })
+  const tempPath = `${path}.${process.pid}.${randomUUID()}.tmp`
+  try {
+    writeFileSync(tempPath, JSON.stringify(data, null, 2), { encoding: 'utf-8', mode: 0o600 })
+    if (process.platform !== 'win32') chmodSync(tempPath, 0o600)
+    renameSync(tempPath, path)
+  } finally {
+    rmSync(tempPath, { force: true })
+  }
+}
+
+export type OpenCodeAuthUpdateResult =
+  { status: 'updated' } | { status: 'unchanged' } | { status: 'unparseable'; error?: string }
+
+export function updateOpenCodeAuthPlaceholder(
+  providerID: string,
+  placeholderKey: string
+): OpenCodeAuthUpdateResult {
+  const path = getOpenCodeAuthPath()
+  return withInterprocessFileLock(path, () => {
+    // Read only after acquiring the lock so concurrent provider updates are merged.
+    const result = readAuthFile(path)
+    if (result.status === 'unparseable') return result
+
+    const data = result.status === 'ok' ? result.data : {}
+    let changed = false
+
+    if (
+      providerID === KIRO_PROVIDER_ID &&
+      data[KIRO_LEGACY_PROVIDER_ID] &&
+      !data[KIRO_PROVIDER_ID]
+    ) {
+      data[KIRO_PROVIDER_ID] = data[KIRO_LEGACY_PROVIDER_ID]
+      changed = true
+    }
+
+    if (!data[providerID]) {
+      data[providerID] = { type: 'api', key: placeholderKey }
+      changed = true
+    }
+
+    if (!changed) {
+      if (process.platform !== 'win32' && result.status === 'ok') chmodSync(path, 0o600)
+      return { status: 'unchanged' }
+    }
+
+    atomicWritePrivateJsonFile(path, data)
+    return { status: 'updated' }
+  })
+}
+
+export function ensureOpenCodeAuthPlaceholder(providerID = KIRO_PROVIDER_ID): void {
+  try {
+    const result = updateOpenCodeAuthPlaceholder(providerID, PLACEHOLDER_KEY)
+    if (result.status === 'unparseable') {
+      logger.warn('OpenCode auth file could not be parsed; skipping placeholder auth setup', {
+        path: getOpenCodeAuthPath(),
+        error: result.error
+      })
+    } else if (result.status === 'updated') {
+      logger.log('OpenCode auth placeholder ensured', { providerID })
+    }
+  } catch (error) {
+    logger.warn('Failed to write OpenCode auth placeholder', {
+      providerID,
+      error: error instanceof Error ? error.message : String(error)
+    })
+  }
+}

--- a/src/plugin/request.ts
+++ b/src/plugin/request.ts
@@ -185,7 +185,6 @@ function buildCodeWhispererRequest(
         }
       }
     } else curContent = getContentText(curMsg)
-    if (!curContent) curContent = curTrs.length ? 'Tool results provided.' : CONTINUE_TURN_CONTENT
   }
   const request: CodeWhispererRequest = {
     conversationState: {

--- a/src/plugin/request.ts
+++ b/src/plugin/request.ts
@@ -8,6 +8,7 @@ import {
   injectSystemPrompt
 } from '../infrastructure/transformers/history-builder.js'
 import {
+  SYNTHETIC_TURN_CONTENT,
   findOriginalToolCall,
   getContentText,
   mergeAdjacentMessages
@@ -140,11 +141,11 @@ function buildCodeWhispererRequest(
     if (arm.content || arm.toolUses) {
       history.push({ assistantResponseMessage: arm })
     }
-    curContent = '[system: conversation continues]'
+    curContent = SYNTHETIC_TURN_CONTENT
   } else {
     const prev = history[history.length - 1]
     if (prev && !prev.assistantResponseMessage)
-      history.push({ assistantResponseMessage: { content: '[system: conversation continues]' } })
+      history.push({ assistantResponseMessage: { content: SYNTHETIC_TURN_CONTENT } })
     if (curMsg.role === 'tool') {
       if (curMsg.tool_results) {
         for (const tr of curMsg.tool_results)
@@ -182,8 +183,7 @@ function buildCodeWhispererRequest(
         }
       }
     } else curContent = getContentText(curMsg)
-    if (!curContent)
-      curContent = curTrs.length ? 'Tool results provided.' : '[system: conversation continues]'
+    if (!curContent) curContent = curTrs.length ? 'Tool results provided.' : SYNTHETIC_TURN_CONTENT
   }
   const request: CodeWhispererRequest = {
     conversationState: {

--- a/src/plugin/request.ts
+++ b/src/plugin/request.ts
@@ -8,6 +8,7 @@ import {
   injectSystemPrompt
 } from '../infrastructure/transformers/history-builder.js'
 import {
+  CONTINUE_TURN_CONTENT,
   SYNTHETIC_TURN_CONTENT,
   findOriginalToolCall,
   getContentText,
@@ -142,7 +143,7 @@ function buildCodeWhispererRequest(
     if (arm.content || arm.toolUses) {
       history.push({ assistantResponseMessage: arm })
     }
-    curContent = SYNTHETIC_TURN_CONTENT
+    curContent = CONTINUE_TURN_CONTENT
   } else {
     const prev = history[history.length - 1]
     if (prev && !prev.assistantResponseMessage)
@@ -184,7 +185,7 @@ function buildCodeWhispererRequest(
         }
       }
     } else curContent = getContentText(curMsg)
-    if (!curContent) curContent = curTrs.length ? 'Tool results provided.' : SYNTHETIC_TURN_CONTENT
+    if (!curContent) curContent = curTrs.length ? 'Tool results provided.' : CONTINUE_TURN_CONTENT
   }
   const request: CodeWhispererRequest = {
     conversationState: {

--- a/src/plugin/request.ts
+++ b/src/plugin/request.ts
@@ -11,6 +11,7 @@ import {
   SYNTHETIC_TURN_CONTENT,
   findOriginalToolCall,
   getContentText,
+  getToolResultText,
   mergeAdjacentMessages
 } from '../infrastructure/transformers/message-transformer.js'
 import {
@@ -150,13 +151,13 @@ function buildCodeWhispererRequest(
       if (curMsg.tool_results) {
         for (const tr of curMsg.tool_results)
           curTrs.push({
-            content: [{ text: getContentText(tr) }],
+            content: [{ text: getToolResultText(tr) }],
             status: 'success',
             toolUseId: tr.tool_call_id
           })
       } else {
         curTrs.push({
-          content: [{ text: getContentText(curMsg) }],
+          content: [{ text: getToolResultText(curMsg) }],
           status: 'success',
           toolUseId: curMsg.tool_call_id
         })
@@ -167,7 +168,7 @@ function buildCodeWhispererRequest(
       for (const p of curMsg.content) {
         if (p.type === 'tool_result') {
           curTrs.push({
-            content: [{ text: getContentText(p.content || p) }],
+            content: [{ text: getToolResultText(p.content || p) }],
             status: 'success',
             toolUseId: p.tool_use_id
           })

--- a/src/plugin/request.ts
+++ b/src/plugin/request.ts
@@ -40,6 +40,7 @@ interface TransformResult {
 interface EffortConfig {
   effort?: Effort
   autoEffortMapping?: boolean
+  requestEffort?: Effort
 }
 
 type ToastFunction = (message: string, variant: 'info' | 'warning' | 'success' | 'error') => void
@@ -342,7 +343,8 @@ export function transformToSdkRequest(
     think,
     budget,
     effortConfig?.effort,
-    effortConfig?.autoEffortMapping ?? true
+    effortConfig?.autoEffortMapping ?? false,
+    effortConfig?.requestEffort
   )
 
   return {

--- a/src/plugin/sdk-client.ts
+++ b/src/plugin/sdk-client.ts
@@ -1,6 +1,7 @@
 import { CodeWhispererStreamingClient } from '@aws/codewhisperer-streaming-client'
 import { KIRO_CONSTANTS } from '../constants.js'
 import { getEffortSchemaPath } from './effort.js'
+import * as logger from './logger.js'
 import type { Effort, KiroAuthDetails } from './types'
 
 export type ResolvedSdkEndpointMode = 'kiro-runtime' | 'legacy-q'
@@ -13,6 +14,32 @@ interface ClientCacheEntry {
 
 const clientCache = new Map<string, ClientCacheEntry>()
 const KIRO_CLI_MAX_ATTEMPTS = 3
+const KIRO_TRANSIENT_ERROR_MESSAGE =
+  'Encountered an unexpected error when processing the request, please try again.'
+
+export function markRetryableKiroEventStreamError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false
+
+  const sdkError = error as {
+    $metadata?: { httpStatusCode?: number }
+    $response?: { statusCode?: number }
+    $retryable?: Record<string, unknown>
+    message?: string
+    name?: string
+    reason?: string
+  }
+  const status = sdkError.$metadata?.httpStatusCode ?? sdkError.$response?.statusCode
+  if (status !== 200) return false
+
+  const transient =
+    sdkError.name === 'InternalServerException' ||
+    sdkError.reason === 'MODEL_TEMPORARILY_UNAVAILABLE' ||
+    sdkError.message?.includes(KIRO_TRANSIENT_ERROR_MESSAGE)
+  if (!transient) return false
+
+  if (sdkError.$retryable === undefined) sdkError.$retryable = {}
+  return true
+}
 
 export function getSdkEndpoint(region: string, endpointMode: ResolvedSdkEndpointMode): string {
   if (region.startsWith('us-gov-')) return `https://q-fips.${region}.amazonaws.com`
@@ -46,6 +73,36 @@ export function createSdkClient(
   clientConfig.endpoint = getSdkEndpoint(region, endpointMode)
 
   const client = new CodeWhispererStreamingClient(clientConfig)
+
+  // Kiro can send a transient exception as the first frame of an HTTP 200 event stream.
+  // Smithy otherwise classifies that startup failure as a non-retryable client error.
+  client.middlewareStack.addRelativeTo(
+    (next: any) => async (args: any) => {
+      try {
+        return await next(args)
+      } catch (error) {
+        if (markRetryableKiroEventStreamError(error)) {
+          const sdkError = error as {
+            $metadata?: { httpStatusCode?: number }
+            $response?: { statusCode?: number }
+            name?: string
+            reason?: string
+          }
+          logger.warn('Retrying transient Kiro event-stream startup failure', {
+            status: sdkError.$metadata?.httpStatusCode ?? sdkError.$response?.statusCode,
+            name: sdkError.name,
+            reason: sdkError.reason
+          })
+        }
+        throw error
+      }
+    },
+    {
+      relation: 'before',
+      toMiddleware: 'deserializerMiddleware',
+      name: 'classifyKiroEventStreamError'
+    }
+  )
 
   client.middlewareStack.add(
     (next: any) => async (args: any) => {

--- a/src/plugin/sdk-client.ts
+++ b/src/plugin/sdk-client.ts
@@ -1,11 +1,10 @@
 import { CodeWhispererStreamingClient } from '@aws/codewhisperer-streaming-client'
 import { KIRO_CONSTANTS } from '../constants.js'
+import { getEffortSchemaPath } from './effort.js'
 import type { Effort, KiroAuthDetails } from './types'
 
-/**
- * Cache key includes effort to ensure separate clients for different effort levels,
- * since middleware is configured at client creation time.
- */
+export type ResolvedSdkEndpointMode = 'kiro-runtime' | 'legacy-q'
+
 interface ClientCacheEntry {
   client: CodeWhispererStreamingClient
   token: string
@@ -15,12 +14,20 @@ interface ClientCacheEntry {
 const clientCache = new Map<string, ClientCacheEntry>()
 const KIRO_CLI_MAX_ATTEMPTS = 3
 
+export function getSdkEndpoint(region: string, endpointMode: ResolvedSdkEndpointMode): string {
+  if (region.startsWith('us-gov-')) return `https://q-fips.${region}.amazonaws.com`
+  return endpointMode === 'kiro-runtime'
+    ? `https://runtime.${region}.kiro.dev`
+    : `https://q.${region}.amazonaws.com`
+}
+
 export function createSdkClient(
   auth: KiroAuthDetails,
   region: string,
+  endpointMode: ResolvedSdkEndpointMode = 'kiro-runtime',
   effort?: Effort
 ): CodeWhispererStreamingClient {
-  const cacheKey = `${region}:${auth.email || 'default'}:${effort || 'none'}`
+  const cacheKey = `${region}:${endpointMode}:${auth.email || auth.clientId || 'default'}:${effort || 'none'}`
   const cached = clientCache.get(cacheKey)
 
   if (cached && cached.token === auth.access && cached.effort === effort) {
@@ -28,16 +35,18 @@ export function createSdkClient(
   }
 
   const token = auth.access
-  const client = new CodeWhispererStreamingClient({
+  const clientConfig: ConstructorParameters<typeof CodeWhispererStreamingClient>[0] = {
     region,
-    endpoint: `https://q.${region}.amazonaws.com`,
     token: () => Promise.resolve({ token }),
     maxAttempts: KIRO_CLI_MAX_ATTEMPTS,
     retryMode: 'standard',
     customUserAgent: [[KIRO_CONSTANTS.USER_AGENT]]
-  })
+  }
 
-  // Add Kiro-specific headers
+  clientConfig.endpoint = getSdkEndpoint(region, endpointMode)
+
+  const client = new CodeWhispererStreamingClient(clientConfig)
+
   client.middlewareStack.add(
     (next: any) => async (args: any) => {
       args.request.headers['x-amzn-kiro-agent-mode'] = 'vibe'
@@ -46,23 +55,35 @@ export function createSdkClient(
     { step: 'build', name: 'addKiroHeaders' }
   )
 
-  // Inject additionalModelRequestFields for effort-based thinking control
   if (effort) {
     client.middlewareStack.add(
       (next: any) => async (args: any) => {
-        // The SDK serializes input to args.input, we need to modify the body
-        // before it's sent. The body is in args.request.body as a string.
         if (args.request?.body) {
           try {
             const body = JSON.parse(args.request.body)
-            body.additionalModelRequestFields = {
-              output_config: {
-                effort
+            const modelId = body.conversationState?.currentMessage?.userInputMessage?.modelId
+            const schemaPath = getEffortSchemaPath(modelId)
+            if (schemaPath === 'reasoning') {
+              body.additionalModelRequestFields = {
+                ...body.additionalModelRequestFields,
+                reasoning: {
+                  ...body.additionalModelRequestFields?.reasoning,
+                  effort
+                }
+              }
+            } else if (schemaPath === 'output_config') {
+              body.additionalModelRequestFields = {
+                ...body.additionalModelRequestFields,
+                thinking: { type: 'adaptive', display: 'summarized' },
+                output_config: {
+                  ...body.additionalModelRequestFields?.output_config,
+                  effort
+                }
               }
             }
             args.request.body = JSON.stringify(body)
           } catch {
-            // If body parsing fails, continue without modification
+            // Continue without effort when an unexpected body cannot be parsed.
           }
         }
         return next(args)

--- a/src/plugin/storage/locked-operations.ts
+++ b/src/plugin/storage/locked-operations.ts
@@ -15,6 +15,8 @@ const LOCK_OPTIONS = {
   realpath: false
 }
 
+const lockWaitBuffer = new Int32Array(new SharedArrayBuffer(4))
+
 export async function withDatabaseLock<T>(dbPath: string, fn: () => Promise<T>): Promise<T> {
   const lockPath = `${dbPath}.lock`
 
@@ -36,6 +38,31 @@ export async function withDatabaseLock<T>(dbPath: string, fn: () => Promise<T>):
         console.warn('Failed to release lock:', e)
       }
     }
+  }
+}
+
+export function withDatabaseLockSync<T>(dbPath: string, fn: () => T): T {
+  const deadline = Date.now() + 10000
+  let release: (() => void) | undefined
+
+  while (!release) {
+    try {
+      release = lockfile.lockSync(dbPath, { stale: LOCK_OPTIONS.stale, realpath: false })
+    } catch (error) {
+      if (
+        !(error && typeof error === 'object' && 'code' in error && error.code === 'ELOCKED') ||
+        Date.now() >= deadline
+      ) {
+        throw error
+      }
+      Atomics.wait(lockWaitBuffer, 0, 0, 25)
+    }
+  }
+
+  try {
+    return fn()
+  } finally {
+    release()
   }
 }
 
@@ -67,13 +94,40 @@ export function mergeAccounts(
       const hasPermanentError =
         isPermanentError(existingAcc.unhealthyReason) || incomingHasPermanentError
       const incomingRecovered = acc.isHealthy && !incomingHasPermanentError
+      const incomingSync = acc.lastSync || 0
+      const existingSync = existingAcc.lastSync || 0
+      const incomingHasQuota = (acc.limitCount || 0) > 0
+      const existingHasQuota = (existingAcc.limitCount || 0) > 0
+      // Only adopt the incoming quota snapshot when it is strictly newer AND it
+      // is not an empty (0/0) snapshot replacing real existing quota. A failed
+      // remote usage fetch produces a newer timestamp with zeroed counts, which
+      // must never clobber good quota data.
+      const useIncomingQuota =
+        incomingSync > 0 && incomingSync > existingSync && (incomingHasQuota || !existingHasQuota)
+      const incomingExpires = acc.expiresAt || 0
+      const existingExpires = existingAcc.expiresAt || 0
+      const preserveExistingAccess =
+        existingAcc.isHealthy && existingExpires > Date.now() && existingExpires >= incomingExpires
+      const incomingCredentialTime = acc.refreshTokenUpdatedAt || 0
+      const existingCredentialTime = existingAcc.refreshTokenUpdatedAt || 0
+      const useIncomingRefresh =
+        !existingAcc.refreshToken ||
+        (acc.refreshToken !== existingAcc.refreshToken &&
+          incomingCredentialTime > existingCredentialTime)
 
       accountMap.set(acc.id, {
         ...existingAcc,
         ...acc,
+        refreshToken: useIncomingRefresh ? acc.refreshToken : existingAcc.refreshToken,
+        refreshTokenUpdatedAt: Math.max(existingCredentialTime, incomingCredentialTime),
+        accessToken: preserveExistingAccess ? existingAcc.accessToken : acc.accessToken,
+        expiresAt: preserveExistingAccess ? existingAcc.expiresAt : acc.expiresAt,
         lastUsed: Math.max(existingAcc.lastUsed || 0, acc.lastUsed || 0),
-        usedCount: Math.max(existingAcc.usedCount || 0, acc.usedCount || 0),
-        limitCount: Math.max(existingAcc.limitCount || 0, acc.limitCount || 0),
+        usedCount: useIncomingQuota ? acc.usedCount : existingAcc.usedCount,
+        limitCount: useIncomingQuota ? acc.limitCount : existingAcc.limitCount,
+        subscriptionPlan: useIncomingQuota
+          ? acc.subscriptionPlan || existingAcc.subscriptionPlan
+          : existingAcc.subscriptionPlan || acc.subscriptionPlan,
         rateLimitResetTime: Math.max(
           existingAcc.rateLimitResetTime || 0,
           acc.rateLimitResetTime || 0

--- a/src/plugin/storage/migrations.ts
+++ b/src/plugin/storage/migrations.ts
@@ -9,6 +9,8 @@ export function runMigrations(db: Database): void {
   migrateStartUrlColumn(db)
   migrateOidcRegionColumn(db)
   migrateDropRefreshTokenUniqueIndex(db)
+  migrateSubscriptionPlanColumn(db)
+  migrateRefreshTokenUpdatedAtColumn(db)
 }
 
 function migrateToUniqueRefreshToken(db: Database): void {
@@ -88,15 +90,17 @@ function migrateRealEmailColumn(db: Database): void {
             id TEXT PRIMARY KEY, email TEXT NOT NULL, auth_method TEXT NOT NULL,
             region TEXT NOT NULL, oidc_region TEXT, client_id TEXT, client_secret TEXT, profile_arn TEXT,
             start_url TEXT,
-            refresh_token TEXT NOT NULL, access_token TEXT NOT NULL, expires_at INTEGER NOT NULL,
+            refresh_token TEXT NOT NULL, refresh_token_updated_at INTEGER DEFAULT 0,
+            access_token TEXT NOT NULL, expires_at INTEGER NOT NULL,
             rate_limit_reset INTEGER DEFAULT 0, is_healthy INTEGER DEFAULT 1, unhealthy_reason TEXT,
             recovery_time INTEGER, fail_count INTEGER DEFAULT 0, last_used INTEGER DEFAULT 0,
-            used_count INTEGER DEFAULT 0, limit_count INTEGER DEFAULT 0, last_sync INTEGER DEFAULT 0
+            used_count REAL DEFAULT 0, limit_count REAL DEFAULT 0, subscription_plan TEXT,
+            last_sync INTEGER DEFAULT 0
           )
         `)
       db.exec(`
-          INSERT INTO accounts_new (id, email, auth_method, region, oidc_region, client_id, client_secret, profile_arn, start_url, refresh_token, access_token, expires_at, rate_limit_reset, is_healthy, unhealthy_reason, recovery_time, fail_count, last_used, used_count, limit_count, last_sync)
-          SELECT id, email, auth_method, region, NULL, client_id, client_secret, profile_arn, NULL, refresh_token, access_token, expires_at, COALESCE(rate_limit_reset, 0), COALESCE(is_healthy, 1), unhealthy_reason, recovery_time, COALESCE(fail_count, 0), COALESCE(last_used, 0), 0, 0, 0 FROM accounts
+          INSERT INTO accounts_new (id, email, auth_method, region, oidc_region, client_id, client_secret, profile_arn, start_url, refresh_token, refresh_token_updated_at, access_token, expires_at, rate_limit_reset, is_healthy, unhealthy_reason, recovery_time, fail_count, last_used, used_count, limit_count, subscription_plan, last_sync)
+          SELECT id, email, auth_method, region, NULL, client_id, client_secret, profile_arn, NULL, refresh_token, 0, access_token, expires_at, COALESCE(rate_limit_reset, 0), COALESCE(is_healthy, 1), unhealthy_reason, recovery_time, COALESCE(fail_count, 0), COALESCE(last_used, 0), 0, 0, NULL, 0 FROM accounts
         `)
       db.exec('DROP TABLE accounts')
       db.exec('ALTER TABLE accounts_new RENAME TO accounts')
@@ -107,12 +111,33 @@ function migrateRealEmailColumn(db: Database): void {
   } else {
     const needed: Record<string, string> = {
       fail_count: 'INTEGER DEFAULT 0',
-      used_count: 'INTEGER DEFAULT 0',
-      limit_count: 'INTEGER DEFAULT 0',
+      used_count: 'REAL DEFAULT 0',
+      limit_count: 'REAL DEFAULT 0',
+      subscription_plan: 'TEXT',
       last_sync: 'INTEGER DEFAULT 0'
     }
     for (const [n, d] of Object.entries(needed)) {
       if (!names.has(n)) db.exec(`ALTER TABLE accounts ADD COLUMN ${n} ${d}`)
+    }
+  }
+}
+
+function migrateSubscriptionPlanColumn(db: Database): void {
+  const columns = db.prepare('PRAGMA table_info(accounts)').all() as any[]
+  const names = new Set(columns.map((c) => c.name))
+  if (!names.has('subscription_plan')) {
+    db.exec('ALTER TABLE accounts ADD COLUMN subscription_plan TEXT')
+  }
+}
+
+function migrateRefreshTokenUpdatedAtColumn(db: Database): void {
+  const columns = db.prepare('PRAGMA table_info(accounts)').all() as any[]
+  if (!columns.some((column) => column.name === 'refresh_token_updated_at')) {
+    try {
+      db.exec('ALTER TABLE accounts ADD COLUMN refresh_token_updated_at INTEGER DEFAULT 0')
+    } catch (error) {
+      const currentColumns = db.prepare('PRAGMA table_info(accounts)').all() as any[]
+      if (!currentColumns.some((column) => column.name === 'refresh_token_updated_at')) throw error
     }
   }
 }

--- a/src/plugin/storage/sqlite.ts
+++ b/src/plugin/storage/sqlite.ts
@@ -1,10 +1,15 @@
 import type Libsql from 'libsql'
 import Database from 'libsql'
-import { existsSync, mkdirSync } from 'node:fs'
+import { chmodSync, existsSync, mkdirSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import type { ManagedAccount } from '../types'
-import { deduplicateAccounts, mergeAccounts, withDatabaseLock } from './locked-operations'
+import {
+  deduplicateAccounts,
+  mergeAccounts,
+  withDatabaseLock,
+  withDatabaseLockSync
+} from './locked-operations'
 import { runMigrations } from './migrations'
 
 function getBaseDir(): string {
@@ -17,16 +22,19 @@ function getBaseDir(): string {
 export const DB_PATH = join(getBaseDir(), 'kiro.db')
 
 export class KiroDatabase {
-  private db: Libsql.Database
+  private db!: Libsql.Database
   private path: string
 
   constructor(path: string = DB_PATH) {
     this.path = path
     const dir = join(path, '..')
-    if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
-    this.db = new Database(path)
-    this.db.pragma('busy_timeout = 5000')
-    this.init()
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 })
+    withDatabaseLockSync(path, () => {
+      this.db = new Database(path)
+      this.db.pragma('busy_timeout = 5000')
+      this.init()
+    })
+    this.secureFiles()
   }
   private init() {
     this.db.pragma('journal_mode = WAL')
@@ -35,13 +43,22 @@ export class KiroDatabase {
         id TEXT PRIMARY KEY, email TEXT NOT NULL, auth_method TEXT NOT NULL,
         region TEXT NOT NULL, oidc_region TEXT, client_id TEXT, client_secret TEXT, profile_arn TEXT,
         start_url TEXT,
-        refresh_token TEXT NOT NULL, access_token TEXT NOT NULL, expires_at INTEGER NOT NULL,
+        refresh_token TEXT NOT NULL, refresh_token_updated_at INTEGER DEFAULT 0,
+        access_token TEXT NOT NULL, expires_at INTEGER NOT NULL,
         rate_limit_reset INTEGER DEFAULT 0, is_healthy INTEGER DEFAULT 1, unhealthy_reason TEXT,
         recovery_time INTEGER, fail_count INTEGER DEFAULT 0, last_used INTEGER DEFAULT 0,
-        used_count INTEGER DEFAULT 0, limit_count INTEGER DEFAULT 0, last_sync INTEGER DEFAULT 0
+        used_count REAL DEFAULT 0, limit_count REAL DEFAULT 0, subscription_plan TEXT,
+        last_sync INTEGER DEFAULT 0
       )
     `)
     runMigrations(this.db)
+  }
+
+  private secureFiles() {
+    if (process.platform === 'win32') return
+    for (const path of [this.path, `${this.path}-wal`, `${this.path}-shm`]) {
+      if (existsSync(path)) chmodSync(path, 0o600)
+    }
   }
 
   getAccounts(): any[] {
@@ -54,19 +71,21 @@ export class KiroDatabase {
         `
       INSERT INTO accounts (
         id, email, auth_method, region, oidc_region, client_id, client_secret,
-        profile_arn, start_url, refresh_token, access_token, expires_at, rate_limit_reset,
+        profile_arn, start_url, refresh_token, refresh_token_updated_at, access_token, expires_at, rate_limit_reset,
         is_healthy, unhealthy_reason, recovery_time, fail_count, last_used,
-        used_count, limit_count, last_sync
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        used_count, limit_count, subscription_plan, last_sync
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(id) DO UPDATE SET
         id=excluded.id, email=excluded.email, auth_method=excluded.auth_method,
         region=excluded.region, oidc_region=excluded.oidc_region, client_id=excluded.client_id, client_secret=excluded.client_secret,
         profile_arn=excluded.profile_arn, start_url=excluded.start_url, refresh_token=excluded.refresh_token,
+        refresh_token_updated_at=excluded.refresh_token_updated_at,
         access_token=excluded.access_token, expires_at=excluded.expires_at,
         rate_limit_reset=excluded.rate_limit_reset, is_healthy=excluded.is_healthy,
         unhealthy_reason=excluded.unhealthy_reason, recovery_time=excluded.recovery_time,
         fail_count=excluded.fail_count, last_used=excluded.last_used,
-        used_count=excluded.used_count, limit_count=excluded.limit_count, last_sync=excluded.last_sync
+        used_count=excluded.used_count, limit_count=excluded.limit_count,
+        subscription_plan=excluded.subscription_plan, last_sync=excluded.last_sync
     `
       )
       .run(
@@ -80,6 +99,7 @@ export class KiroDatabase {
         acc.profileArn || null,
         acc.startUrl || null,
         acc.refreshToken,
+        acc.refreshTokenUpdatedAt || 0,
         acc.accessToken,
         acc.expiresAt,
         acc.rateLimitResetTime || 0,
@@ -90,6 +110,7 @@ export class KiroDatabase {
         acc.lastUsed || 0,
         acc.usedCount || 0,
         acc.limitCount || 0,
+        acc.subscriptionPlan || null,
         acc.lastSync || 0
       )
   }
@@ -110,6 +131,7 @@ export class KiroDatabase {
         this.db.exec('ROLLBACK')
         throw e
       }
+      this.secureFiles()
     })
   }
 
@@ -129,12 +151,14 @@ export class KiroDatabase {
         this.db.exec('ROLLBACK')
         throw e
       }
+      this.secureFiles()
     })
   }
 
   async deleteAccount(id: string): Promise<void> {
     await withDatabaseLock(this.path, async () => {
       this.db.prepare('DELETE FROM accounts WHERE id = ?').run(id)
+      this.secureFiles()
     })
   }
 
@@ -168,6 +192,7 @@ export class KiroDatabase {
         this.db.exec('ROLLBACK')
         throw e
       }
+      this.secureFiles()
     })
   }
 
@@ -183,6 +208,7 @@ export class KiroDatabase {
       profileArn: row.profile_arn,
       startUrl: row.start_url || undefined,
       refreshToken: row.refresh_token,
+      refreshTokenUpdatedAt: row.refresh_token_updated_at || 0,
       accessToken: row.access_token,
       expiresAt: row.expires_at,
       rateLimitResetTime: row.rate_limit_reset,
@@ -193,6 +219,7 @@ export class KiroDatabase {
       lastUsed: row.last_used,
       usedCount: row.used_count,
       limitCount: row.limit_count,
+      subscriptionPlan: row.subscription_plan || undefined,
       lastSync: row.last_sync
     }
   }

--- a/src/plugin/streaming/sdk-stream-transformer.ts
+++ b/src/plugin/streaming/sdk-stream-transformer.ts
@@ -2,27 +2,17 @@ import { parseBracketToolCalls } from '../../infrastructure/transformers/tool-ca
 import { getContextWindowSize } from '../models.js'
 import { estimateTokens } from '../response.js'
 import { convertToOpenAI } from './openai-converter.js'
-import { findRealTag } from './stream-parser.js'
-import { createTextDeltaEvents, createThinkingDeltaEvents, stopBlock } from './stream-state.js'
-import { StreamState, THINKING_END_TAG, THINKING_START_TAG, ToolCallState } from './types.js'
+import { createStreamState, stopBlock } from './stream-state.js'
+import { createContentDeltaEvents, flushContentDeltaEvents } from './thinking-parser.js'
+import { ToolCallState } from './types.js'
 
 export async function* transformSdkStream(
   sdkResponse: any,
   model: string,
-  conversationId: string
+  conversationId: string,
+  thinkingRequested = model.endsWith('-thinking')
 ): AsyncGenerator<any> {
-  const thinkingRequested = true
-
-  const streamState: StreamState = {
-    thinkingRequested,
-    buffer: '',
-    inThinking: false,
-    thinkingExtracted: false,
-    thinkingBlockIndex: null,
-    textBlockIndex: null,
-    nextBlockIndex: 0,
-    stoppedBlocks: new Set()
-  }
+  const streamState = createStreamState(thinkingRequested)
 
   let totalContent = ''
   let textOnlyContent = ''
@@ -44,85 +34,9 @@ export async function* transformSdkStream(
         totalContent += text
         textOnlyContent += text
 
-        if (!thinkingRequested) {
-          for (const ev of createTextDeltaEvents(text, streamState)) {
-            {
-              const _c = convertToOpenAI(ev, conversationId, model)
-              if (_c !== null) yield _c
-            }
-          }
-          continue
-        }
-
-        streamState.buffer += text
-        const deltaEvents: any[] = []
-
-        while (streamState.buffer.length > 0) {
-          if (!streamState.inThinking && !streamState.thinkingExtracted) {
-            const startPos = findRealTag(streamState.buffer, THINKING_START_TAG)
-            if (startPos !== -1) {
-              const before = streamState.buffer.slice(0, startPos)
-              if (before) {
-                deltaEvents.push(...createTextDeltaEvents(before, streamState))
-              }
-              streamState.buffer = streamState.buffer.slice(startPos + THINKING_START_TAG.length)
-              streamState.inThinking = true
-              continue
-            }
-
-            const safeLen = Math.max(0, streamState.buffer.length - THINKING_START_TAG.length)
-            if (safeLen > 0) {
-              const safeText = streamState.buffer.slice(0, safeLen)
-              if (safeText) {
-                deltaEvents.push(...createTextDeltaEvents(safeText, streamState))
-              }
-              streamState.buffer = streamState.buffer.slice(safeLen)
-            }
-            break
-          }
-
-          if (streamState.inThinking) {
-            const endPos = findRealTag(streamState.buffer, THINKING_END_TAG)
-            if (endPos !== -1) {
-              const thinkingPart = streamState.buffer.slice(0, endPos)
-              if (thinkingPart) {
-                deltaEvents.push(...createThinkingDeltaEvents(thinkingPart, streamState))
-              }
-              streamState.buffer = streamState.buffer.slice(endPos + THINKING_END_TAG.length)
-              streamState.inThinking = false
-              streamState.thinkingExtracted = true
-              deltaEvents.push(...createThinkingDeltaEvents('', streamState))
-              deltaEvents.push(...stopBlock(streamState.thinkingBlockIndex, streamState))
-              if (streamState.buffer.startsWith('\n\n')) {
-                streamState.buffer = streamState.buffer.slice(2)
-              }
-              continue
-            }
-
-            const safeLen = Math.max(0, streamState.buffer.length - THINKING_END_TAG.length)
-            if (safeLen > 0) {
-              const safeThinking = streamState.buffer.slice(0, safeLen)
-              if (safeThinking) {
-                deltaEvents.push(...createThinkingDeltaEvents(safeThinking, streamState))
-              }
-              streamState.buffer = streamState.buffer.slice(safeLen)
-            }
-            break
-          }
-
-          if (streamState.thinkingExtracted) {
-            const rest = streamState.buffer
-            streamState.buffer = ''
-            if (rest) {
-              deltaEvents.push(...createTextDeltaEvents(rest, streamState))
-            }
-            break
-          }
-        }
-
-        for (const ev of deltaEvents) {
-          const chunk = convertToOpenAI(ev, conversationId, model)
-          if (chunk !== null) yield chunk
+        for (const ev of createContentDeltaEvents(text, streamState)) {
+          const converted = convertToOpenAI(ev, conversationId, model)
+          if (converted !== null) yield converted
         }
       } else if (event.toolUseEvent) {
         const tc = event.toolUseEvent
@@ -162,28 +76,9 @@ export async function* transformSdkStream(
       currentToolCall = null
     }
 
-    if (thinkingRequested && streamState.buffer) {
-      if (streamState.inThinking) {
-        for (const ev of createThinkingDeltaEvents(streamState.buffer, streamState)) {
-          const _c = convertToOpenAI(ev, conversationId, model)
-          if (_c !== null) yield _c
-        }
-        streamState.buffer = ''
-        for (const ev of createThinkingDeltaEvents('', streamState)) {
-          const _c = convertToOpenAI(ev, conversationId, model)
-          if (_c !== null) yield _c
-        }
-        for (const ev of stopBlock(streamState.thinkingBlockIndex, streamState)) {
-          const _c = convertToOpenAI(ev, conversationId, model)
-          if (_c !== null) yield _c
-        }
-      } else {
-        for (const ev of createTextDeltaEvents(streamState.buffer, streamState)) {
-          const _c = convertToOpenAI(ev, conversationId, model)
-          if (_c !== null) yield _c
-        }
-        streamState.buffer = ''
-      }
+    for (const ev of flushContentDeltaEvents(streamState)) {
+      const converted = convertToOpenAI(ev, conversationId, model)
+      if (converted !== null) yield converted
     }
 
     for (const ev of stopBlock(streamState.textBlockIndex, streamState)) {

--- a/src/plugin/streaming/sdk-stream-transformer.ts
+++ b/src/plugin/streaming/sdk-stream-transformer.ts
@@ -3,6 +3,7 @@ import { getContextWindowSize } from '../models.js'
 import { estimateTokens } from '../response.js'
 import { convertToOpenAI } from './openai-converter.js'
 import { createStreamState, stopBlock } from './stream-state.js'
+import { SystemReminderFilter } from './system-reminder-filter.js'
 import { createContentDeltaEvents, flushContentDeltaEvents } from './thinking-parser.js'
 import { ToolCallState } from './types.js'
 
@@ -13,6 +14,7 @@ export async function* transformSdkStream(
   thinkingRequested = model.endsWith('-thinking')
 ): AsyncGenerator<any> {
   const streamState = createStreamState(thinkingRequested)
+  const systemReminderFilter = new SystemReminderFilter()
 
   let totalContent = ''
   let textOnlyContent = ''
@@ -30,7 +32,8 @@ export async function* transformSdkStream(
   try {
     for await (const event of eventStream) {
       if (event.assistantResponseEvent?.content) {
-        const text = event.assistantResponseEvent.content
+        const text = systemReminderFilter.push(event.assistantResponseEvent.content)
+        if (!text) continue
         totalContent += text
         textOnlyContent += text
 
@@ -68,6 +71,16 @@ export async function* transformSdkStream(
         if (cue.contextUsagePercentage) {
           contextUsagePercentage = cue.contextUsagePercentage
         }
+      }
+    }
+
+    const trailingText = systemReminderFilter.flush()
+    if (trailingText) {
+      totalContent += trailingText
+      textOnlyContent += trailingText
+      for (const ev of createContentDeltaEvents(trailingText, streamState)) {
+        const converted = convertToOpenAI(ev, conversationId, model)
+        if (converted !== null) yield converted
       }
     }
 

--- a/src/plugin/streaming/stream-parser.ts
+++ b/src/plugin/streaming/stream-parser.ts
@@ -121,28 +121,36 @@ export function parseStreamBuffer(buffer: string): { events: any[]; remaining: s
   return { events, remaining }
 }
 
-export function findRealTag(buffer: string, tag: string): number {
-  const codeBlockPattern = /```[\s\S]*?```/g
-  const codeBlocks: Array<[number, number]> = []
+function isQuoteCharAt(text: string, index: number): boolean {
+  if (index < 0 || index >= text.length) return false
+  const ch = text[index]
+  return ch === '"' || ch === "'" || ch === '`'
+}
 
-  let match: RegExpExecArray | null
-  while ((match = codeBlockPattern.exec(buffer)) !== null) {
-    codeBlocks.push([match.index, match.index + match[0].length])
+function isInsideCodeFence(text: string, index: number): boolean {
+  let fenceCount = 0
+  let pos = 0
+
+  while ((pos = text.indexOf('```', pos)) !== -1 && pos < index) {
+    fenceCount++
+    pos += 3
   }
 
-  let pos = 0
+  return fenceCount % 2 === 1
+}
+
+export function findRealTag(buffer: string, tag: string, startIndex = 0): number {
+  let pos = Math.max(0, startIndex)
+
   while ((pos = buffer.indexOf(tag, pos)) !== -1) {
-    let inCodeBlock = false
-    for (const [start, end] of codeBlocks) {
-      if (pos >= start && pos < end) {
-        inCodeBlock = true
-        break
-      }
-    }
-    if (!inCodeBlock) {
+    const hasQuoteBefore = isQuoteCharAt(buffer, pos - 1)
+    const hasQuoteAfter = isQuoteCharAt(buffer, pos + tag.length)
+
+    if (!hasQuoteBefore && !hasQuoteAfter && !isInsideCodeFence(buffer, pos)) {
       return pos
     }
-    pos += tag.length
+
+    pos += 1
   }
 
   return -1

--- a/src/plugin/streaming/stream-state.ts
+++ b/src/plugin/streaming/stream-state.ts
@@ -1,4 +1,22 @@
+import { createThinkingLexState } from './thinking-lexer.js'
 import { StreamEvent, StreamState } from './types.js'
+
+export function createStreamState(thinkingRequested: boolean): StreamState {
+  return {
+    thinkingRequested,
+    buffer: '',
+    pendingTextBeforeThinking: '',
+    inThinking: false,
+    thinkingExtracted: false,
+    thinkingBlockIndex: null,
+    textBlockIndex: null,
+    nextBlockIndex: 0,
+    stoppedBlocks: new Set(),
+    stripThinkingLeadingNewline: false,
+    stripTextLeadingNewlinesAfterThinking: false,
+    thinkingLex: createThinkingLexState()
+  }
+}
 
 export function ensureBlockStart(
   blockType: 'thinking' | 'text',

--- a/src/plugin/streaming/stream-transformer.ts
+++ b/src/plugin/streaming/stream-transformer.ts
@@ -4,6 +4,7 @@ import { estimateTokens } from '../response.js'
 import { convertToOpenAI } from './openai-converter.js'
 import { parseStreamBuffer } from './stream-parser.js'
 import { createStreamState, stopBlock } from './stream-state.js'
+import { SystemReminderFilter } from './system-reminder-filter.js'
 import { createContentDeltaEvents, flushContentDeltaEvents } from './thinking-parser.js'
 import { ToolCallState } from './types.js'
 
@@ -14,6 +15,7 @@ export async function* transformKiroStream(
   thinkingRequested = model.endsWith('-thinking')
 ): AsyncGenerator<any> {
   const streamState = createStreamState(thinkingRequested)
+  const systemReminderFilter = new SystemReminderFilter()
 
   if (!response.body) {
     throw new Error('Response body is null')
@@ -46,10 +48,12 @@ export async function* transformKiroStream(
         if (event.type === 'contextUsage' && event.data.contextUsagePercentage) {
           contextUsagePercentage = event.data.contextUsagePercentage
         } else if (event.type === 'content' && event.data) {
-          totalContent += event.data
-          textOnlyContent += event.data
+          const text = systemReminderFilter.push(event.data)
+          if (!text) continue
+          totalContent += text
+          textOnlyContent += text
 
-          for (const ev of createContentDeltaEvents(event.data, streamState)) {
+          for (const ev of createContentDeltaEvents(text, streamState)) {
             const converted = convertToOpenAI(ev, conversationId, model)
             if (converted !== null) yield converted
           }
@@ -94,6 +98,16 @@ export async function* transformKiroStream(
             currentToolCall = null
           }
         }
+      }
+    }
+
+    const trailingText = systemReminderFilter.flush()
+    if (trailingText) {
+      totalContent += trailingText
+      textOnlyContent += trailingText
+      for (const ev of createContentDeltaEvents(trailingText, streamState)) {
+        const converted = convertToOpenAI(ev, conversationId, model)
+        if (converted !== null) yield converted
       }
     }
 

--- a/src/plugin/streaming/stream-transformer.ts
+++ b/src/plugin/streaming/stream-transformer.ts
@@ -2,27 +2,18 @@ import { parseBracketToolCalls } from '../../infrastructure/transformers/tool-ca
 import { getContextWindowSize } from '../models.js'
 import { estimateTokens } from '../response.js'
 import { convertToOpenAI } from './openai-converter.js'
-import { findRealTag, parseStreamBuffer } from './stream-parser.js'
-import { createTextDeltaEvents, createThinkingDeltaEvents, stopBlock } from './stream-state.js'
-import { StreamState, THINKING_END_TAG, THINKING_START_TAG, ToolCallState } from './types.js'
+import { parseStreamBuffer } from './stream-parser.js'
+import { createStreamState, stopBlock } from './stream-state.js'
+import { createContentDeltaEvents, flushContentDeltaEvents } from './thinking-parser.js'
+import { ToolCallState } from './types.js'
 
 export async function* transformKiroStream(
   response: Response,
   model: string,
-  conversationId: string
+  conversationId: string,
+  thinkingRequested = model.endsWith('-thinking')
 ): AsyncGenerator<any> {
-  const thinkingRequested = true
-
-  const streamState: StreamState = {
-    thinkingRequested,
-    buffer: '',
-    inThinking: false,
-    thinkingExtracted: false,
-    thinkingBlockIndex: null,
-    textBlockIndex: null,
-    nextBlockIndex: 0,
-    stoppedBlocks: new Set()
-  }
+  const streamState = createStreamState(thinkingRequested)
 
   if (!response.body) {
     throw new Error('Response body is null')
@@ -58,91 +49,9 @@ export async function* transformKiroStream(
           totalContent += event.data
           textOnlyContent += event.data
 
-          if (!thinkingRequested) {
-            for (const ev of createTextDeltaEvents(event.data, streamState)) {
-              {
-                const _c = convertToOpenAI(ev, conversationId, model)
-                if (_c !== null) yield _c
-              }
-            }
-            continue
-          }
-
-          streamState.buffer += event.data
-          const deltaEvents: any[] = []
-
-          while (streamState.buffer.length > 0) {
-            if (!streamState.inThinking && !streamState.thinkingExtracted) {
-              const startPos = findRealTag(streamState.buffer, THINKING_START_TAG)
-              if (startPos !== -1) {
-                const before = streamState.buffer.slice(0, startPos)
-                if (before) {
-                  deltaEvents.push(...createTextDeltaEvents(before, streamState))
-                }
-
-                streamState.buffer = streamState.buffer.slice(startPos + THINKING_START_TAG.length)
-                streamState.inThinking = true
-                continue
-              }
-
-              const safeLen = Math.max(0, streamState.buffer.length - THINKING_START_TAG.length)
-              if (safeLen > 0) {
-                const safeText = streamState.buffer.slice(0, safeLen)
-                if (safeText) {
-                  deltaEvents.push(...createTextDeltaEvents(safeText, streamState))
-                }
-                streamState.buffer = streamState.buffer.slice(safeLen)
-              }
-              break
-            }
-
-            if (streamState.inThinking) {
-              const endPos = findRealTag(streamState.buffer, THINKING_END_TAG)
-              if (endPos !== -1) {
-                const thinkingPart = streamState.buffer.slice(0, endPos)
-                if (thinkingPart) {
-                  deltaEvents.push(...createThinkingDeltaEvents(thinkingPart, streamState))
-                }
-
-                streamState.buffer = streamState.buffer.slice(endPos + THINKING_END_TAG.length)
-                streamState.inThinking = false
-                streamState.thinkingExtracted = true
-
-                deltaEvents.push(...createThinkingDeltaEvents('', streamState))
-                deltaEvents.push(...stopBlock(streamState.thinkingBlockIndex, streamState))
-
-                if (streamState.buffer.startsWith('\n\n')) {
-                  streamState.buffer = streamState.buffer.slice(2)
-                }
-                continue
-              }
-
-              const safeLen = Math.max(0, streamState.buffer.length - THINKING_END_TAG.length)
-              if (safeLen > 0) {
-                const safeThinking = streamState.buffer.slice(0, safeLen)
-                if (safeThinking) {
-                  deltaEvents.push(...createThinkingDeltaEvents(safeThinking, streamState))
-                }
-                streamState.buffer = streamState.buffer.slice(safeLen)
-              }
-              break
-            }
-
-            if (streamState.thinkingExtracted) {
-              const rest = streamState.buffer
-              streamState.buffer = ''
-              if (rest) {
-                deltaEvents.push(...createTextDeltaEvents(rest, streamState))
-              }
-              break
-            }
-          }
-
-          for (const ev of deltaEvents) {
-            {
-              const _c = convertToOpenAI(ev, conversationId, model)
-              if (_c !== null) yield _c
-            }
+          for (const ev of createContentDeltaEvents(event.data, streamState)) {
+            const converted = convertToOpenAI(ev, conversationId, model)
+            if (converted !== null) yield converted
           }
         } else if (event.type === 'toolUse') {
           const tc = event.data
@@ -193,28 +102,9 @@ export async function* transformKiroStream(
       currentToolCall = null
     }
 
-    if (thinkingRequested && streamState.buffer) {
-      if (streamState.inThinking) {
-        for (const ev of createThinkingDeltaEvents(streamState.buffer, streamState)) {
-          const _c = convertToOpenAI(ev, conversationId, model)
-          if (_c !== null) yield _c
-        }
-        streamState.buffer = ''
-        for (const ev of createThinkingDeltaEvents('', streamState)) {
-          const _c = convertToOpenAI(ev, conversationId, model)
-          if (_c !== null) yield _c
-        }
-        for (const ev of stopBlock(streamState.thinkingBlockIndex, streamState)) {
-          const _c = convertToOpenAI(ev, conversationId, model)
-          if (_c !== null) yield _c
-        }
-      } else {
-        for (const ev of createTextDeltaEvents(streamState.buffer, streamState)) {
-          const _c = convertToOpenAI(ev, conversationId, model)
-          if (_c !== null) yield _c
-        }
-        streamState.buffer = ''
-      }
+    for (const ev of flushContentDeltaEvents(streamState)) {
+      const converted = convertToOpenAI(ev, conversationId, model)
+      if (converted !== null) yield converted
     }
 
     for (const ev of stopBlock(streamState.textBlockIndex, streamState)) {

--- a/src/plugin/streaming/system-reminder-filter.ts
+++ b/src/plugin/streaming/system-reminder-filter.ts
@@ -1,0 +1,96 @@
+const SYSTEM_REMINDER_START = '<system-reminder>'
+const SYSTEM_REMINDER_END = '</system-reminder>'
+
+type LineMode = 'candidate' | 'passthrough'
+
+export class SystemReminderFilter {
+  private candidate = ''
+  private currentLine = ''
+  private inFence = false
+  private fenceChar = ''
+  private fenceLength = 0
+  private lineMode: LineMode = 'candidate'
+
+  push(text: string): string {
+    if (!text) return ''
+
+    const output: string[] = []
+    for (const char of text) {
+      this.currentLine += char
+
+      if (this.lineMode === 'passthrough') {
+        output.push(char)
+        if (char === '\n') this.finishLine()
+        continue
+      }
+
+      this.candidate += char
+      if (char === '\n') {
+        this.finishCandidate(output)
+        continue
+      }
+
+      if (!this.couldBeMarkerLine()) {
+        output.push(this.candidate)
+        this.lineMode = 'passthrough'
+        this.candidate = ''
+      }
+    }
+
+    return output.join('')
+  }
+
+  flush(): string {
+    if (this.lineMode !== 'candidate' || !this.candidate) {
+      this.candidate = ''
+      this.currentLine = ''
+      return ''
+    }
+
+    const output: string[] = []
+    this.finishCandidate(output)
+    return output.join('')
+  }
+
+  private couldBeMarkerLine(): boolean {
+    if (this.inFence) return false
+
+    const value = this.candidate.trimStart()
+    return [SYSTEM_REMINDER_START, SYSTEM_REMINDER_END].some(
+      (marker) =>
+        marker.startsWith(value) || (value.startsWith(marker) && !value.slice(marker.length).trim())
+    )
+  }
+
+  private finishCandidate(output: string[]): void {
+    const marker = this.candidate.trim()
+    if (this.inFence || (marker !== SYSTEM_REMINDER_START && marker !== SYSTEM_REMINDER_END)) {
+      output.push(this.candidate)
+    }
+    this.finishLine()
+  }
+
+  private finishLine(): void {
+    this.updateFenceState()
+    this.candidate = ''
+    this.currentLine = ''
+    this.lineMode = 'candidate'
+  }
+
+  private updateFenceState(): void {
+    const line = this.currentLine.replace(/[\r\n]+$/, '').trimStart()
+    const match = line.match(/^(`{3,}|~{3,})/)
+    if (!match) return
+
+    const marker = match[1]!
+    if (!this.inFence) {
+      this.inFence = true
+      this.fenceChar = marker[0]!
+      this.fenceLength = marker.length
+    } else if (marker[0] === this.fenceChar && marker.length >= this.fenceLength) {
+      this.inFence = false
+      this.fenceChar = ''
+      this.fenceLength = 0
+    }
+  }
+}

--- a/src/plugin/streaming/thinking-lexer.ts
+++ b/src/plugin/streaming/thinking-lexer.ts
@@ -1,0 +1,222 @@
+// Stateful lexer for locating a "real" thinking control tag (`<thinking>` or
+// `</thinking>`) inside model output. The lexer carries lexical state (inside a
+// quoted span / inline code span / fenced code block) across chunk boundaries
+// so that literal tags embedded in quotes or code never open or close the
+// reasoning block, even when the surrounding quote or fence is split across
+// multiple SDK chunks.
+
+export interface ThinkingLexState {
+  // Inside a ``` / ~~~ fenced code block.
+  inFence: boolean
+  // The marker character that opened the current fence ('`' or '~').
+  fenceChar: string
+  // The number of marker characters that opened the current fence.
+  fenceLen: number
+  // Number of backticks of an open inline code span (0 when not in a span).
+  inlineTicks: number
+  // The quote character of an open quoted span ('"' or "'"), '' when none.
+  quote: string
+  // True when the previous character inside a quoted span was a backslash.
+  quoteEscape: boolean
+  // Last committed character, used to avoid treating apostrophes in words as
+  // single-quote delimiters.
+  lastChar: string
+  // Whether the scanner is at the logical start of a line (ignoring leading
+  // whitespace), used for fenced-code detection.
+  atLineStart: boolean
+}
+
+export interface ThinkingScanResult {
+  // Index in `text` where the real tag begins, or -1 when not found.
+  tagIndex: number
+  // Number of leading characters of `text` that are safe to emit and whose
+  // lexical state has been folded into `lex`. Equals `tagIndex` when a tag is
+  // found.
+  safeLength: number
+}
+
+export function createThinkingLexState(): ThinkingLexState {
+  return {
+    inFence: false,
+    fenceChar: '',
+    fenceLen: 0,
+    inlineTicks: 0,
+    quote: '',
+    quoteEscape: false,
+    lastChar: '',
+    atLineStart: true
+  }
+}
+
+export function resetThinkingLexState(lex: ThinkingLexState): void {
+  lex.inFence = false
+  lex.fenceChar = ''
+  lex.fenceLen = 0
+  lex.inlineTicks = 0
+  lex.quote = ''
+  lex.quoteEscape = false
+  lex.lastChar = ''
+  lex.atLineStart = true
+}
+
+function measureRun(text: string, start: number, ch: string): { len: number; complete: boolean } {
+  let len = 0
+  while (start + len < text.length && text[start + len] === ch) len++
+  // The run is "complete" only when a different character follows it inside the
+  // available text. A run that reaches the end of the buffer might continue in
+  // the next chunk, so it cannot be classified yet.
+  return { len, complete: start + len < text.length }
+}
+
+function isPartialTagAtEnd(text: string, index: number, tag: string): boolean {
+  const tail = text.slice(index)
+  return tail.length < tag.length && tag.startsWith(tail)
+}
+
+function isWhitespace(ch: string): boolean {
+  return ch === ' ' || ch === '\t'
+}
+
+function isWordChar(ch: string): boolean {
+  return /[A-Za-z0-9_]/.test(ch)
+}
+
+function isLikelyOpeningSingleQuote(prev: string, next: string | undefined): boolean {
+  if (!next || isWhitespace(next) || next === '\n' || next === '\r') return false
+  return !prev || !isWordChar(prev)
+}
+
+function commitChar(lex: ThinkingLexState, ch: string): void {
+  lex.lastChar = ch
+}
+
+// Scans `text` for the first lexically "real" occurrence of `tag`, folding
+// lexical transitions into `lex`. When `flush` is false the scanner retains
+// trailing characters that could be the prefix of the tag or an unterminated
+// backtick run so that tokens split across chunks are handled correctly on the
+// next call.
+export function scanForTag(
+  text: string,
+  lex: ThinkingLexState,
+  tag: string,
+  flush: boolean
+): ThinkingScanResult {
+  let i = 0
+  let committed = 0
+
+  while (i < text.length) {
+    const ch = text[i]!
+
+    if (ch === '\n') {
+      lex.atLineStart = true
+      i += 1
+      committed = i
+      commitChar(lex, ch)
+      continue
+    }
+
+    if (lex.inFence) {
+      if (lex.atLineStart && ch === lex.fenceChar) {
+        const run = measureRun(text, i, ch)
+        if (!run.complete && !flush) break
+        if (run.len >= lex.fenceLen) {
+          lex.inFence = false
+          lex.fenceChar = ''
+          lex.fenceLen = 0
+        }
+        i += run.len
+        lex.atLineStart = false
+        committed = i
+        commitChar(lex, ch)
+        continue
+      }
+      if (!isWhitespace(ch)) lex.atLineStart = false
+      i += 1
+      committed = i
+      commitChar(lex, ch)
+      continue
+    }
+
+    if (lex.inlineTicks > 0) {
+      if (ch === '`') {
+        const run = measureRun(text, i, ch)
+        if (!run.complete && !flush) break
+        if (run.len === lex.inlineTicks) {
+          lex.inlineTicks = 0
+        }
+        i += run.len
+        lex.atLineStart = false
+        committed = i
+        commitChar(lex, ch)
+        continue
+      }
+      if (!isWhitespace(ch)) lex.atLineStart = false
+      i += 1
+      committed = i
+      commitChar(lex, ch)
+      continue
+    }
+
+    if (lex.quote) {
+      if (lex.quoteEscape) {
+        lex.quoteEscape = false
+      } else if (ch === '\\') {
+        lex.quoteEscape = true
+      } else if (ch === lex.quote) {
+        lex.quote = ''
+      }
+      if (!isWhitespace(ch)) lex.atLineStart = false
+      i += 1
+      committed = i
+      commitChar(lex, ch)
+      continue
+    }
+
+    // Normal (unprotected) state.
+    if (ch === '<') {
+      if (text.startsWith(tag, i)) {
+        return { tagIndex: i, safeLength: i }
+      }
+      if (!flush && isPartialTagAtEnd(text, i, tag)) break
+      lex.atLineStart = false
+      i += 1
+      committed = i
+      commitChar(lex, ch)
+      continue
+    }
+
+    if (ch === '`' || ch === '~') {
+      const run = measureRun(text, i, ch)
+      if (!run.complete && !flush) break
+      if (lex.atLineStart && run.len >= 3) {
+        lex.inFence = true
+        lex.fenceChar = ch
+        lex.fenceLen = run.len
+      } else if (ch === '`') {
+        lex.inlineTicks = run.len
+      }
+      // A tilde run that is not a fence is treated as literal text.
+      i += run.len
+      lex.atLineStart = false
+      committed = i
+      commitChar(lex, ch)
+      continue
+    }
+
+    if (ch === '"' || (ch === "'" && isLikelyOpeningSingleQuote(lex.lastChar, text[i + 1]))) {
+      lex.quote = ch
+      lex.atLineStart = false
+      i += 1
+      committed = i
+      commitChar(lex, ch)
+      continue
+    }
+
+    if (!isWhitespace(ch)) lex.atLineStart = false
+    i += 1
+    committed = i
+    commitChar(lex, ch)
+  }
+
+  return { tagIndex: -1, safeLength: committed }
+}

--- a/src/plugin/streaming/thinking-parser.ts
+++ b/src/plugin/streaming/thinking-parser.ts
@@ -1,0 +1,161 @@
+import { createTextDeltaEvents, createThinkingDeltaEvents, stopBlock } from './stream-state.js'
+import { resetThinkingLexState, scanForTag } from './thinking-lexer.js'
+import { StreamEvent, StreamState, THINKING_END_TAG, THINKING_START_TAG } from './types.js'
+
+export function createContentDeltaEvents(text: string, streamState: StreamState): StreamEvent[] {
+  if (!text) return []
+
+  if (!streamState.thinkingRequested) {
+    return createTextDeltaEvents(text, streamState)
+  }
+
+  streamState.buffer += text
+  return drainThinkingBuffer(streamState, false)
+}
+
+export function flushContentDeltaEvents(streamState: StreamState): StreamEvent[] {
+  const events: StreamEvent[] = []
+
+  if (!streamState.thinkingRequested) {
+    events.push(...createTextDeltaEvents(streamState.buffer, streamState))
+    streamState.buffer = ''
+    return events
+  }
+
+  events.push(...drainThinkingBuffer(streamState, true))
+
+  if (streamState.inThinking) {
+    const remainingThinking = stripThinkingLeadingNewline(streamState.buffer, streamState)
+    if (remainingThinking) {
+      events.push(...createThinkingDeltaEvents(remainingThinking, streamState))
+    }
+    streamState.buffer = ''
+    events.push(...createThinkingDeltaEvents('', streamState))
+    events.push(...stopBlock(streamState.thinkingBlockIndex, streamState))
+    return events
+  }
+
+  if (!streamState.thinkingExtracted) {
+    const remaining = streamState.pendingTextBeforeThinking + streamState.buffer
+    streamState.pendingTextBeforeThinking = ''
+    streamState.buffer = ''
+    events.push(...createTextDeltaEvents(remaining, streamState))
+    return events
+  }
+
+  const remainingText = stripTextLeadingNewlinesAfterThinking(streamState.buffer, streamState)
+  streamState.buffer = ''
+  events.push(...createTextDeltaEvents(remainingText, streamState))
+  return events
+}
+
+function drainThinkingBuffer(
+  streamState: StreamState,
+  allowEndAtBufferEnd: boolean
+): StreamEvent[] {
+  const events: StreamEvent[] = []
+
+  while (streamState.buffer.length > 0) {
+    if (!streamState.inThinking && !streamState.thinkingExtracted) {
+      const scan = scanForTag(
+        streamState.buffer,
+        streamState.thinkingLex,
+        THINKING_START_TAG,
+        allowEndAtBufferEnd
+      )
+      if (scan.tagIndex !== -1) {
+        streamState.pendingTextBeforeThinking = ''
+        streamState.buffer = streamState.buffer.slice(scan.tagIndex + THINKING_START_TAG.length)
+        streamState.inThinking = true
+        streamState.stripThinkingLeadingNewline = true
+        resetThinkingLexState(streamState.thinkingLex)
+        // Content immediately after the open tag is on the same line as the
+        // tag, so it is not at a line start until a newline is stripped below.
+        streamState.thinkingLex.atLineStart = false
+        continue
+      }
+
+      const safeLen = scan.safeLength
+      if (safeLen > 0) {
+        streamState.pendingTextBeforeThinking += streamState.buffer.slice(0, safeLen)
+        streamState.buffer = streamState.buffer.slice(safeLen)
+      }
+      break
+    }
+
+    if (streamState.inThinking) {
+      streamState.buffer = stripThinkingLeadingNewline(streamState.buffer, streamState)
+
+      const scan = scanForTag(
+        streamState.buffer,
+        streamState.thinkingLex,
+        THINKING_END_TAG,
+        allowEndAtBufferEnd
+      )
+
+      if (scan.tagIndex !== -1) {
+        const thinkingPart = streamState.buffer.slice(0, scan.tagIndex)
+        if (thinkingPart) {
+          events.push(...createThinkingDeltaEvents(thinkingPart, streamState))
+        }
+
+        streamState.buffer = streamState.buffer.slice(scan.tagIndex + THINKING_END_TAG.length)
+        streamState.inThinking = false
+        streamState.thinkingExtracted = true
+        streamState.pendingTextBeforeThinking = ''
+        streamState.stripThinkingLeadingNewline = false
+        streamState.stripTextLeadingNewlinesAfterThinking = true
+        resetThinkingLexState(streamState.thinkingLex)
+        events.push(...createThinkingDeltaEvents('', streamState))
+        events.push(...stopBlock(streamState.thinkingBlockIndex, streamState))
+        continue
+      }
+
+      const safeLen = scan.safeLength
+      if (safeLen > 0) {
+        const safeThinking = streamState.buffer.slice(0, safeLen)
+        if (safeThinking) {
+          events.push(...createThinkingDeltaEvents(safeThinking, streamState))
+        }
+        streamState.buffer = streamState.buffer.slice(safeLen)
+      }
+      break
+    }
+
+    const text = stripTextLeadingNewlinesAfterThinking(streamState.buffer, streamState)
+    streamState.buffer = ''
+    events.push(...createTextDeltaEvents(text, streamState))
+    break
+  }
+
+  return events
+}
+
+function stripThinkingLeadingNewline(text: string, streamState: StreamState): string {
+  if (!streamState.stripThinkingLeadingNewline) return text
+  if (text.startsWith('\r\n')) {
+    streamState.stripThinkingLeadingNewline = false
+    streamState.thinkingLex.atLineStart = true
+    return text.slice(2)
+  }
+  if (text.startsWith('\n')) {
+    streamState.stripThinkingLeadingNewline = false
+    streamState.thinkingLex.atLineStart = true
+    return text.slice(1)
+  }
+  if (text !== '\r') {
+    streamState.stripThinkingLeadingNewline = false
+  }
+  return text
+}
+
+function stripTextLeadingNewlinesAfterThinking(text: string, streamState: StreamState): string {
+  if (!streamState.stripTextLeadingNewlinesAfterThinking || !text) return text
+
+  const stripped = text.replace(/^[\r\n]+/, '')
+  if (stripped.length > 0) {
+    streamState.stripTextLeadingNewlinesAfterThinking = false
+  }
+
+  return stripped
+}

--- a/src/plugin/streaming/types.ts
+++ b/src/plugin/streaming/types.ts
@@ -1,3 +1,5 @@
+import type { ThinkingLexState } from './thinking-lexer.js'
+
 export interface StreamEvent {
   type: string
   message?: any
@@ -10,12 +12,16 @@ export interface StreamEvent {
 export interface StreamState {
   thinkingRequested: boolean
   buffer: string
+  pendingTextBeforeThinking: string
   inThinking: boolean
   thinkingExtracted: boolean
   thinkingBlockIndex: number | null
   textBlockIndex: number | null
   nextBlockIndex: number
   stoppedBlocks: Set<number>
+  stripThinkingLeadingNewline: boolean
+  stripTextLeadingNewlinesAfterThinking: boolean
+  thinkingLex: ThinkingLexState
 }
 
 export interface ToolCallState {

--- a/src/plugin/sync/kiro-cli.ts
+++ b/src/plugin/sync/kiro-cli.ts
@@ -50,7 +50,7 @@ export async function syncFromKiroCli() {
         const data = safeJsonParse(row.value)
         if (!data) continue
 
-        const isIdc = row.key.includes('odic')
+        const isIdc = row.key.includes('odic') || row.key.includes('oidc')
         const authMethod = isIdc ? 'idc' : 'desktop'
         const oidcRegion = normalizeRegion(data.region)
         let profileArn: string | undefined = data.profile_arn || data.profileArn
@@ -81,6 +81,7 @@ export async function syncFromKiroCli() {
 
         let usedCount = 0
         let limitCount = 0
+        let subscriptionPlan: string | undefined
         let email: string | undefined
         let usageOk = false
 
@@ -99,9 +100,10 @@ export async function syncFromKiroCli() {
           const u = await fetchUsageLimits(authForUsage)
           usedCount = u.usedCount || 0
           limitCount = u.limitCount || 0
+          subscriptionPlan = typeof u.subscriptionPlan === 'string' ? u.subscriptionPlan : undefined
+          usageOk = true
           if (typeof u.email === 'string' && u.email) {
             email = u.email
-            usageOk = true
           }
         } catch (e) {
           logger.warn('Kiro CLI sync: failed to fetch usage/email; falling back', {
@@ -136,10 +138,12 @@ export async function syncFromKiroCli() {
         if (
           existingById &&
           existingById.is_healthy === 1 &&
+          existingById.refresh_token === refreshToken &&
           existingById.expires_at >= cliExpiresAt &&
           existingById.expires_at > Date.now()
-        )
-          continue
+        ) {
+          if (!usageOk) continue
+        }
 
         if (usageOk) {
           const placeholderEmail = makePlaceholderEmail(
@@ -182,6 +186,22 @@ export async function syncFromKiroCli() {
           }
         }
 
+        // When the usage fetch failed we must not advance the quota snapshot:
+        // carry forward any existing quota and leave the quota sync timestamp
+        // unchanged so mergeAccounts does not treat zeroed counts as newer.
+        const carriedUsedCount = usageOk ? usedCount : existingById?.used_count || 0
+        const carriedLimitCount = usageOk ? limitCount : existingById?.limit_count || 0
+        const carriedSubscriptionPlan = usageOk
+          ? subscriptionPlan
+          : existingById?.subscription_plan || undefined
+        const carriedLastSync = usageOk ? Date.now() : existingById?.last_sync || 0
+        const refreshTokenUpdatedAt =
+          existingById &&
+          existingById.refresh_token !== refreshToken &&
+          existingById.expires_at >= cliExpiresAt
+            ? existingById.refresh_token_updated_at || 0
+            : Date.now()
+
         await kiroDb.upsertAccount({
           id,
           email: resolvedEmail,
@@ -193,14 +213,16 @@ export async function syncFromKiroCli() {
           profileArn,
           startUrl,
           refreshToken,
+          refreshTokenUpdatedAt,
           accessToken,
           expiresAt: cliExpiresAt,
           rateLimitResetTime: 0,
           isHealthy: true,
           failCount: 0,
-          usedCount,
-          limitCount,
-          lastSync: Date.now()
+          usedCount: carriedUsedCount,
+          limitCount: carriedLimitCount,
+          subscriptionPlan: carriedSubscriptionPlan,
+          lastSync: carriedLastSync
         })
 
         syncedAccounts.push({
@@ -225,21 +247,70 @@ export async function syncFromKiroCli() {
   }
 }
 
-export async function writeToKiroCli(acc: any) {
+export async function writeToKiroCli(acc: any, previousRefreshToken?: string) {
   const dbPath = getCliDbPath()
   if (!existsSync(dbPath)) return
   try {
     const cliDb = new Database(dbPath)
     cliDb.pragma('busy_timeout = 5000')
     const rows = cliDb.prepare('SELECT key, value FROM auth_kv').all() as any[]
-    const targetKey = acc.authMethod === 'idc' ? 'kirocli:odic:token' : 'kirocli:social:token'
-    const row = rows.find((r) => r.key === targetKey || r.key.endsWith(targetKey))
-    if (row) {
-      const data = JSON.parse(row.value)
+    const tokenRows = rows
+      .filter((row) => {
+        if (typeof row?.key !== 'string') return false
+        if (acc.authMethod === 'idc') {
+          return (
+            row.key.includes(':token') && (row.key.includes('odic') || row.key.includes('oidc'))
+          )
+        }
+        return row.key === 'kirocli:social:token' || row.key.endsWith('kirocli:social:token')
+      })
+      .map((row) => ({ row, data: safeJsonParse(row.value) }))
+      .filter(({ data }) => data)
+
+    const expected = {
+      clientId: acc.clientId,
+      profileArn: acc.profileArn,
+      startUrl: acc.startUrl,
+      refreshToken: previousRefreshToken || acc.refreshToken
+    }
+    const matches = tokenRows.filter(({ data }) => {
+      const embedded = {
+        clientId: data.client_id || data.clientId,
+        profileArn: data.profile_arn || data.profileArn,
+        startUrl: data.start_url || data.startUrl,
+        refreshToken: data.refresh_token || data.refreshToken
+      }
+      if (expected.profileArn && !embedded.profileArn) {
+        if (!expected.refreshToken || expected.refreshToken !== embedded.refreshToken) return false
+      }
+      let stableIdentityAgreed = false
+      for (const key of ['clientId', 'profileArn', 'startUrl'] as const) {
+        if (!expected[key] || !embedded[key]) continue
+        if (expected[key] !== embedded[key]) return false
+        stableIdentityAgreed = true
+      }
+      if (stableIdentityAgreed) return true
+      return !!expected.refreshToken && expected.refreshToken === embedded.refreshToken
+    })
+
+    if (matches.length === 1) {
+      const { row, data } = matches[0]!
       data.access_token = acc.accessToken
       data.refresh_token = acc.refreshToken
       data.expires_at = new Date(acc.expiresAt).toISOString()
-      cliDb.prepare('UPDATE auth_kv SET value = ? WHERE key = ?').run(JSON.stringify(data), row.key)
+      const result = cliDb
+        .prepare('UPDATE auth_kv SET value = ? WHERE key = ? AND value = ?')
+        .run(JSON.stringify(data), row.key, row.value)
+      if (result.changes !== 1) {
+        logger.warn('Write back skipped: Kiro CLI token changed concurrently', {
+          authMethod: acc.authMethod
+        })
+      }
+    } else if (matches.length > 1) {
+      logger.warn('Write back skipped: Kiro CLI token identity is ambiguous', {
+        authMethod: acc.authMethod,
+        matches: matches.length
+      })
     }
     cliDb.close()
   } catch (e) {

--- a/src/plugin/sync/stale-accounts.ts
+++ b/src/plugin/sync/stale-accounts.ts
@@ -1,5 +1,3 @@
-import { isPermanentError } from '../health'
-
 export type SyncedCliAccount = {
   id: string
   email: string
@@ -27,19 +25,11 @@ export function getStaleKiroCliAccountIds(
       const email = account.email
       const clientId = account.client_id || account.clientId
       const profileArn = account.profile_arn || account.profileArn
-      const lastSync = account.last_sync || account.lastSync || 0
-      const unhealthyReason = account.unhealthy_reason || account.unhealthyReason
-
       return syncedAccounts.some((synced) => {
-        const sameAuthMethod = authMethod === synced.authMethod
-        const sameEmail = !!email && email === synced.email
-        const sameClient = !!clientId && clientId === synced.clientId
-        const sameProfile = !!profileArn && profileArn === synced.profileArn
-        const sameIdentity = sameEmail || sameClient || sameProfile
-
-        if (sameAuthMethod && sameIdentity) return true
-        if (sameAuthMethod && lastSync > 0) return true
-        return isPermanentError(unhealthyReason) && sameIdentity
+        if (authMethod !== synced.authMethod) return false
+        if (profileArn && synced.profileArn) return profileArn === synced.profileArn
+        if (clientId && synced.clientId) return clientId === synced.clientId
+        return !!email && email === synced.email
       })
     })
     .map((account) => account.id)

--- a/src/plugin/token.ts
+++ b/src/plugin/token.ts
@@ -1,13 +1,31 @@
+import { getOidcEndpoint } from '../constants'
 import { decodeRefreshToken, encodeRefreshToken } from '../kiro/auth'
 import { KiroTokenRefreshError } from './errors'
 import type { KiroAuthDetails, RefreshParts } from './types'
+
+const REFRESH_TIMEOUT_MS = 30000
+const REFRESH_NETWORK_ATTEMPTS = 2
+const REFRESH_RETRY_DELAY_MS = 200
+
+function isTransientNetworkError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  const code =
+    (error as Error & { code?: string; cause?: { code?: string } }).code ||
+    (error as Error & { cause?: { code?: string } }).cause?.code
+  return (
+    error.name === 'AbortError' ||
+    error.name === 'TimeoutError' ||
+    error.name === 'TypeError' ||
+    ['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND', 'EAI_AGAIN'].includes(code || '')
+  )
+}
 
 export async function refreshAccessToken(auth: KiroAuthDetails): Promise<KiroAuthDetails> {
   const p = decodeRefreshToken(auth.refresh)
   const isIdc = auth.authMethod === 'idc'
   const oidcRegion = auth.oidcRegion || auth.region
   const url = isIdc
-    ? `https://oidc.${oidcRegion}.amazonaws.com/token`
+    ? `${getOidcEndpoint(oidcRegion)}/token`
     : `https://prod.${auth.region}.auth.desktop.kiro.dev/refreshToken`
 
   if (isIdc && (!p.clientId || !p.clientSecret)) {
@@ -30,18 +48,30 @@ export async function refreshAccessToken(auth: KiroAuthDetails): Promise<KiroAut
     : 'aws-sdk-js/3.0.0 KiroIDE-0.1.0 os/macos lang/js md/nodejs/18.0.0'
 
   try {
-    const res = await fetch(url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Accept: 'application/json',
-        'amz-sdk-request': 'attempt=1; max=1',
-        'x-amzn-kiro-agent-mode': 'vibe',
-        'user-agent': ua,
-        Connection: 'close'
-      },
-      body: JSON.stringify(requestBody)
-    })
+    let res: Response | undefined
+    for (let attempt = 0; attempt < REFRESH_NETWORK_ATTEMPTS; attempt++) {
+      try {
+        res = await fetch(url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+            'amz-sdk-request': `attempt=${attempt + 1}; max=${REFRESH_NETWORK_ATTEMPTS}`,
+            'x-amzn-kiro-agent-mode': 'vibe',
+            'user-agent': ua,
+            Connection: 'close'
+          },
+          body: JSON.stringify(requestBody),
+          signal: AbortSignal.timeout(REFRESH_TIMEOUT_MS)
+        })
+        break
+      } catch (error) {
+        if (attempt + 1 >= REFRESH_NETWORK_ATTEMPTS || !isTransientNetworkError(error)) throw error
+        await new Promise((resolve) => setTimeout(resolve, REFRESH_RETRY_DELAY_MS))
+      }
+    }
+
+    if (!res) throw new Error('Token refresh did not receive a response')
 
     if (!res.ok) {
       const txt = await res.text()

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -37,6 +37,7 @@ export interface ManagedAccount {
   profileArn?: string
   startUrl?: string
   refreshToken: string
+  refreshTokenUpdatedAt?: number
   accessToken: string
   expiresAt: number
   rateLimitResetTime: number
@@ -46,6 +47,7 @@ export interface ManagedAccount {
   failCount: number
   usedCount?: number
   limitCount?: number
+  subscriptionPlan?: string
   lastSync?: number
   lastUsed?: number
 }

--- a/src/plugin/usage-format.ts
+++ b/src/plugin/usage-format.ts
@@ -1,0 +1,14 @@
+export function formatUsageValue(value: number, fractionDigits = 2): string {
+  if (!Number.isFinite(value)) return (0).toFixed(fractionDigits)
+  return value.toFixed(fractionDigits)
+}
+
+export function formatUsageLimit(value: number): string {
+  if (!Number.isFinite(value)) return '0'
+  return Number.isInteger(value) ? String(value) : value.toFixed(2)
+}
+
+export function formatUsageRatio(used: number, limit: number): string {
+  if (limit <= 0) return formatUsageValue(used)
+  return `${formatUsageValue(used)} / ${formatUsageLimit(limit)}`
+}

--- a/src/plugin/usage.ts
+++ b/src/plugin/usage.ts
@@ -1,8 +1,48 @@
 import { KiroAuthDetails, ManagedAccount } from './types'
 
+export function getUsageEndpointBases(region: string): string[] {
+  // Kiro documents q.<region>.amazonaws.com as legacy but still required until
+  // deprecation completes: https://kiro.dev/docs/cli/privacy-and-security/firewalls/
+  if (region.startsWith('us-gov-')) return [`https://q-fips.${region}.amazonaws.com`]
+  return [`https://management.${region}.kiro.dev`, `https://q.${region}.amazonaws.com`]
+}
+
+export function normalizeSubscriptionPlan(data: any): string | undefined {
+  const plan =
+    data?.subscriptionInfo?.subscriptionTitle ||
+    data?.subscription?.title ||
+    data?.subscriptionInfo?.tier ||
+    data?.subscription?.tier ||
+    data?.tierId
+
+  if (typeof plan !== 'string') return undefined
+  const cleaned = plan.trim()
+  return cleaned || undefined
+}
+
+export function extractUsageTotals(data: any): { usedCount: number; limitCount: number } {
+  let usedCount = 0
+  let limitCount = 0
+
+  if (Array.isArray(data?.usageBreakdownList)) {
+    for (const s of data.usageBreakdownList) {
+      if (s.freeTrialInfo) {
+        usedCount += s.freeTrialInfo.currentUsageWithPrecision ?? s.freeTrialInfo.currentUsage ?? 0
+        limitCount += s.freeTrialInfo.usageLimitWithPrecision ?? s.freeTrialInfo.usageLimit ?? 0
+      }
+      usedCount += s.currentUsageWithPrecision ?? s.currentUsage ?? 0
+      limitCount += s.usageLimitWithPrecision ?? s.usageLimit ?? 0
+    }
+  }
+
+  return { usedCount, limitCount }
+}
+
 export async function fetchUsageLimits(auth: KiroAuthDetails): Promise<any> {
   // Try different parameter combinations
   const attempts: Array<{ resourceType?: string; origin?: string }> = [
+    { origin: 'KIRO_CLI' },
+    { resourceType: 'AGENTIC_REQUEST', origin: 'KIRO_CLI' },
     { resourceType: 'AGENTIC_REQUEST', origin: 'AI_EDITOR' },
     { origin: 'AI_EDITOR' },
     { resourceType: 'CONVERSATION', origin: 'AI_EDITOR' },
@@ -11,67 +51,69 @@ export async function fetchUsageLimits(auth: KiroAuthDetails): Promise<any> {
 
   let lastError: Error | null = null
 
-  for (const [index, params] of attempts.entries()) {
-    const url = new URL(`https://q.${auth.region}.amazonaws.com/getUsageLimits`)
-    url.searchParams.set('isEmailRequired', 'true')
-    if (params.origin) url.searchParams.set('origin', params.origin)
-    if (params.resourceType) url.searchParams.set('resourceType', params.resourceType)
-    if (auth.profileArn) url.searchParams.set('profileArn', auth.profileArn)
+  const endpointBases = getUsageEndpointBases(auth.region)
 
-    try {
-      const res = await fetch(url.toString(), {
-        method: 'GET',
-        headers: {
-          Authorization: `Bearer ${auth.access}`,
-          'Content-Type': 'application/json',
-          'x-amzn-kiro-agent-mode': 'vibe',
-          'amz-sdk-request': 'attempt=1; max=1'
-        }
-      })
+  for (const [endpointIndex, endpointBase] of endpointBases.entries()) {
+    for (const [attemptIndex, params] of attempts.entries()) {
+      const url = new URL(`${endpointBase}/getUsageLimits`)
+      url.searchParams.set('isEmailRequired', 'true')
+      if (params.origin) url.searchParams.set('origin', params.origin)
+      if (params.resourceType) url.searchParams.set('resourceType', params.resourceType)
+      if (auth.profileArn) url.searchParams.set('profileArn', auth.profileArn)
 
-      if (!res.ok) {
-        const body = await res.text().catch(() => '')
-        const requestId =
-          res.headers.get('x-amzn-requestid') ||
-          res.headers.get('x-amzn-request-id') ||
-          res.headers.get('x-amz-request-id') ||
-          ''
-        const errType =
-          res.headers.get('x-amzn-errortype') || res.headers.get('x-amzn-error-type') || ''
+      try {
+        const res = await fetch(url.toString(), {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${auth.access}`,
+            'Content-Type': 'application/json',
+            'x-amzn-kiro-agent-mode': 'vibe',
+            'amz-sdk-request': 'attempt=1; max=1'
+          },
+          signal: AbortSignal.timeout(30000)
+        })
 
-        if (body.includes('FEATURE_NOT_SUPPORTED') && index < attempts.length - 1) {
+        if (!res.ok) {
+          const body = await res.text().catch(() => '')
+          const requestId =
+            res.headers.get('x-amzn-requestid') ||
+            res.headers.get('x-amzn-request-id') ||
+            res.headers.get('x-amz-request-id') ||
+            ''
+          const errType =
+            res.headers.get('x-amzn-errortype') || res.headers.get('x-amzn-error-type') || ''
+
+          if (
+            body.includes('FEATURE_NOT_SUPPORTED') &&
+            (attemptIndex < attempts.length - 1 || endpointIndex < endpointBases.length - 1)
+          ) {
+            continue
+          }
+
+          const msg =
+            body && body.length > 0
+              ? `${body.slice(0, 2000)}${body.length > 2000 ? '…' : ''}`
+              : `HTTP ${res.status}`
+          lastError = new Error(
+            `Status: ${res.status}${errType ? ` (${errType})` : ''}${
+              requestId ? ` [${requestId}]` : ''
+            }: ${msg}`
+          )
           continue
         }
 
-        const msg =
-          body && body.length > 0
-            ? `${body.slice(0, 2000)}${body.length > 2000 ? '…' : ''}`
-            : `HTTP ${res.status}`
-        lastError = new Error(
-          `Status: ${res.status}${errType ? ` (${errType})` : ''}${
-            requestId ? ` [${requestId}]` : ''
-          }: ${msg}`
-        )
-        continue
-      }
-
-      const data: any = await res.json()
-      let usedCount = 0,
-        limitCount = 0
-      if (Array.isArray(data.usageBreakdownList)) {
-        for (const s of data.usageBreakdownList) {
-          if (s.freeTrialInfo) {
-            usedCount += s.freeTrialInfo.currentUsage || 0
-            limitCount += s.freeTrialInfo.usageLimit || 0
-          }
-          usedCount += s.currentUsage || 0
-          limitCount += s.usageLimit || 0
+        const data: any = await res.json()
+        const { usedCount, limitCount } = extractUsageTotals(data)
+        return {
+          usedCount,
+          limitCount,
+          email: data.userInfo?.email,
+          subscriptionPlan: normalizeSubscriptionPlan(data)
         }
+      } catch (e) {
+        lastError = e instanceof Error ? e : new Error(String(e))
+        if (attemptIndex < attempts.length - 1 || endpointIndex < endpointBases.length - 1) continue
       }
-      return { usedCount, limitCount, email: data.userInfo?.email }
-    } catch (e) {
-      lastError = e instanceof Error ? e : new Error(String(e))
-      if (index < attempts.length - 1) continue
     }
   }
 
@@ -86,10 +128,14 @@ export function updateAccountQuota(
   const meta = {
     usedCount: usage.usedCount || 0,
     limitCount: usage.limitCount || 0,
-    email: usage.email
+    email: usage.email,
+    subscriptionPlan: usage.subscriptionPlan,
+    lastSync: Date.now()
   }
   account.usedCount = meta.usedCount
   account.limitCount = meta.limitCount
+  account.lastSync = meta.lastSync
   if (usage.email) account.email = usage.email
+  if (usage.subscriptionPlan) account.subscriptionPlan = usage.subscriptionPlan
   if (accountManager) accountManager.updateUsage(account.id, meta)
 }

--- a/src/tui-usage.ts
+++ b/src/tui-usage.ts
@@ -1,0 +1,160 @@
+import { Database } from 'bun:sqlite'
+import { existsSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { formatUsageRatio } from './plugin/usage-format.js'
+
+export const USAGE_REFRESH_INTERVAL_MS = 15000
+
+export type UsageAccount = {
+  email: string
+  authMethod: string
+  region: string
+  usedCount: number
+  limitCount: number
+  subscriptionPlan?: string
+  isHealthy: boolean
+  lastSync: number
+  lastUsed: number
+}
+
+export type UsageSnapshot = {
+  accounts: UsageAccount[]
+  error?: string
+}
+
+export type UsageSummary = {
+  account?: UsageAccount
+  plan: string
+  used: number
+  limit: number
+}
+
+export type TuiDisplayOptions = {
+  showAccountEmail: boolean
+  showPlan: boolean
+  showCredits: boolean
+}
+
+export type SessionProviderMessage = {
+  providerID?: string
+  model?: {
+    providerID?: string
+  }
+  info?: {
+    providerID?: string
+  }
+}
+
+export function getOpencodeConfigDir(): string {
+  if (process.platform === 'win32') {
+    return join(process.env.APPDATA || join(homedir(), 'AppData', 'Roaming'), 'opencode')
+  }
+  return join(process.env.XDG_CONFIG_HOME || join(homedir(), '.config'), 'opencode')
+}
+
+export function getDefaultKiroDbPath(): string {
+  return join(getOpencodeConfigDir(), 'kiro.db')
+}
+
+export function readUsageSnapshot(dbPath = getDefaultKiroDbPath()): UsageSnapshot {
+  if (!existsSync(dbPath)) return { accounts: [] }
+
+  let db: Database | undefined
+  try {
+    db = new Database(dbPath, { readonly: true })
+    const columns = db.prepare('PRAGMA table_info(accounts)').all() as Array<{ name: string }>
+    const names = new Set(columns.map((column) => column.name))
+    const subscriptionColumn = names.has('subscription_plan')
+      ? 'subscription_plan'
+      : 'NULL AS subscription_plan'
+
+    const rows = db
+      .prepare(
+        `
+        SELECT email, auth_method, region, used_count, limit_count, ${subscriptionColumn},
+               is_healthy, last_sync, last_used
+        FROM accounts
+        ORDER BY last_used DESC, email ASC
+      `
+      )
+      .all() as any[]
+
+    return { accounts: rows.map(normalizeUsageAccount) }
+  } catch (error) {
+    return { accounts: [], error: error instanceof Error ? error.message : String(error) }
+  } finally {
+    db?.close()
+  }
+}
+
+function normalizeUsageAccount(row: any): UsageAccount {
+  return {
+    email: String(row.email || ''),
+    authMethod: String(row.auth_method || ''),
+    region: String(row.region || ''),
+    usedCount: Number(row.used_count || 0),
+    limitCount: Number(row.limit_count || 0),
+    subscriptionPlan: typeof row.subscription_plan === 'string' ? row.subscription_plan : undefined,
+    isHealthy: row.is_healthy === 1 || row.is_healthy === true,
+    lastSync: Number(row.last_sync || 0),
+    lastUsed: Number(row.last_used || 0)
+  }
+}
+
+export function planLabel(account: UsageAccount | undefined): string {
+  if (!account) return 'Kiro'
+  if (account.subscriptionPlan) return account.subscriptionPlan
+  return account.authMethod === 'idc' ? 'Q Developer' : 'Kiro'
+}
+
+export function summarizeUsage(snapshot: UsageSnapshot): UsageSummary {
+  const account = snapshot.accounts.find((item) => item.isHealthy) || snapshot.accounts[0]
+  const used = account?.usedCount || 0
+  const limit = account?.limitCount || 0
+
+  return {
+    account,
+    plan: planLabel(account),
+    used,
+    limit
+  }
+}
+
+export function formatRequestQuota(summary: UsageSummary): string {
+  return `Credits: ${formatUsageRatio(summary.used, summary.limit)}`
+}
+
+export function resolveTuiDisplayOptions(options: Record<string, unknown> = {}): TuiDisplayOptions {
+  return {
+    showAccountEmail: options.show_account_email === true,
+    showPlan: options.show_plan !== false,
+    showCredits: options.show_credits !== false
+  }
+}
+
+export function isKiroProviderID(providerID: string | undefined): boolean {
+  return providerID === 'kiro'
+}
+
+export function getMessageProviderID(message: SessionProviderMessage): string | undefined {
+  return message.providerID || message.model?.providerID || message.info?.providerID
+}
+
+export function getSessionProviderID(
+  messages: ReadonlyArray<SessionProviderMessage>
+): string | undefined {
+  const message = messages.findLast((item) => getMessageProviderID(item))
+  return message ? getMessageProviderID(message) : undefined
+}
+
+export function shouldShowKiroUsage(
+  messages: ReadonlyArray<SessionProviderMessage>,
+  fallbackModel?: string
+): boolean {
+  const sessionProviderID = getSessionProviderID(messages)
+  if (sessionProviderID) return isKiroProviderID(sessionProviderID)
+
+  const fallbackProviderID = fallbackModel?.split('/')[0]
+  return isKiroProviderID(fallbackProviderID)
+}

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -1,0 +1,90 @@
+/** @jsxImportSource @opentui/solid */
+import type { TuiPlugin, TuiPluginApi } from '@opencode-ai/plugin/tui'
+import { createMemo, createSignal, Show, type Accessor } from 'solid-js'
+import {
+  formatRequestQuota,
+  readUsageSnapshot,
+  resolveTuiDisplayOptions,
+  shouldShowKiroUsage,
+  summarizeUsage,
+  USAGE_REFRESH_INTERVAL_MS,
+  type TuiDisplayOptions,
+  type UsageSnapshot
+} from './tui-usage.js'
+
+function UsageSidebar(props: {
+  api: TuiPluginApi
+  sessionID: string
+  snapshot: Accessor<UsageSnapshot>
+  display: TuiDisplayOptions
+}) {
+  const theme = () => props.api.theme.current
+  const messages = createMemo(() => props.api.state.session.messages(props.sessionID))
+  const enabled = createMemo(() => shouldShowKiroUsage(messages(), props.api.state.config.model))
+  const summary = createMemo(() => summarizeUsage(props.snapshot()))
+  const account = createMemo(() => summary().account)
+
+  return (
+    <Show when={enabled()}>
+      <box gap={0}>
+        <text fg={theme().text} wrapMode="none">
+          <b>Kiro</b>
+        </text>
+        <Show when={account()} fallback={<text fg={theme().textMuted}>No quota data</text>}>
+          <box gap={0}>
+            <Show when={props.display.showAccountEmail}>
+              <text fg={theme().textMuted} wrapMode="none">
+                Account: {account()?.email}
+              </text>
+            </Show>
+            <Show when={props.display.showPlan}>
+              <text fg={theme().textMuted} wrapMode="none">
+                Plan: {summary().plan}
+              </text>
+            </Show>
+            <Show when={props.display.showCredits}>
+              <text fg={theme().textMuted} wrapMode="none">
+                {formatRequestQuota(summary())}
+              </text>
+            </Show>
+          </box>
+        </Show>
+        <Show when={props.snapshot().error}>
+          {(error) => <text fg={theme().warning}>Usage unavailable: {error()}</text>}
+        </Show>
+      </box>
+    </Show>
+  )
+}
+
+const tui: TuiPlugin = async (api, options) => {
+  const display = resolveTuiDisplayOptions(options)
+  const [snapshot, setSnapshot] = createSignal(readUsageSnapshot())
+  const refresh = () => setSnapshot(readUsageSnapshot())
+  const timer = setInterval(refresh, USAGE_REFRESH_INTERVAL_MS)
+  api.lifecycle.onDispose(() => clearInterval(timer))
+  api.event.on('session.idle', refresh)
+  api.event.on('message.updated', refresh)
+  refresh()
+
+  api.slots.register({
+    order: 90,
+    slots: {
+      sidebar_content(_ctx, props) {
+        return (
+          <UsageSidebar
+            api={api}
+            sessionID={props.session_id}
+            snapshot={snapshot}
+            display={display}
+          />
+        )
+      }
+    }
+  })
+}
+
+export default {
+  id: 'kiro-auth-usage',
+  tui
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,8 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
   "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["**/*.test.ts", "**/*.spec.ts", "src/__tests__/database-init-worker.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,8 @@
     "target": "ESNext",
     "module": "Preserve",
     "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "jsxImportSource": "@opentui/solid",
     "types": ["bun-types", "node"],
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary

Modernizes the Kiro provider across models, authentication, request handling, storage, packaging, and TUI integration.

### Models and reasoning
- Refresh the built-in catalog with current Kiro models, context limits, modalities, and credit multipliers.
- Add native effort variants, including model-specific Claude and GPT-5.6 request schemas.
- Preserve legacy aliases while keeping the default catalog aligned with current model IDs.

### Authentication and storage
- Harden Kiro CLI sync, token refresh, profile identity matching, and conditional credential writeback.
- Add partition-aware IAM Identity Center handling, bounded network requests, GovCloud FIPS endpoints, and secure OIDC client caching.
- Protect credential files and database operations with atomic writes, private permissions, interprocess locking, and concurrent migration safety.

### Requests and streaming
- Add Kiro runtime endpoint support with targeted legacy endpoint fallback.
- Preserve successful-response stream errors instead of reporting misleading `Kiro Error: 200` failures.
- Improve thinking extraction across split tags, quoted/code literals, plain-text responses, tool calls, and usage metadata.

### Usage and TUI
- Track quota as credits and preserve valid snapshots when usage lookup fails.
- Add a packaged TUI entrypoint with configurable account, plan, and credit display.
- Document installation, authentication, model variants, configuration, and troubleshooting.

### Packaging and tests
- Publish root and TUI exports and prepare release metadata for `1.12.0`.
- Add regression coverage for auth concurrency, token recovery, CLI writeback, OIDC caching, endpoint fallback, model effort payloads, streaming, storage migrations, and TUI usage.

## Validation

- `bun run check`
- 137 tests across 20 files
- TypeScript build and Prettier checks
- `npm pack --dry-run`
- Live Kiro smoke tests for GPT-5.6 effort variants, Claude Sonnet 4.6, and Claude Sonnet 5