### PR TITLE
feat(models): discover context windows from Kiro catalog

### DIFF
--- a/src/__tests__/models.test.ts
+++ b/src/__tests__/models.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'bun:test'
+import { getContextWindowSize } from '../plugin/models.js'
+
+describe('getContextWindowSize', () => {
+  test('uses the configured long context size for standard model aliases', () => {
+    expect(getContextWindowSize('claude-sonnet-4-6')).toBe(1_000_000)
+    expect(getContextWindowSize('claude-opus-4-6')).toBe(1_000_000)
+  })
+
+  test('preserves the standard context size for standard models', () => {
+    expect(getContextWindowSize('claude-sonnet-4-5')).toBe(200_000)
+    expect(getContextWindowSize('deepseek-3.2')).toBe(128_000)
+  })
+
+  test('supports explicit 1m model aliases', () => {
+    expect(getContextWindowSize('claude-sonnet-4-6-1m')).toBe(1_000_000)
+  })
+})

--- a/src/__tests__/models.test.ts
+++ b/src/__tests__/models.test.ts
@@ -1,18 +1,40 @@
 import { describe, expect, test } from 'bun:test'
-import { getContextWindowSize } from '../plugin/models.js'
+import {
+  clearContextWindowCatalog,
+  getContextWindowSize,
+  refreshContextWindowSizes
+} from '../plugin/models.js'
+import type { KiroAuthDetails } from '../plugin/types.js'
+
+const auth: KiroAuthDetails = {
+  access: 'test-token',
+  refresh: 'test-refresh',
+  expires: Date.now() + 60_000,
+  authMethod: 'idc',
+  region: 'us-east-1'
+}
 
 describe('getContextWindowSize', () => {
-  test('uses the configured long context size for standard model aliases', () => {
-    expect(getContextWindowSize('claude-sonnet-4-6')).toBe(1_000_000)
-    expect(getContextWindowSize('claude-opus-4-6')).toBe(1_000_000)
-  })
+  test('uses maxInputTokens from the live model catalog for aliases', async () => {
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          models: [
+            { modelId: 'claude-sonnet-4.6', tokenLimits: { maxInputTokens: 1_000_000 } },
+            { modelId: 'deepseek-3.2', tokenLimits: { maxInputTokens: 164_000 } }
+          ]
+        }),
+        { status: 200 }
+      )) as typeof fetch
 
-  test('preserves the standard context size for standard models', () => {
-    expect(getContextWindowSize('claude-sonnet-4-5')).toBe(200_000)
-    expect(getContextWindowSize('deepseek-3.2')).toBe(128_000)
-  })
-
-  test('supports explicit 1m model aliases', () => {
-    expect(getContextWindowSize('claude-sonnet-4-6-1m')).toBe(1_000_000)
+    try {
+      await refreshContextWindowSizes(auth)
+      expect(getContextWindowSize('claude-sonnet-4-6')).toBe(1_000_000)
+      expect(getContextWindowSize('deepseek-3.2')).toBe(164_000)
+    } finally {
+      globalThis.fetch = originalFetch
+      clearContextWindowCatalog()
+    }
   })
 })

--- a/src/core/request/request-handler.ts
+++ b/src/core/request/request-handler.ts
@@ -4,6 +4,7 @@ import type { AccountManager } from '../../plugin/accounts'
 import type { KiroConfig } from '../../plugin/config'
 import { isPermanentError } from '../../plugin/health'
 import * as logger from '../../plugin/logger'
+import { refreshContextWindowSizes } from '../../plugin/models'
 import { transformToSdkRequest } from '../../plugin/request'
 import { createSdkClient } from '../../plugin/sdk-client'
 import { syncFromKiroCli } from '../../plugin/sync/kiro-cli'
@@ -132,6 +133,7 @@ export class RequestHandler {
         continue
       }
 
+      await refreshContextWindowSizes(auth)
       const sdkPrep = this.prepareSdkRequest(init?.body, model, auth, think, budget, showToast)
 
       const apiTimestamp = this.config.enable_log_api_request ? logger.getTimestamp() : null

--- a/src/plugin/models.ts
+++ b/src/plugin/models.ts
@@ -1,5 +1,24 @@
 import { MODEL_MAPPING, SUPPORTED_MODELS, isLongContextModel } from '../constants'
 
+const MODEL_CONTEXT_WINDOWS = {
+  auto: 200_000,
+  'claude-sonnet-4': 200_000,
+  'claude-sonnet-4-5': 200_000,
+  'claude-sonnet-4-6': 1_000_000,
+  'claude-sonnet-5': 1_000_000,
+  'claude-haiku-4-5': 200_000,
+  'claude-opus-4-5': 200_000,
+  'claude-opus-4-6': 1_000_000,
+  'claude-opus-4-7': 1_000_000,
+  'claude-opus-4-8': 1_000_000,
+  'claude-opus-4-8-thinking': 1_000_000,
+  'deepseek-3.2': 128_000,
+  'glm-5': 200_000,
+  'minimax-m2.5': 200_000,
+  'minimax-m2.1': 200_000,
+  'qwen3-coder-next': 256_000
+} as const
+
 export function resolveKiroModel(model: string): string {
   const resolved = MODEL_MAPPING[model]
   if (!resolved) {
@@ -9,5 +28,8 @@ export function resolveKiroModel(model: string): string {
 }
 
 export function getContextWindowSize(model: string): number {
+  if (model in MODEL_CONTEXT_WINDOWS) {
+    return MODEL_CONTEXT_WINDOWS[model as keyof typeof MODEL_CONTEXT_WINDOWS]
+  }
   return isLongContextModel(model) ? 1000000 : 200000
 }

--- a/src/plugin/models.ts
+++ b/src/plugin/models.ts
@@ -77,6 +77,7 @@ export async function refreshContextWindowSizes(auth: KiroAuthDetails): Promise<
     applyCatalog(cached.contextWindows)
     return
   }
+  activeContextWindows = new Map()
 
   const regions = [getCatalogRegion(auth)]
   if (!regions.includes('us-east-1')) regions.push('us-east-1')

--- a/src/plugin/models.ts
+++ b/src/plugin/models.ts
@@ -1,23 +1,28 @@
-import { MODEL_MAPPING, SUPPORTED_MODELS, isLongContextModel } from '../constants'
+import {
+  extractRegionFromArn,
+  isLongContextModel,
+  MODEL_MAPPING,
+  SUPPORTED_MODELS
+} from '../constants'
+import type { KiroAuthDetails } from './types'
 
-const MODEL_CONTEXT_WINDOWS = {
-  auto: 200_000,
-  'claude-sonnet-4': 200_000,
-  'claude-sonnet-4-5': 200_000,
-  'claude-sonnet-4-6': 1_000_000,
-  'claude-sonnet-5': 1_000_000,
-  'claude-haiku-4-5': 200_000,
-  'claude-opus-4-5': 200_000,
-  'claude-opus-4-6': 1_000_000,
-  'claude-opus-4-7': 1_000_000,
-  'claude-opus-4-8': 1_000_000,
-  'claude-opus-4-8-thinking': 1_000_000,
-  'deepseek-3.2': 128_000,
-  'glm-5': 200_000,
-  'minimax-m2.5': 200_000,
-  'minimax-m2.1': 200_000,
-  'qwen3-coder-next': 256_000
-} as const
+const MODEL_CATALOG_TTL_MS = 5 * 60 * 1000
+const DEFAULT_CONTEXT_WINDOW = 200_000
+
+type ModelCatalogResponse = {
+  models?: Array<{
+    modelId?: string
+    tokenLimits?: { maxInputTokens?: number }
+  }>
+}
+
+type CatalogCacheEntry = {
+  expiresAt: number
+  contextWindows: Map<string, number>
+}
+
+const catalogCache = new Map<string, CatalogCacheEntry>()
+let activeContextWindows = new Map<string, number>()
 
 export function resolveKiroModel(model: string): string {
   const resolved = MODEL_MAPPING[model]
@@ -28,8 +33,84 @@ export function resolveKiroModel(model: string): string {
 }
 
 export function getContextWindowSize(model: string): number {
-  if (model in MODEL_CONTEXT_WINDOWS) {
-    return MODEL_CONTEXT_WINDOWS[model as keyof typeof MODEL_CONTEXT_WINDOWS]
+  return (
+    activeContextWindows.get(model) ??
+    (isLongContextModel(model) ? 1_000_000 : DEFAULT_CONTEXT_WINDOW)
+  )
+}
+
+function getCatalogRegion(auth: KiroAuthDetails): string {
+  return extractRegionFromArn(auth.profileArn) ?? auth.region ?? 'us-east-1'
+}
+
+function applyCatalog(contextWindows: Map<string, number>): void {
+  activeContextWindows = new Map(contextWindows)
+}
+
+function parseModelCatalog(data: ModelCatalogResponse): Map<string, number> {
+  const contextWindows = new Map<string, number>()
+
+  for (const model of data.models ?? []) {
+    const modelId = model.modelId
+    const maxInputTokens = model.tokenLimits?.maxInputTokens
+    if (
+      !modelId ||
+      typeof maxInputTokens !== 'number' ||
+      !Number.isInteger(maxInputTokens) ||
+      maxInputTokens <= 0
+    )
+      continue
+
+    contextWindows.set(modelId, maxInputTokens)
+    for (const [alias, resolved] of Object.entries(MODEL_MAPPING)) {
+      if (resolved === modelId) contextWindows.set(alias, maxInputTokens)
+    }
   }
-  return isLongContextModel(model) ? 1000000 : 200000
+
+  return contextWindows
+}
+
+export async function refreshContextWindowSizes(auth: KiroAuthDetails): Promise<void> {
+  const cacheKey = `${auth.access}:${getCatalogRegion(auth)}`
+  const cached = catalogCache.get(cacheKey)
+  if (cached && cached.expiresAt > Date.now()) {
+    applyCatalog(cached.contextWindows)
+    return
+  }
+
+  const regions = [getCatalogRegion(auth)]
+  if (!regions.includes('us-east-1')) regions.push('us-east-1')
+
+  for (const region of regions) {
+    const endpoint = new URL(`https://q.${region}.amazonaws.com/ListAvailableModels`)
+    endpoint.searchParams.set('origin', 'AI_EDITOR')
+
+    try {
+      const response = await fetch(endpoint, {
+        headers: {
+          Accept: 'application/json',
+          Authorization: `Bearer ${auth.access}`
+        },
+        signal: AbortSignal.timeout(5_000)
+      })
+      if (!response.ok) continue
+
+      const contextWindows = parseModelCatalog((await response.json()) as ModelCatalogResponse)
+      if (contextWindows.size === 0) continue
+
+      catalogCache.set(cacheKey, {
+        expiresAt: Date.now() + MODEL_CATALOG_TTL_MS,
+        contextWindows
+      })
+      applyCatalog(contextWindows)
+      return
+    } catch {
+      continue
+    }
+  }
+}
+
+export function clearContextWindowCatalog(): void {
+  catalogCache.clear()
+  activeContextWindows = new Map()
 }


### PR DESCRIPTION
## Summary

Discover each account's model context window from Kiro's live model catalog instead of maintaining a hardcoded context-size table.

## Changes

- `src/plugin/models.ts`: Query `GET https://q.{region}.amazonaws.com/ListAvailableModels?origin=AI_EDITOR` with the selected account's bearer token. Read `models[].tokenLimits.maxInputTokens`, map resolved Kiro model IDs back to plugin aliases, cache results for 5 minutes, and fall back to the existing `-1m` alias heuristic when discovery is unavailable.
- `src/core/request/request-handler.ts`: Refresh the catalog after selecting/refreshing the active account and before preparing the request, so response usage estimation uses the active account's actual limits.
- `src/__tests__/models.test.ts`: Verify live API limits and alias mapping.

## Verification

- `bun run build` passed
- `bun test src/__tests__/models.test.ts` passed (1 pass, 0 fail)
- Live authenticated request verified `ListAvailableModels` returns `tokenLimits.maxInputTokens` (including 1M Sonnet 4.6 and account-specific limits for DeepSeek/MiniMax).

Note: `bun test` still has unrelated pre-existing failures in `bearer-retry.test.ts` and `sdk-client.test.ts`; the focused model test and build pass.