### PR TITLE
fix: return HTTP 400 Response for overflow to trigger opencode compaction

### DIFF
--- a/src/core/request/request-handler.ts
+++ b/src/core/request/request-handler.ts
@@ -212,7 +212,23 @@ export class RequestHandler {
             continue
           }
 
-          throw new Error(`Kiro Error: ${httpStatus}`)
+          const errMsg = e?.message || `Kiro Error: ${httpStatus}`
+          if (/input is too long/i.test(errMsg)) {
+            return new Response(
+              JSON.stringify({
+                error: {
+                  message: 'input is too long for requested model',
+                  type: 'invalid_request_error',
+                  code: 'context_length_exceeded'
+                }
+              }),
+              {
+                status: 400,
+                headers: { 'Content-Type': 'application/json' }
+              }
+            )
+          }
+          throw new Error(errMsg)
         }
 
         const networkResult = await this.errorHandler.handleNetworkError(e, { retry }, showToast)


### PR DESCRIPTION
## Problem

When Kiro API returns "Input is too long" (400), the plugin was throwing a plain `Error`. This bypassed ai-sdk's `APICallError` handling, so OpenCode never recognized it as a context overflow and never triggered automatic compaction.

## Solution

Return a proper HTTP 400 `Response` object with:
- `message: "input is too long for requested model"` (matches OpenCode's overflow pattern)
- `type: "invalid_request_error"`
- `code: "context_length_exceeded"`

This allows ai-sdk to convert it into an `APICallError`, which OpenCode then pattern-matches to trigger compaction retry.

## Testing

- Verified overflow scenario now triggers compaction instead of showing a terminal error.