### PR TITLE
Add Claude Opus 5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,21 @@ Add the plugin to your `opencode.json` or `opencode.jsonc`:
             "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
           }
         },
+        "claude-opus-5": {
+          "name": "Claude Opus 5",
+          "limit": { "context": 1000000, "output": 64000 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
+        },
+        "claude-opus-5-thinking": {
+          "name": "Claude Opus 5 Thinking",
+          "limit": { "context": 1000000, "output": 64000 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+          "variants": {
+            "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
+            "medium": { "thinkingConfig": { "thinkingBudget": 16384 } },
+            "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
+          }
+        },
         "claude-sonnet-4-5-1m": {
           "name": "Claude Sonnet 4.5 (1M Context)",
           "limit": { "context": 1000000, "output": 64000 },

--- a/src/__tests__/effort.test.ts
+++ b/src/__tests__/effort.test.ts
@@ -16,6 +16,7 @@ describe('effort module', () => {
       expect(supportsEffort('claude-sonnet-4.6-1m')).toBe(true)
       expect(supportsEffort('claude-sonnet-5')).toBe(true)
       expect(supportsEffort('claude-sonnet-5-1m')).toBe(true)
+      expect(supportsEffort('claude-opus-5')).toBe(true)
     })
 
     test('returns false for unsupported models', () => {
@@ -25,9 +26,10 @@ describe('effort module', () => {
   })
 
   describe('supportsXHighEffort', () => {
-    test('returns true for opus 4.7 and 4.8', () => {
+    test('returns true for opus 4.7, 4.8 and 5', () => {
       expect(supportsXHighEffort('claude-opus-4.8')).toBe(true)
       expect(supportsXHighEffort('claude-opus-4.7')).toBe(true)
+      expect(supportsXHighEffort('claude-opus-5')).toBe(true)
     })
 
     test('returns false for other models', () => {
@@ -45,6 +47,8 @@ describe('effort module', () => {
       expect(resolveEffort('claude-opus-4.8', 'low')).toBe('low')
       expect(resolveEffort('claude-opus-4.8', 'max')).toBe('max')
       expect(resolveEffort('claude-opus-4.8', 'xhigh')).toBe('xhigh')
+      expect(resolveEffort('claude-opus-5', 'xhigh')).toBe('xhigh')
+      expect(resolveEffort('claude-opus-5', 'max')).toBe('max')
     })
 
     test('clamps xhigh to max for models without xhigh support', () => {
@@ -88,6 +92,8 @@ describe('effort module', () => {
     test('uses budget mapping when thinking and auto-mapping enabled', () => {
       expect(getEffectiveEffort('claude-opus-4.8', true, 128000, undefined, true)).toBe('max')
       expect(getEffectiveEffort('claude-opus-4.8', true, 20000, undefined, true)).toBe('medium')
+      expect(getEffectiveEffort('claude-opus-5', true, 32768, undefined, true)).toBe('max')
+      expect(getEffectiveEffort('claude-opus-5', true, 8192, undefined, true)).toBe('low')
     })
 
     test('falls back to medium when auto-mapping disabled', () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -78,6 +78,8 @@ export const MODEL_MAPPING: Record<string, string> = {
   'claude-opus-4-7-thinking': 'claude-opus-4.7',
   'claude-opus-4-8': 'claude-opus-4.8',
   'claude-opus-4-8-thinking': 'claude-opus-4.8',
+  'claude-opus-5': 'claude-opus-5',
+  'claude-opus-5-thinking': 'claude-opus-5',
   // Auto
   auto: 'auto',
   // Open weight models

--- a/src/plugin/effort.ts
+++ b/src/plugin/effort.ts
@@ -9,7 +9,7 @@ export const EFFORT_LEVELS: readonly Effort[] = ['low', 'medium', 'high', 'xhigh
  * Models that support the 5-value effort enum (including xhigh).
  * These models support up to 128k thinking tokens with max effort.
  */
-const XHIGH_CAPABLE_MODELS = new Set(['claude-opus-4.7', 'claude-opus-4.8'])
+const XHIGH_CAPABLE_MODELS = new Set(['claude-opus-4.7', 'claude-opus-4.8', 'claude-opus-5'])
 
 /**
  * Models that support the 4-value effort enum (no xhigh).


### PR DESCRIPTION
This PR adds support for Claude Opus 5, which is now available in Kiro according to https://kiro.dev/blog/opus-5/.

## Changes

- Added model mappings for `claude-opus-5` and `claude-opus-5-thinking` in `src/constants.ts`
- Registered `claude-opus-5` as effort capable, in the xhigh tier alongside Opus 4.7 and 4.8
- Added the two models to the README example config
- Extended the effort test suite with Opus 5 cases

## Effort support

Per https://kiro.dev/docs/cli/chat/effort/, Claude Opus 5 accepts the full five value effort enum (`low`, `medium`, `high`, `xhigh`, `max`), the same as Opus 4.7 and 4.8. Opus 4.6 is limited to four values, so Opus 5 goes in `XHIGH_CAPABLE_MODELS` rather than the four value set.

Without this the model was registered but got no effort field on the request, so Kiro never allocated a reasoning budget and no thinking output was produced.

## Notes

No explicit `-1m` model IDs are added. Kiro does not expose separate long context IDs for Opus 5, so only the two base IDs are mapped. The 1M context is reflected in the `limit.context` value.

The docs list a `max_tokens` ceiling of 128000 for Opus 5. The README example keeps `output: 64000` to stay consistent with how Opus 4.8 is already declared. Raising the declared output limit for both is left for a separate change.

## Testing

- Type checking passed (`tsc --noEmit`)
- Build passed (`tsc -p tsconfig.build.json` plus the ESM import fixup)
- Prettier formatting check passed
- Effort resolution verified against the built output: `supportsEffort`, `supportsXHighEffort`, `resolveEffort`, `budgetToEffort` and `getEffectiveEffort` all return the expected values for `claude-opus-5`

Note: `bun` is not installed in my environment, so `bun test` was not run. The effort behaviour was verified directly against `dist/` instead.

## Reference

- Kiro blog post announcing Opus 5: https://kiro.dev/blog/opus-5/
- Effort levels per model: https://kiro.dev/docs/cli/chat/effort/
