### PR TITLE
fix: derive IdC OIDC region from device registration, not profile ARN

### DIFF
--- a/src/plugin/sync/kiro-cli.ts
+++ b/src/plugin/sync/kiro-cli.ts
@@ -1,6 +1,6 @@
 import Database from 'libsql'
 import { existsSync } from 'node:fs'
-import { extractRegionFromArn, normalizeRegion } from '../../constants'
+import { extractRegionFromArn, isValidRegion, normalizeRegion } from '../../constants'
 import { createDeterministicAccountId } from '../accounts'
 import * as logger from '../logger'
 import { kiroDb } from '../storage/sqlite'
@@ -57,7 +57,10 @@ export async function syncFromKiroCli() {
         // serviceRegion wins over data.region: kiro-cli stores data.region as the
         // OIDC region (often us-east-1) regardless of where the account actually lives.
         const serviceRegion = extractRegionFromArn(profileArn) || normalizeRegion(data.region)
-        const oidcRegion = serviceRegion
+        const oidcRegion =
+          (isIdc && typeof deviceReg?.region === 'string' && isValidRegion(deviceReg.region)
+            ? deviceReg.region
+            : undefined) || serviceRegion
         const startUrl: string | undefined =
           typeof data.start_url === 'string'
             ? data.start_url


### PR DESCRIPTION
Fix for token refresh issue for when the Q profile and Identity Center are in different regions. Here the refresh reaches a regional endpoint that never issued the device registration and fails with HTTP 400 Invalid token provided. As such, tokens last an hour, so sessions start fine and break mid-session. 

syncFromKiroCli sets oidcRegion = serviceRegion, where serviceRegion is derived from the Q Developer profile ARN. refreshAccessToken then POSTs the Identity Center refresh to https://oidc.<oidcRegion>.amazonaws.com/token.

isValidRegion is used rather than normalizeRegion because the latter returns us-east-1 for unrecognised input, which would substitute a wrong region instead of falling back.

region still comes from the ARN, so the q.<region>.amazonaws.com inference endpoint is unchanged.