### PR TITLE
feat: add interactive multi-account manager menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ models with substantial trial quotas.
   size dynamically during retries.
 - **Intelligent Account Rotation**: Prioritizes multi-account usage based on lowest
   available quota.
+- **Interactive Account Manager**: An `opencode auth login` menu to list accounts with
+  live status/usage, add accounts, refresh quotas on demand, and delete individual
+  accounts or all of them.
 - **High-Performance Storage**: Efficient account and usage management using native Bun
   SQLite.
 - **Native Thinking Mode**: Streams Kiro's native reasoning to OpenCode's thinking
@@ -130,6 +133,23 @@ setting is a global override for all supported models, not a per-model setting.
    - You can also pre-configure defaults in `~/.config/opencode/kiro.json` via
      `idc_start_url` and `idc_region`.
 3. Configuration will be automatically managed at `~/.config/opencode/kiro.db`.
+
+### Managing accounts
+
+Run `opencode auth login`, select `kiro`, then choose **Manage accounts (list · quotas ·
+delete)** to open an interactive menu:
+
+- **Add account** — starts the AWS Builder ID device flow and adds the account to the
+  rotation pool. (For IAM Identity Center with a Start URL / profile ARN, use the
+  dedicated login methods listed below the menu instead.)
+- **Check quotas (refresh all)** — refreshes each account's token if needed and fetches
+  live usage, printing `used/limit (%)` per account.
+- **Per-account actions** — select an account to view its status/usage/region and delete
+  it.
+- **Delete all accounts** — clears every stored account (asks for confirmation).
+
+The menu requires an interactive terminal. In non-interactive contexts (SSH pipes, CI) it
+falls back to the plain add-account flow.
 
 ## Local plugin development
 

--- a/src/core/auth/account-menu-method.ts
+++ b/src/core/auth/account-menu-method.ts
@@ -1,0 +1,241 @@
+import type { AuthOAuthResult } from '@opencode-ai/plugin'
+import type { AccountRepository } from '../../infrastructure/database/account-repository.js'
+import type { AccountManager } from '../../plugin/accounts.js'
+import * as logger from '../../plugin/logger.js'
+import type { ManagedAccount } from '../../plugin/types.js'
+import { ANSI, isTTY } from '../../plugin/ui/ansi.js'
+import { confirm } from '../../plugin/ui/confirm.js'
+import { select, type SelectItem } from '../../plugin/ui/select.js'
+import { summarizeUsage } from '../../plugin/usage.js'
+import { UsageTracker } from '../account/usage-tracker.js'
+import type { IdcAuthMethod } from './idc-auth-method.js'
+import { TokenRefresher } from './token-refresher.js'
+
+const noopToast = () => {}
+
+type MenuChoice =
+  | { type: 'cancel' }
+  | { type: 'add' }
+  | { type: 'check' }
+  | { type: 'delete-all' }
+  | { type: 'account'; account: ManagedAccount }
+
+function statusBadge(acc: ManagedAccount): string {
+  if (!acc.isHealthy) return `${ANSI.red}[unhealthy]${ANSI.reset}`
+  if (acc.rateLimitResetTime && Date.now() < acc.rateLimitResetTime) {
+    return `${ANSI.yellow}[rate-limited]${ANSI.reset}`
+  }
+  return `${ANSI.green}[healthy]${ANSI.reset}`
+}
+
+function usageLabel(acc: ManagedAccount): string {
+  const { used, limit, pct } = summarizeUsage(acc.usedCount ?? 0, acc.limitCount ?? 0)
+  if (limit > 0) return `${used}/${limit} (${pct}%)`
+  if (used > 0) return `${used} used`
+  return 'usage unknown'
+}
+
+/**
+ * Interactive multi-account manager shown when the user picks the "Manage
+ * accounts" login method. Renders a TUI menu (Add / Check quotas / per-account
+ * delete / Delete all) on top of the plugin's existing account storage and
+ * rotation backend. Non-login actions return an empty OAuth result whose
+ * callback reports `failed`, matching the plugin auth contract without storing
+ * a new credential.
+ */
+export class AccountMenuMethod {
+  constructor(
+    private config: any,
+    private repository: AccountRepository,
+    private accountManager: AccountManager,
+    private idcMethod: IdcAuthMethod
+  ) {}
+
+  async authorize(inputs?: Record<string, string>): Promise<AuthOAuthResult> {
+    // The interactive menu needs a raw-mode TTY. In non-interactive contexts
+    // (SSH pipes, CI) fall back to the plain add-account flow.
+    if (!isTTY()) {
+      return this.idcMethod.authorize(inputs)
+    }
+    try {
+      return await this.runMenu(inputs)
+    } catch (e) {
+      logger.warn('Account menu failed; falling back to add-account flow', {
+        error: e instanceof Error ? e.message : String(e)
+      })
+      return this.idcMethod.authorize(inputs)
+    }
+  }
+
+  private done(message: string): AuthOAuthResult {
+    return {
+      url: '',
+      instructions: message,
+      method: 'auto',
+      callback: async () => ({ type: 'failed' })
+    }
+  }
+
+  private async runMenu(inputs?: Record<string, string>): Promise<AuthOAuthResult> {
+    for (;;) {
+      const accounts = this.accountManager.getAccounts()
+      const choice = await select<MenuChoice>(this.buildItems(accounts), {
+        message: 'Kiro accounts',
+        subtitle: 'Select an action or account',
+        clearScreen: true
+      })
+
+      if (!choice || choice.type === 'cancel') {
+        return this.done('Closed account manager.')
+      }
+
+      if (choice.type === 'add') {
+        // Delegate to the real OAuth device flow (AWS Builder ID by default).
+        return this.idcMethod.authorize(inputs)
+      }
+
+      if (choice.type === 'check') {
+        await this.checkQuotas(accounts)
+        continue
+      }
+
+      if (choice.type === 'delete-all') {
+        const ok = await confirm('Delete ALL accounts? This cannot be undone.')
+        if (!ok) continue
+        for (const a of accounts) this.accountManager.removeAccount(a)
+        return this.done('All accounts deleted. Run `opencode auth login` to re-add.')
+      }
+
+      if (choice.type === 'account') {
+        await this.accountSubmenu(choice.account)
+        continue
+      }
+    }
+  }
+
+  private buildItems(accounts: ManagedAccount[]): SelectItem<MenuChoice>[] {
+    const items: SelectItem<MenuChoice>[] = [
+      { label: 'Actions', value: { type: 'cancel' }, kind: 'heading' },
+      { label: 'Add account', value: { type: 'add' }, color: 'cyan' },
+      { label: 'Check quotas (refresh all)', value: { type: 'check' }, color: 'cyan' }
+    ]
+
+    if (accounts.length > 0) {
+      items.push({ label: '', value: { type: 'cancel' }, separator: true })
+      items.push({ label: 'Accounts', value: { type: 'cancel' }, kind: 'heading' })
+      accounts.forEach((acc, idx) => {
+        items.push({
+          label: `${idx + 1}. ${acc.email} ${statusBadge(acc)}`,
+          hint: usageLabel(acc),
+          value: { type: 'account', account: acc }
+        })
+      })
+      items.push({ label: '', value: { type: 'cancel' }, separator: true })
+      items.push({ label: 'Danger zone', value: { type: 'cancel' }, kind: 'heading' })
+      items.push({ label: 'Delete all accounts', value: { type: 'delete-all' }, color: 'red' })
+    }
+
+    return items
+  }
+
+  private async accountSubmenu(acc: ManagedAccount): Promise<void> {
+    const action = await select<'back' | 'delete'>(
+      [
+        { label: 'Back', value: 'back' },
+        { label: 'Delete this account', value: 'delete', color: 'red' }
+      ],
+      {
+        message: `${acc.email} ${statusBadge(acc)}`,
+        subtitle: `Usage: ${usageLabel(acc)} | Method: ${acc.authMethod} | Region: ${acc.region}`,
+        clearScreen: true
+      }
+    )
+
+    if (action === 'delete') {
+      const ok = await confirm(`Delete ${acc.email}?`)
+      if (ok) this.accountManager.removeAccount(acc)
+    }
+  }
+
+  private async checkQuotas(accounts: ManagedAccount[]): Promise<void> {
+    const out = process.stdout
+    out.write(ANSI.clearScreen + ANSI.moveTo(1, 1))
+    out.write(`${ANSI.bold}Checking quotas for ${accounts.length} account(s)...${ANSI.reset}\n\n`)
+
+    if (accounts.length === 0) {
+      out.write('  No accounts. Choose "Add account" first.\n')
+      await this.waitForKey()
+      return
+    }
+
+    const { syncFromKiroCli } = await import('../../plugin/sync/kiro-cli.js')
+    const tokenRefresher = new TokenRefresher(
+      this.config,
+      this.accountManager,
+      syncFromKiroCli,
+      this.repository
+    )
+    const usageTracker = new UsageTracker(this.config, this.accountManager, this.repository)
+
+    for (const acc of accounts) {
+      out.write(`  ${acc.email} ... `)
+      try {
+        const { account: usable } = await tokenRefresher.refreshIfNeeded(
+          acc,
+          this.accountManager.toAuthDetails(acc),
+          noopToast
+        )
+        if (!usable.isHealthy) {
+          out.write(`${ANSI.red}unhealthy (${usable.unhealthyReason ?? 'unknown'})${ANSI.reset}\n`)
+          continue
+        }
+        await usageTracker.syncNow(usable, this.accountManager.toAuthDetails(usable))
+        const fresh = this.accountManager.getAccounts().find((a) => a.id === acc.id) ?? usable
+        const { used, limit, pct } = summarizeUsage(fresh.usedCount ?? 0, fresh.limitCount ?? 0)
+        const color = pct >= 90 ? ANSI.red : pct >= 60 ? ANSI.yellow : ANSI.green
+        out.write(
+          limit > 0
+            ? `${color}${used}/${limit} (${pct}%)${ANSI.reset}\n`
+            : `${color}${used} used${ANSI.reset}\n`
+        )
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e)
+        out.write(`${ANSI.red}error: ${msg.slice(0, 100)}${ANSI.reset}\n`)
+      }
+    }
+
+    out.write(`\n  ${ANSI.dim}Press any key to return to the menu...${ANSI.reset}`)
+    await this.waitForKey()
+  }
+
+  private waitForKey(): Promise<void> {
+    return new Promise((resolve) => {
+      const stdin = process.stdin
+      if (!stdin.isTTY) {
+        resolve()
+        return
+      }
+      const wasRaw = stdin.isRaw ?? false
+      const cleanup = () => {
+        stdin.removeListener('data', onData)
+        try {
+          stdin.setRawMode(wasRaw)
+        } catch {
+          // best-effort
+        }
+        stdin.pause()
+      }
+      const onData = () => {
+        cleanup()
+        resolve()
+      }
+      try {
+        stdin.setRawMode(true)
+      } catch {
+        // best-effort
+      }
+      stdin.resume()
+      stdin.once('data', onData)
+    })
+  }
+}

--- a/src/core/auth/auth-handler.ts
+++ b/src/core/auth/auth-handler.ts
@@ -4,6 +4,7 @@ import { RegionSchema } from '../../plugin/config/schema.js'
 import * as logger from '../../plugin/logger.js'
 import { summarizeUsage } from '../../plugin/usage.js'
 import { UsageTracker } from '../account/usage-tracker.js'
+import { AccountMenuMethod } from './account-menu-method.js'
 import { IdcAuthMethod } from './idc-auth-method.js'
 import { TokenRefresher } from './token-refresher.js'
 
@@ -114,11 +115,22 @@ export class AuthHandler {
     }
 
     const idcMethod = new IdcAuthMethod(this.config, this.repository, this.accountManager)
+    const menuMethod = new AccountMenuMethod(
+      this.config,
+      this.repository,
+      this.accountManager,
+      idcMethod
+    )
 
     const configStartUrl = this.config.idc_start_url
     const configRegion = this.config.idc_region
 
     return [
+      {
+        label: 'Manage accounts (list · quotas · delete)',
+        type: 'oauth' as const,
+        authorize: (inputs?: any) => menuMethod.authorize(inputs)
+      },
       {
         label: 'AWS Builder ID / IAM Identity Center',
         type: 'oauth' as const,

--- a/src/plugin/ui/ansi.ts
+++ b/src/plugin/ui/ansi.ts
@@ -1,0 +1,51 @@
+/**
+ * ANSI escape codes and key parsing for interactive CLI menus.
+ * Works cross-platform (Windows/Mac/Linux).
+ */
+export const ANSI = {
+  // Cursor control
+  hide: '\x1b[?25l',
+  show: '\x1b[?25h',
+  up: (n = 1) => `\x1b[${n}A`,
+  down: (n = 1) => `\x1b[${n}B`,
+  clearLine: '\x1b[2K',
+  clearScreen: '\x1b[2J',
+  moveTo: (row: number, col: number) => `\x1b[${row};${col}H`,
+  // Styles
+  cyan: '\x1b[36m',
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  yellow: '\x1b[33m',
+  dim: '\x1b[2m',
+  bold: '\x1b[1m',
+  reset: '\x1b[0m',
+  inverse: '\x1b[7m'
+} as const
+
+export type KeyAction = 'up' | 'down' | 'enter' | 'escape' | 'escape-start' | null
+
+/**
+ * Parse raw keyboard input buffer into a key action.
+ * Handles Windows/Mac/Linux differences in arrow key sequences.
+ */
+export function parseKey(data: Buffer): KeyAction {
+  const s = data.toString()
+  // Arrow keys (ANSI escape sequences)
+  // Standard: \x1b[A (up), \x1b[B (down); Application mode: \x1bOA / \x1bOB
+  if (s === '\x1b[A' || s === '\x1bOA') return 'up'
+  if (s === '\x1b[B' || s === '\x1bOB') return 'down'
+  // Enter (CR or LF)
+  if (s === '\r' || s === '\n') return 'enter'
+  // Ctrl-C
+  if (s === '\x03') return 'escape'
+  // Bare escape byte - may be the start of an arrow-key sequence
+  if (s === '\x1b') return 'escape-start'
+  return null
+}
+
+/**
+ * Check if the terminal supports interactive input.
+ */
+export function isTTY(): boolean {
+  return Boolean(process.stdin.isTTY)
+}

--- a/src/plugin/ui/confirm.ts
+++ b/src/plugin/ui/confirm.ts
@@ -1,0 +1,19 @@
+import { select } from './select.js'
+
+/**
+ * Yes/No confirmation prompt rendered via the interactive select menu.
+ * Returns `false` on Esc / Ctrl-C.
+ */
+export async function confirm(message: string, defaultYes = false): Promise<boolean> {
+  const items = defaultYes
+    ? [
+        { label: 'Yes', value: true },
+        { label: 'No', value: false }
+      ]
+    : [
+        { label: 'No', value: false },
+        { label: 'Yes', value: true }
+      ]
+  const result = await select(items, { message })
+  return result ?? false
+}

--- a/src/plugin/ui/select.ts
+++ b/src/plugin/ui/select.ts
@@ -1,0 +1,276 @@
+import { ANSI, isTTY, parseKey } from './ansi.js'
+
+const ESCAPE_TIMEOUT_MS = 50
+const ANSI_REGEX = new RegExp('\\x1b\\[[0-9;]*m', 'g')
+const ANSI_LEADING_REGEX = new RegExp('^\\x1b\\[[0-9;]*m')
+
+export type SelectColor = 'red' | 'green' | 'yellow' | 'cyan'
+
+export interface SelectItem<T> {
+  label: string
+  value: T
+  hint?: string
+  color?: SelectColor
+  disabled?: boolean
+  separator?: boolean
+  kind?: 'heading'
+}
+
+export interface SelectOptions {
+  message: string
+  subtitle?: string
+  help?: string
+  clearScreen?: boolean
+}
+
+function stripAnsi(input: string): string {
+  return input.replace(ANSI_REGEX, '')
+}
+
+function truncateAnsi(input: string, maxVisibleChars: number): string {
+  if (maxVisibleChars <= 0) return ''
+  const visible = stripAnsi(input)
+  if (visible.length <= maxVisibleChars) return input
+  const suffix = maxVisibleChars >= 3 ? '...' : '.'.repeat(maxVisibleChars)
+  const keep = Math.max(0, maxVisibleChars - suffix.length)
+  let out = ''
+  let i = 0
+  let kept = 0
+  while (i < input.length && kept < keep) {
+    // Preserve ANSI sequences without counting them.
+    if (input[i] === '\x1b') {
+      const m = input.slice(i).match(ANSI_LEADING_REGEX)
+      if (m) {
+        out += m[0]
+        i += m[0].length
+        continue
+      }
+    }
+    out += input[i]
+    i += 1
+    kept += 1
+  }
+  if (out.includes('\x1b[')) {
+    return `${out}${ANSI.reset}${suffix}`
+  }
+  return out + suffix
+}
+
+function getColorCode(color?: SelectColor): string {
+  switch (color) {
+    case 'red':
+      return ANSI.red
+    case 'green':
+      return ANSI.green
+    case 'yellow':
+      return ANSI.yellow
+    case 'cyan':
+      return ANSI.cyan
+    default:
+      return ''
+  }
+}
+
+/**
+ * Render an interactive single-select menu in a raw-mode TTY and resolve with
+ * the chosen item's value (or `null` on Esc / Ctrl-C / no TTY-signal).
+ *
+ * Ported from the antigravity auth plugin's select helper, generalized over the
+ * item value type.
+ */
+export async function select<T>(items: SelectItem<T>[], options: SelectOptions): Promise<T | null> {
+  if (!isTTY()) {
+    throw new Error('Interactive select requires a TTY terminal')
+  }
+  if (items.length === 0) {
+    throw new Error('No menu items provided')
+  }
+
+  const isSelectable = (i: SelectItem<T>) => !i.disabled && !i.separator && i.kind !== 'heading'
+  const enabledItems = items.filter(isSelectable)
+  if (enabledItems.length === 0) {
+    throw new Error('All items disabled')
+  }
+  if (enabledItems.length === 1) {
+    return enabledItems[0]!.value
+  }
+
+  const { message, subtitle } = options
+  const { stdin, stdout } = process
+  let cursor = items.findIndex(isSelectable)
+  if (cursor === -1) cursor = 0
+  let escapeTimeout: NodeJS.Timeout | null = null
+  let isCleanedUp = false
+  let renderedLines = 0
+
+  const render = () => {
+    const columns = stdout.columns ?? 80
+    const rows = stdout.rows ?? 24
+    const shouldClearScreen = options.clearScreen === true
+    const previousRenderedLines = renderedLines
+    if (shouldClearScreen) {
+      stdout.write(ANSI.clearScreen + ANSI.moveTo(1, 1))
+    } else if (previousRenderedLines > 0) {
+      stdout.write(ANSI.up(previousRenderedLines))
+    }
+    let linesWritten = 0
+    const writeLine = (line: string) => {
+      stdout.write(`${ANSI.clearLine}${line}\n`)
+      linesWritten += 1
+    }
+    // Subtitle renders as 3 lines: spacer, subtitle, blank. Header counted separately.
+    const subtitleLines = subtitle ? 3 : 0
+    const fixedLines = 1 + subtitleLines + 2 // header + subtitle + (help + bottom)
+    const maxVisibleItems = Math.max(1, Math.min(items.length, rows - fixedLines - 1))
+    // If the menu is taller than the viewport, render a window around the cursor.
+    let windowStart = 0
+    let windowEnd = items.length
+    if (items.length > maxVisibleItems) {
+      windowStart = cursor - Math.floor(maxVisibleItems / 2)
+      windowStart = Math.max(0, Math.min(windowStart, items.length - maxVisibleItems))
+      windowEnd = windowStart + maxVisibleItems
+    }
+    const visibleItems = items.slice(windowStart, windowEnd)
+    const headerMessage = truncateAnsi(message, Math.max(1, columns - 4))
+    writeLine(`${ANSI.dim}┌  ${ANSI.reset}${headerMessage}`)
+    if (subtitle) {
+      writeLine(`${ANSI.dim}│${ANSI.reset}`)
+      const sub = truncateAnsi(subtitle, Math.max(1, columns - 4))
+      writeLine(`${ANSI.cyan}◆${ANSI.reset}  ${sub}`)
+      writeLine('')
+    }
+    for (let i = 0; i < visibleItems.length; i++) {
+      const itemIndex = windowStart + i
+      const item = visibleItems[i]
+      if (!item) continue
+      if (item.separator) {
+        writeLine(`${ANSI.dim}│${ANSI.reset}`)
+        continue
+      }
+      if (item.kind === 'heading') {
+        const heading = truncateAnsi(
+          `${ANSI.dim}${ANSI.bold}${item.label}${ANSI.reset}`,
+          Math.max(1, columns - 6)
+        )
+        writeLine(`${ANSI.cyan}│${ANSI.reset}  ${heading}`)
+        continue
+      }
+      const isSelected = itemIndex === cursor
+      const colorCode = getColorCode(item.color)
+      let labelText: string
+      if (item.disabled) {
+        labelText = `${ANSI.dim}${item.label} (unavailable)${ANSI.reset}`
+      } else if (isSelected) {
+        labelText = colorCode ? `${colorCode}${item.label}${ANSI.reset}` : item.label
+        if (item.hint) labelText += ` ${ANSI.dim}${item.hint}${ANSI.reset}`
+      } else {
+        labelText = colorCode
+          ? `${ANSI.dim}${colorCode}${item.label}${ANSI.reset}`
+          : `${ANSI.dim}${item.label}${ANSI.reset}`
+        if (item.hint) labelText += ` ${ANSI.dim}${item.hint}${ANSI.reset}`
+      }
+      // Prevent wrapping: cursor positioning relies on a fixed line count.
+      labelText = truncateAnsi(labelText, Math.max(1, columns - 8))
+      if (isSelected) {
+        writeLine(`${ANSI.cyan}│${ANSI.reset}  ${ANSI.green}●${ANSI.reset} ${labelText}`)
+      } else {
+        writeLine(`${ANSI.cyan}│${ANSI.reset}  ${ANSI.dim}○${ANSI.reset} ${labelText}`)
+      }
+    }
+    const windowHint =
+      items.length > visibleItems.length ? ` (${windowStart + 1}-${windowEnd}/${items.length})` : ''
+    const helpText = options.help ?? `Up/Down to select | Enter: confirm | Esc: back${windowHint}`
+    const help = truncateAnsi(helpText, Math.max(1, columns - 6))
+    writeLine(`${ANSI.cyan}│${ANSI.reset}  ${ANSI.dim}${help}${ANSI.reset}`)
+    writeLine(`${ANSI.cyan}└${ANSI.reset}`)
+    if (!shouldClearScreen && previousRenderedLines > linesWritten) {
+      const extra = previousRenderedLines - linesWritten
+      for (let i = 0; i < extra; i++) {
+        writeLine('')
+      }
+    }
+    renderedLines = linesWritten
+  }
+
+  return new Promise<T | null>((resolve) => {
+    const wasRaw = stdin.isRaw ?? false
+    const cleanup = () => {
+      if (isCleanedUp) return
+      isCleanedUp = true
+      if (escapeTimeout) {
+        clearTimeout(escapeTimeout)
+        escapeTimeout = null
+      }
+      try {
+        stdin.removeListener('data', onKey)
+        stdin.setRawMode(wasRaw)
+        stdin.pause()
+        stdout.write(ANSI.show)
+      } catch {
+        // Intentionally ignored - cleanup is best-effort
+      }
+      process.removeListener('SIGINT', onSignal)
+      process.removeListener('SIGTERM', onSignal)
+    }
+    const onSignal = () => {
+      cleanup()
+      resolve(null)
+    }
+    const finishWithValue = (value: T | null) => {
+      cleanup()
+      resolve(value)
+    }
+    const findNextSelectable = (from: number, direction: number): number => {
+      if (items.length === 0) return from
+      let next = from
+      do {
+        next = (next + direction + items.length) % items.length
+      } while (items[next]?.disabled || items[next]?.separator || items[next]?.kind === 'heading')
+      return next
+    }
+    const onKey = (data: Buffer) => {
+      if (escapeTimeout) {
+        clearTimeout(escapeTimeout)
+        escapeTimeout = null
+      }
+      const action = parseKey(data)
+      switch (action) {
+        case 'up':
+          cursor = findNextSelectable(cursor, -1)
+          render()
+          return
+        case 'down':
+          cursor = findNextSelectable(cursor, 1)
+          render()
+          return
+        case 'enter':
+          finishWithValue(items[cursor]?.value ?? null)
+          return
+        case 'escape':
+          finishWithValue(null)
+          return
+        case 'escape-start':
+          // Bare escape byte - wait to see if more bytes arrive (arrow-key sequence)
+          escapeTimeout = setTimeout(() => {
+            finishWithValue(null)
+          }, ESCAPE_TIMEOUT_MS)
+          return
+        default:
+          return
+      }
+    }
+    process.once('SIGINT', onSignal)
+    process.once('SIGTERM', onSignal)
+    try {
+      stdin.setRawMode(true)
+    } catch {
+      cleanup()
+      resolve(null)
+      return
+    }
+    stdin.resume()
+    stdout.write(ANSI.hide)
+    render()
+    stdin.on('data', onKey)
+  })
+}


### PR DESCRIPTION
Add a "Manage accounts" login method to `opencode auth login` that opens an interactive TUI menu on top of the existing account storage/rotation backend:

- list accounts with live health status and usage (used/limit/%)
- add an account via the AWS Builder ID device flow
- check quotas on demand (refreshes tokens + fetches usage per account)
- delete individual accounts or all accounts (with confirmation)

Ships a self-contained raw-mode TTY select/confirm UI (src/plugin/ui). Falls back to the plain add-account flow when stdin is not a TTY.